### PR TITLE
feat: Add field-level encryption for sensitive properties

### DIFF
--- a/Demo/Fleet/Fleet.Library/Entities/Car.cs
+++ b/Demo/Fleet/Fleet.Library/Entities/Car.cs
@@ -1,4 +1,5 @@
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Encryption.Abstractions;
 
 namespace Fleet.Entities;
 
@@ -9,6 +10,9 @@ public class Car
     public string Model { get; set; } = string.Empty;
     public int Year { get; set; }
     public string? Color { get; set; }
+
+    [Encrypted]
+    public string? VinNumber { get; set; }
 
     [LookupReference(typeof(LookupReferences.CarStatus))]
     public string? Status { get; set; }

--- a/Demo/Fleet/Fleet.Library/Fleet.Library.csproj
+++ b/Demo/Fleet/Fleet.Library/Fleet.Library.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
+		<ProjectReference Include="..\..\..\MintPlayer.Spark.Encryption.Abstractions\MintPlayer.Spark.Encryption.Abstractions.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Replication.Abstractions\MintPlayer.Spark.Replication.Abstractions.csproj" />
 	</ItemGroup>
 

--- a/Demo/Fleet/Fleet/App_Data/Model/Car.json
+++ b/Demo/Fleet/Fleet/App_Data/Model/Car.json
@@ -55,6 +55,19 @@
       "rules": []
     },
     {
+      "id": "ed465dac-ffad-4d1c-b09a-60e61f907c5a",
+      "name": "VinNumber",
+      "label": "Vin Number",
+      "dataType": "string",
+      "isRequired": false,
+      "isVisible": true,
+      "isReadOnly": false,
+      "order": 5,
+      "inQueryType": false,
+      "showedOn": "PersistentObject",
+      "rules": []
+    },
+    {
       "id": "78cc91e9-6158-4172-8663-8a5b0b0b65c5",
       "name": "Status",
       "label": "Status",

--- a/Demo/Fleet/Fleet/Fleet.csproj
+++ b/Demo/Fleet/Fleet/Fleet.csproj
@@ -19,6 +19,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Fleet.Library\Fleet.Library.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark\MintPlayer.Spark.csproj" />
+		<ProjectReference Include="..\..\..\MintPlayer.Spark.Encryption\MintPlayer.Spark.Encryption.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Messaging\MintPlayer.Spark.Messaging.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Replication\MintPlayer.Spark.Replication.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.SourceGenerators\MintPlayer.Spark.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/Demo/Fleet/Fleet/Program.cs
+++ b/Demo/Fleet/Fleet/Program.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Fleet;
 using MintPlayer.AspNetCore.SpaServices.Extensions;
 using MintPlayer.Spark;
+using MintPlayer.Spark.Encryption;
 using MintPlayer.Spark.Messaging;
 using MintPlayer.Spark.Replication;
 
@@ -12,6 +13,13 @@ builder.Services.AddSpark(builder.Configuration);
 builder.Services.AddScoped<SparkContext, FleetContext>();
 
 builder.Services.AddSparkMessaging();
+
+builder.Services.AddSparkEncryption(opt =>
+{
+    var section = builder.Configuration.GetSection("SparkEncryption");
+    opt.OwnKey = section["OwnKey"];
+    section.GetSection("ModuleKeys").Bind(opt.ModuleKeys);
+});
 
 builder.Services.AddSparkReplication(opt =>
 {
@@ -37,6 +45,7 @@ app.UseSpaStaticFilesImproved();
 app.UseRouting();
 app.UseAuthorization();
 app.UseSpark();
+app.UseSparkEncryption();
 app.CreateSparkIndexes();
 app.CreateSparkMessagingIndexes();
 app.UseSparkReplication();

--- a/Demo/Fleet/Fleet/appsettings.json
+++ b/Demo/Fleet/Fleet/appsettings.json
@@ -12,6 +12,12 @@
       "Database": "SparkFleet"
     }
   },
+  "SparkEncryption": {
+    "OwnKey": "VzERXTeyPP7UlS7TChN1rilbxLEScg2wdou/MH0/mgc=",
+    "ModuleKeys": {
+      "HR": "prXRSlSdJB0UbBU9b1HnZowU3mkoRATZwhJCSiVydGA="
+    }
+  },
   "SparkReplication": {
     "ModuleName": "Fleet",
     "ModuleUrl": "https://localhost:5001",

--- a/Demo/HR/HR.Library/HR.Library.csproj
+++ b/Demo/HR/HR.Library/HR.Library.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
+		<ProjectReference Include="..\..\..\MintPlayer.Spark.Encryption.Abstractions\MintPlayer.Spark.Encryption.Abstractions.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Replication.Abstractions\MintPlayer.Spark.Replication.Abstractions.csproj" />
 	</ItemGroup>
 

--- a/Demo/HR/HR.Library/Replicated/Car.cs
+++ b/Demo/HR/HR.Library/Replicated/Car.cs
@@ -1,3 +1,4 @@
+using MintPlayer.Spark.Encryption.Abstractions;
 using MintPlayer.Spark.Replication.Abstractions;
 
 namespace HR.Replicated;
@@ -15,6 +16,7 @@ namespace HR.Replicated;
             Model: this.Model,
             Year: this.Year,
             Color: this.Color,
+            VinNumber: this.VinNumber,
             '@metadata': {
                 '@collection': 'Cars'
             }
@@ -27,4 +29,7 @@ public class Car
     public string Model { get; set; } = string.Empty;
     public int Year { get; set; }
     public string? Color { get; set; }
+
+    [Encrypted]
+    public string? VinNumber { get; set; }
 }

--- a/Demo/HR/HR/App_Data/Model/Car.json
+++ b/Demo/HR/HR/App_Data/Model/Car.json
@@ -51,6 +51,18 @@
       "order": 4,
       "showedOn": "Query, PersistentObject",
       "rules": []
+    },
+    {
+      "id": "6fda605e-c337-49ad-9257-086a8fe5dedd",
+      "name": "VinNumber",
+      "label": "Vin Number",
+      "dataType": "string",
+      "isRequired": false,
+      "isVisible": true,
+      "isReadOnly": false,
+      "order": 5,
+      "showedOn": "Query, PersistentObject",
+      "rules": []
     }
   ]
 }

--- a/Demo/HR/HR/HR.csproj
+++ b/Demo/HR/HR/HR.csproj
@@ -19,6 +19,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\HR.Library\HR.Library.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark\MintPlayer.Spark.csproj" />
+		<ProjectReference Include="..\..\..\MintPlayer.Spark.Encryption\MintPlayer.Spark.Encryption.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Messaging\MintPlayer.Spark.Messaging.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.Replication\MintPlayer.Spark.Replication.csproj" />
 		<ProjectReference Include="..\..\..\MintPlayer.Spark.SourceGenerators\MintPlayer.Spark.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/Demo/HR/HR/Program.cs
+++ b/Demo/HR/HR/Program.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using HR;
 using MintPlayer.AspNetCore.SpaServices.Extensions;
 using MintPlayer.Spark;
+using MintPlayer.Spark.Encryption;
 using MintPlayer.Spark.Messaging;
 using MintPlayer.Spark.Replication;
 
@@ -12,6 +13,13 @@ builder.Services.AddSpark(builder.Configuration);
 builder.Services.AddScoped<SparkContext, HRContext>();
 
 builder.Services.AddSparkMessaging();
+
+builder.Services.AddSparkEncryption(opt =>
+{
+    var section = builder.Configuration.GetSection("SparkEncryption");
+    opt.OwnKey = section["OwnKey"];
+    section.GetSection("ModuleKeys").Bind(opt.ModuleKeys);
+});
 
 builder.Services.AddSparkReplication(opt =>
 {
@@ -37,6 +45,7 @@ app.UseSpaStaticFilesImproved();
 app.UseRouting();
 app.UseAuthorization();
 app.UseSpark();
+app.UseSparkEncryption();
 app.CreateSparkIndexes();
 app.CreateSparkMessagingIndexes();
 app.UseSparkReplication();

--- a/Demo/HR/HR/appsettings.json
+++ b/Demo/HR/HR/appsettings.json
@@ -12,6 +12,12 @@
       "Database": "SparkHR"
     }
   },
+  "SparkEncryption": {
+    "OwnKey": "prXRSlSdJB0UbBU9b1HnZowU3mkoRATZwhJCSiVydGA=",
+    "ModuleKeys": {
+      "Fleet": "VzERXTeyPP7UlS7TChN1rilbxLEScg2wdou/MH0/mgc="
+    }
+  },
   "SparkReplication": {
     "ModuleName": "HR",
     "ModuleUrl": "https://localhost:5002",

--- a/MintPlayer.Spark.Encryption.Abstractions/Configuration/SparkEncryptionOptions.cs
+++ b/MintPlayer.Spark.Encryption.Abstractions/Configuration/SparkEncryptionOptions.cs
@@ -1,0 +1,20 @@
+namespace MintPlayer.Spark.Encryption.Abstractions.Configuration;
+
+/// <summary>
+/// Configuration options for Spark field-level encryption.
+/// </summary>
+public class SparkEncryptionOptions
+{
+    /// <summary>
+    /// Base64-encoded AES-256 key (32 bytes) for encrypting this module's own data.
+    /// In Development mode, a key is auto-generated if not configured.
+    /// </summary>
+    public string? OwnKey { get; set; }
+
+    /// <summary>
+    /// Keys from other modules, keyed by module name.
+    /// Used to decrypt fields on replicated entities that carry <c>[Replicated(SourceModule = "X")]</c>.
+    /// Each value is a Base64-encoded AES-256 key (32 bytes).
+    /// </summary>
+    public Dictionary<string, string> ModuleKeys { get; set; } = new();
+}

--- a/MintPlayer.Spark.Encryption.Abstractions/EncryptedAttribute.cs
+++ b/MintPlayer.Spark.Encryption.Abstractions/EncryptedAttribute.cs
@@ -1,0 +1,11 @@
+namespace MintPlayer.Spark.Encryption.Abstractions;
+
+/// <summary>
+/// Marks a string property for field-level encryption at rest in RavenDB.
+/// The property value is encrypted before storing and decrypted after loading.
+/// Only valid on properties of type <see cref="string"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class EncryptedAttribute : Attribute
+{
+}

--- a/MintPlayer.Spark.Encryption.Abstractions/MintPlayer.Spark.Encryption.Abstractions.csproj
+++ b/MintPlayer.Spark.Encryption.Abstractions/MintPlayer.Spark.Encryption.Abstractions.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- NuGet Package Metadata -->
+		<PackageId>MintPlayer.Spark.Encryption.Abstractions</PackageId>
+		<Version>10.0.0-preview.2</Version>
+		<Authors>MintPlayer</Authors>
+		<Company>MintPlayer</Company>
+		<Description>Abstractions for MintPlayer.Spark.Encryption: EncryptedAttribute and SparkEncryptionOptions.</Description>
+		<PackageTags>encryption;field-level;ravendb;abstractions</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/MintPlayer/MintPlayer.Spark</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/MintPlayer/MintPlayer.Spark.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+	</PropertyGroup>
+
+</Project>

--- a/MintPlayer.Spark.Encryption/Extensions/SparkEncryptionExtensions.cs
+++ b/MintPlayer.Spark.Encryption/Extensions/SparkEncryptionExtensions.cs
@@ -1,0 +1,152 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Encryption.Abstractions;
+using MintPlayer.Spark.Encryption.Abstractions.Configuration;
+using MintPlayer.Spark.Encryption.Services;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Encryption;
+
+public static class SparkEncryptionExtensions
+{
+    /// <summary>
+    /// Registers field-level encryption services and configuration.
+    /// </summary>
+    public static IServiceCollection AddSparkEncryption(
+        this IServiceCollection services,
+        Action<SparkEncryptionOptions> configure)
+    {
+        services.Configure(configure);
+        services.AddSingleton<FieldEncryptionService>();
+        services.AddSingleton<EncryptedFieldResolver>();
+        return services;
+    }
+
+    /// <summary>
+    /// Hooks field-level encryption into the RavenDB <see cref="IDocumentStore"/> events,
+    /// validates attribute usage, and auto-generates a dev key if needed.
+    /// </summary>
+    public static WebApplication UseSparkEncryption(this WebApplication app)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("SparkEncryption");
+        var options = app.Services.GetRequiredService<IOptions<SparkEncryptionOptions>>().Value;
+        var encryptionService = app.Services.GetRequiredService<FieldEncryptionService>();
+        var fieldResolver = app.Services.GetRequiredService<EncryptedFieldResolver>();
+        var store = app.Services.GetRequiredService<IDocumentStore>();
+
+        // Startup validation: scan for [Encrypted] on non-string properties
+        ValidateEncryptedAttributes(logger);
+
+        // Auto-generate dev key if not configured
+        var hostEnvironment = app.Services.GetRequiredService<IHostEnvironment>();
+        if (hostEnvironment.IsDevelopment() && string.IsNullOrEmpty(options.OwnKey))
+        {
+            var key = new byte[32];
+            RandomNumberGenerator.Fill(key);
+            options.OwnKey = Convert.ToBase64String(key);
+            logger.LogWarning(
+                "SparkEncryption: No OwnKey configured — auto-generated a development key. " +
+                "Set SparkEncryption:OwnKey in appsettings to use a stable key across restarts.");
+        }
+
+        // Hook into BeforeStore to encrypt
+        store.OnBeforeStore += (sender, args) =>
+        {
+            var entityType = args.Entity.GetType();
+            var properties = fieldResolver.GetEncryptedProperties(entityType);
+            if (properties.Length == 0) return;
+
+            var key = fieldResolver.GetKeyForEntity(entityType);
+            if (key == null)
+            {
+                logger.LogWarning("No encryption key available for {EntityType} — skipping encryption", entityType.Name);
+                return;
+            }
+
+            foreach (var prop in properties)
+            {
+                var value = (string?)prop.GetValue(args.Entity);
+                if (value != null && !FieldEncryptionService.IsEncrypted(value))
+                {
+                    var encrypted = encryptionService.Encrypt(value, key);
+                    prop.SetValue(args.Entity, encrypted);
+                }
+            }
+        };
+
+        // Hook into AfterConversionToEntity to decrypt
+        store.OnAfterConversionToEntity += (sender, args) =>
+        {
+            var entityType = args.Entity.GetType();
+            var properties = fieldResolver.GetEncryptedProperties(entityType);
+            if (properties.Length == 0) return;
+
+            var key = fieldResolver.GetKeyForEntity(entityType);
+            if (key == null)
+            {
+                logger.LogWarning("No decryption key available for {EntityType} — encrypted fields will remain as ciphertext", entityType.Name);
+                return;
+            }
+
+            foreach (var prop in properties)
+            {
+                var value = (string?)prop.GetValue(args.Entity);
+                if (FieldEncryptionService.IsEncrypted(value))
+                {
+                    var decrypted = encryptionService.Decrypt(value!, key);
+                    prop.SetValue(args.Entity, decrypted);
+                }
+            }
+        };
+
+        logger.LogInformation("SparkEncryption: Field-level encryption hooks registered on IDocumentStore");
+        return app;
+    }
+
+    private static void ValidateEncryptedAttributes(ILogger logger)
+    {
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly == null) return;
+
+        var referencedAssemblies = entryAssembly.GetReferencedAssemblies()
+            .Select(name =>
+            {
+                try { return Assembly.Load(name); }
+                catch { return null; }
+            })
+            .Where(a => a != null)
+            .Cast<Assembly>()
+            .Append(entryAssembly);
+
+        var violations = new List<string>();
+
+        foreach (var assembly in referencedAssemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).Cast<Type>().ToArray(); }
+
+            foreach (var type in types)
+            {
+                foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (prop.GetCustomAttribute<EncryptedAttribute>() != null && prop.PropertyType != typeof(string))
+                    {
+                        violations.Add($"{type.FullName}.{prop.Name} ({prop.PropertyType.Name})");
+                    }
+                }
+            }
+        }
+
+        if (violations.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"[Encrypted] can only be applied to string properties. Invalid usage found on: {string.Join(", ", violations)}");
+        }
+    }
+}

--- a/MintPlayer.Spark.Encryption/MintPlayer.Spark.Encryption.csproj
+++ b/MintPlayer.Spark.Encryption/MintPlayer.Spark.Encryption.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- NuGet Package Metadata -->
+		<PackageId>MintPlayer.Spark.Encryption</PackageId>
+		<Version>10.0.0-preview.2</Version>
+		<Authors>MintPlayer</Authors>
+		<Company>MintPlayer</Company>
+		<Description>Field-level encryption for MintPlayer.Spark using AES-256-GCM. Encrypts marked properties before storing in RavenDB and decrypts after loading.</Description>
+		<PackageTags>encryption;field-level;ravendb;aes-gcm</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/MintPlayer/MintPlayer.Spark</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/MintPlayer/MintPlayer.Spark.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\MintPlayer.Spark.Encryption.Abstractions\MintPlayer.Spark.Encryption.Abstractions.csproj" />
+		<ProjectReference Include="..\MintPlayer.Spark.Replication.Abstractions\MintPlayer.Spark.Replication.Abstractions.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+	</ItemGroup>
+
+</Project>

--- a/MintPlayer.Spark.Encryption/Services/EncryptedFieldResolver.cs
+++ b/MintPlayer.Spark.Encryption/Services/EncryptedFieldResolver.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Encryption.Abstractions;
+using MintPlayer.Spark.Encryption.Abstractions.Configuration;
+using MintPlayer.Spark.Replication.Abstractions;
+
+namespace MintPlayer.Spark.Encryption.Services;
+
+/// <summary>
+/// Resolves <see cref="EncryptedAttribute"/>-decorated properties for a given entity type
+/// and determines which encryption key to use based on the presence of <see cref="ReplicatedAttribute"/>.
+/// Uses a per-type reflection cache for performance.
+/// </summary>
+internal sealed class EncryptedFieldResolver
+{
+    private readonly SparkEncryptionOptions _options;
+    private readonly ConcurrentDictionary<Type, PropertyInfo[]> _cache = new();
+
+    public EncryptedFieldResolver(IOptions<SparkEncryptionOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Gets all string properties decorated with <see cref="EncryptedAttribute"/> for the given type.
+    /// </summary>
+    public PropertyInfo[] GetEncryptedProperties(Type entityType)
+    {
+        return _cache.GetOrAdd(entityType, static type =>
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.PropertyType == typeof(string) && p.GetCustomAttribute<EncryptedAttribute>() != null)
+                .ToArray());
+    }
+
+    /// <summary>
+    /// Returns the appropriate Base64-encoded AES-256 key for encrypting/decrypting the entity type.
+    /// If the type carries <c>[Replicated(SourceModule = "X")]</c>, returns <c>ModuleKeys["X"]</c>;
+    /// otherwise returns <c>OwnKey</c>.
+    /// </summary>
+    public string? GetKeyForEntity(Type entityType)
+    {
+        var replicated = entityType.GetCustomAttribute<ReplicatedAttribute>();
+        if (replicated != null)
+        {
+            return _options.ModuleKeys.TryGetValue(replicated.SourceModule, out var moduleKey)
+                ? moduleKey
+                : null;
+        }
+
+        return _options.OwnKey;
+    }
+}

--- a/MintPlayer.Spark.Encryption/Services/FieldEncryptionService.cs
+++ b/MintPlayer.Spark.Encryption/Services/FieldEncryptionService.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+
+namespace MintPlayer.Spark.Encryption.Services;
+
+/// <summary>
+/// Provides AES-256-GCM encryption and decryption for individual field values.
+/// Ciphertext format: <c>ENC:v1:{iv}:{ciphertext}:{tag}</c> (all segments Base64-encoded).
+/// </summary>
+internal sealed class FieldEncryptionService
+{
+    private const string Prefix = "ENC:v1:";
+    private const int NonceSize = 12; // 96 bits for AES-GCM
+    private const int TagSize = 16;   // 128-bit authentication tag
+
+    /// <summary>
+    /// Encrypts a plaintext string using the given Base64-encoded AES-256 key.
+    /// Returns the ciphertext in <c>ENC:v1:{iv}:{ciphertext}:{tag}</c> format.
+    /// </summary>
+    public string Encrypt(string plaintext, string base64Key)
+    {
+        var key = Convert.FromBase64String(base64Key);
+        var plaintextBytes = System.Text.Encoding.UTF8.GetBytes(plaintext);
+
+        var nonce = new byte[NonceSize];
+        RandomNumberGenerator.Fill(nonce);
+
+        var ciphertext = new byte[plaintextBytes.Length];
+        var tag = new byte[TagSize];
+
+        using var aes = new AesGcm(key, TagSize);
+        aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
+
+        return $"{Prefix}{Convert.ToBase64String(nonce)}:{Convert.ToBase64String(ciphertext)}:{Convert.ToBase64String(tag)}";
+    }
+
+    /// <summary>
+    /// Decrypts an <c>ENC:v1:...</c> ciphertext string using the given Base64-encoded AES-256 key.
+    /// Returns the original plaintext.
+    /// </summary>
+    public string Decrypt(string encryptedValue, string base64Key)
+    {
+        var key = Convert.FromBase64String(base64Key);
+
+        // Strip prefix "ENC:v1:" and split into nonce:ciphertext:tag
+        var payload = encryptedValue[Prefix.Length..];
+        var parts = payload.Split(':');
+        if (parts.Length != 3)
+            throw new FormatException($"Invalid encrypted field format. Expected 3 segments after prefix, got {parts.Length}.");
+
+        var nonce = Convert.FromBase64String(parts[0]);
+        var ciphertext = Convert.FromBase64String(parts[1]);
+        var tag = Convert.FromBase64String(parts[2]);
+
+        var plaintext = new byte[ciphertext.Length];
+
+        using var aes = new AesGcm(key, TagSize);
+        aes.Decrypt(nonce, ciphertext, tag, plaintext);
+
+        return System.Text.Encoding.UTF8.GetString(plaintext);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the value starts with the encryption prefix.
+    /// </summary>
+    public static bool IsEncrypted(string? value) => value != null && value.StartsWith(Prefix, StringComparison.Ordinal);
+}

--- a/MintPlayer.Spark.sln
+++ b/MintPlayer.Spark.sln
@@ -37,6 +37,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FleetApp", "FleetApp", "{CF
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HRApp", "HRApp", "{2A519F7C-005D-12C2-C047-E13C1573BFEA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MintPlayer.Spark.Encryption.Abstractions", "MintPlayer.Spark.Encryption.Abstractions\MintPlayer.Spark.Encryption.Abstractions.csproj", "{636575CC-DAC9-413C-A143-F235AB532E8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MintPlayer.Spark.Encryption", "MintPlayer.Spark.Encryption\MintPlayer.Spark.Encryption.csproj", "{CC2F5383-3B75-45F9-8E9A-024701C138FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -203,6 +207,30 @@ Global
 		{1EA25FCC-D73C-4DC5-9405-57CB69DAAD58}.Release|x64.Build.0 = Release|Any CPU
 		{1EA25FCC-D73C-4DC5-9405-57CB69DAAD58}.Release|x86.ActiveCfg = Release|Any CPU
 		{1EA25FCC-D73C-4DC5-9405-57CB69DAAD58}.Release|x86.Build.0 = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|x64.Build.0 = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Debug|x86.Build.0 = Debug|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|x64.ActiveCfg = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|x64.Build.0 = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{636575CC-DAC9-413C-A143-F235AB532E8F}.Release|x86.Build.0 = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|x64.Build.0 = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Debug|x86.Build.0 = Debug|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|x64.Build.0 = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC2F5383-3B75-45F9-8E9A-024701C138FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/PRD-FieldLevelEncryption.md
+++ b/docs/PRD-FieldLevelEncryption.md
@@ -1,0 +1,673 @@
+# Field-Level Encryption PRD for MintPlayer.Spark
+
+## Overview
+
+Implement transparent field-level encryption for the Spark framework, allowing developers to mark sensitive entity properties with an `[Encrypted]` attribute. Encrypted fields are stored as ciphertext in RavenDB documents and transparently decrypted when loaded by the application. Encryption keys reside exclusively in the application configuration (never in the database), and encrypted fields are ETL-compatible — replicated as opaque blobs without re-encryption.
+
+## Motivation
+
+In a multi-module architecture where data is replicated between databases via RavenDB ETL, some fields contain sensitive data (e.g., VIN numbers, social security numbers, salary information). These fields must be encrypted at rest in the database while remaining transparent to application code. Since ETL scripts execute server-side inside RavenDB (with no access to application secrets), the encryption design must ensure encrypted fields can be copied as-is during replication.
+
+### Design Constraints
+
+1. **ETL scripts are crypto-blind** — they run inside RavenDB and cannot access encryption keys
+2. **No double encryption** — each field read/write involves exactly one encryption or decryption operation
+3. **No single shared key** — per-module key isolation for ISO compliance
+4. **Keys stay in the application** — stored in `appsettings.json` or environment variables, never in the database
+
+### Encryption Strategy: Per-Module Symmetric Keys
+
+Each module has its own AES-256-GCM symmetric key. Modules that consume replicated data from other modules are configured with the source module's key.
+
+```
+Fleet appsettings:
+  Encryption:
+    OwnKey: <fleet-aes-key>          # Encrypts/decrypts Fleet's own data
+    ModuleKeys:
+      HR: <hr-aes-key>              # Decrypts replicated HR data
+
+HR appsettings:
+  Encryption:
+    OwnKey: <hr-aes-key>            # Encrypts/decrypts HR's own data
+    ModuleKeys:
+      Fleet: <fleet-aes-key>        # Decrypts replicated Fleet data
+```
+
+**Why not asymmetric encryption?** Asymmetric crypto solves key distribution with untrusted parties. In this architecture, the receiving app needs the decryption key regardless — so it's the same trust level as sharing a symmetric key, but ~1000x slower. Between modules operated by the same team, symmetric keys are simpler, faster, and equally secure.
+
+---
+
+## Goals
+
+1. **Transparent Encryption**: Developers mark properties with `[Encrypted]` — encryption/decryption happens automatically
+2. **ETL-Compatible**: Encrypted fields are replicated as opaque blobs — ETL scripts require no changes
+3. **Per-Module Key Isolation**: Each module's key protects only its own data
+4. **Zero Performance Overhead on Non-Encrypted Fields**: Only fields marked `[Encrypted]` incur crypto cost
+5. **Backward Compatible**: Existing documents without encryption continue to work
+
+---
+
+## Architecture
+
+### High-Level Flow
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Fleet Application                                               │
+│                                                                  │
+│  Car { LicensePlate: "ABC-123", VinNumber: "WBA..." }           │
+│                        │                                         │
+│                   OnBeforeStore                                   │
+│                        │                                         │
+│                   Detect [Encrypted]                              │
+│                   on VinNumber                                    │
+│                        │                                         │
+│                   AES-256-GCM Encrypt                            │
+│                   with Fleet's OwnKey                             │
+│                        │                                         │
+│                        ▼                                         │
+│  RavenDB Document:                                               │
+│  { LicensePlate: "ABC-123", VinNumber: "ENC:iv:ciphertext:tag" }│
+│                                                                  │
+│                   ┌─────────────────┐                            │
+│                   │  RavenDB ETL    │                            │
+│                   │  (crypto-blind) │                            │
+│                   │                 │                            │
+│                   │  Copies blob    │                            │
+│                   │  as-is to HR DB │                            │
+│                   └────────┬────────┘                            │
+│                            │                                     │
+└────────────────────────────┼─────────────────────────────────────┘
+                             │
+┌────────────────────────────┼─────────────────────────────────────┐
+│  HR Application            ▼                                     │
+│                                                                  │
+│  RavenDB Document:                                               │
+│  { LicensePlate: "ABC-123", VinNumber: "ENC:iv:ciphertext:tag" }│
+│                        │                                         │
+│                   OnAfterLoad                                    │
+│                        │                                         │
+│                   Detect [Encrypted]                              │
+│                   on VinNumber                                    │
+│                        │                                         │
+│                   Determine key:                                  │
+│                   Replicated from Fleet?                          │
+│                   → Use ModuleKeys["Fleet"]                      │
+│                        │                                         │
+│                   AES-256-GCM Decrypt                            │
+│                        │                                         │
+│                        ▼                                         │
+│  Car { LicensePlate: "ABC-123", VinNumber: "WBA..." }           │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Key Selection Logic
+
+When **encrypting** (before store):
+- Always use `OwnKey` — the module only encrypts its own data
+
+When **decrypting** (after load):
+- Check if the entity type has a `[Replicated(SourceModule = "X")]` attribute
+  - Yes → Use `ModuleKeys["X"]` (the source module's key)
+  - No → Use `OwnKey` (this module's own data)
+
+---
+
+## New Library: MintPlayer.Spark.Encryption
+
+A separate library project to keep encryption concerns isolated.
+
+### Project: MintPlayer.Spark.Encryption.Abstractions
+
+Shared types that entity libraries reference:
+
+```
+MintPlayer.Spark.Encryption.Abstractions/
+├── EncryptedAttribute.cs
+└── Configuration/
+    └── SparkEncryptionOptions.cs
+```
+
+### Project: MintPlayer.Spark.Encryption
+
+Implementation:
+
+```
+MintPlayer.Spark.Encryption/
+├── Services/
+│   ├── FieldEncryptionService.cs
+│   └── EncryptedFieldResolver.cs
+├── Conventions/
+│   └── EncryptionSessionListeners.cs
+└── Extensions/
+    └── SparkEncryptionExtensions.cs
+```
+
+---
+
+## Detailed Design
+
+### 1. The [Encrypted] Attribute
+
+```csharp
+namespace MintPlayer.Spark.Encryption.Abstractions;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class EncryptedAttribute : Attribute
+{
+}
+```
+
+#### Example Usage (in Fleet entity)
+
+```csharp
+namespace Fleet.Library.Entities;
+
+public class Car
+{
+    public string? Id { get; set; }
+    public string LicensePlate { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public int Year { get; set; }
+    public string? Color { get; set; }
+
+    [Encrypted]
+    public string VinNumber { get; set; } = string.Empty;
+}
+```
+
+#### Supported Property Types
+
+The `[Encrypted]` attribute is only supported on `string` properties. Most sensitive data is string-typed (VIN, SSN, email, etc.), and restricting to strings avoids JSON deserialization mismatches where the CLR type is `int` but the stored value is an encrypted string.
+
+| CLR Type | Support |
+|----------|---------|
+| `string` | Supported — stored as `"ENC:v1:{base64(iv)}:{base64(ciphertext)}:{base64(tag)}"` |
+| All other types | Not supported — will throw at startup validation |
+
+> **Important**: **Encrypted fields cannot be meaningfully queried or sorted on in RavenDB indexes** — ciphertext is not meaningful for comparison. This is an intentional tradeoff: if a field needs to be queryable, it should not be encrypted.
+
+### 2. Encryption Format
+
+Encrypted field values follow a deterministic format stored as a string in the RavenDB document:
+
+```
+ENC:v1:{base64(iv)}:{base64(ciphertext)}:{base64(tag)}
+```
+
+| Component | Description |
+|-----------|-------------|
+| `ENC` | Magic prefix to identify encrypted values |
+| `v1` | Format version (for future algorithm changes) |
+| `iv` | 12-byte initialization vector (randomly generated per encryption) |
+| `ciphertext` | AES-256-GCM encrypted data |
+| `tag` | 16-byte GCM authentication tag |
+
+The `ENC:` prefix allows the decryption logic to distinguish encrypted values from plaintext, which is essential for **backward compatibility** — existing documents with plaintext values will continue to work. On load, if a field marked `[Encrypted]` does not start with `ENC:`, it is treated as plaintext (and optionally re-encrypted on next save).
+
+### 3. Configuration
+
+#### SparkEncryptionOptions
+
+```csharp
+namespace MintPlayer.Spark.Encryption.Abstractions.Configuration;
+
+public class SparkEncryptionOptions
+{
+    /// <summary>
+    /// This module's encryption key (base64-encoded, 256-bit AES key).
+    /// Used to encrypt this module's own data and decrypt it on read.
+    /// </summary>
+    public required string OwnKey { get; set; }
+
+    /// <summary>
+    /// Encryption keys of other modules, keyed by module name.
+    /// Used to decrypt replicated data from those modules.
+    /// Example: { "Fleet": "base64(fleet-aes-key)" }
+    /// </summary>
+    public Dictionary<string, string> ModuleKeys { get; set; } = new();
+}
+```
+
+#### appsettings.json (Fleet)
+
+```json
+{
+    "Spark": {
+        "RavenDb": {
+            "Urls": ["http://localhost:8080"],
+            "Database": "SparkFleet"
+        }
+    },
+    "SparkReplication": {
+        "ModuleName": "Fleet",
+        "ModuleUrl": "https://localhost:5001",
+        "SparkModulesUrls": ["http://localhost:8080"],
+        "SparkModulesDatabase": "SparkModules"
+    },
+    "SparkEncryption": {
+        "OwnKey": "base64-encoded-256-bit-key-here",
+        "ModuleKeys": {
+            "HR": "base64-encoded-256-bit-key-here"
+        }
+    }
+}
+```
+
+#### appsettings.json (HR)
+
+```json
+{
+    "Spark": {
+        "RavenDb": {
+            "Urls": ["http://localhost:8080"],
+            "Database": "SparkHR"
+        }
+    },
+    "SparkReplication": {
+        "ModuleName": "HR",
+        "ModuleUrl": "https://localhost:5002",
+        "SparkModulesUrls": ["http://localhost:8080"],
+        "SparkModulesDatabase": "SparkModules"
+    },
+    "SparkEncryption": {
+        "OwnKey": "base64-encoded-256-bit-key-here",
+        "ModuleKeys": {
+            "Fleet": "base64-encoded-256-bit-key-here"
+        }
+    }
+}
+```
+
+### 4. FieldEncryptionService
+
+Core service handling AES-256-GCM encrypt/decrypt operations.
+
+```csharp
+namespace MintPlayer.Spark.Encryption.Services;
+
+public class FieldEncryptionService
+{
+    /// <summary>
+    /// Encrypts a plaintext string value using AES-256-GCM.
+    /// Returns the encrypted value in "ENC:v1:{iv}:{ciphertext}:{tag}" format.
+    /// </summary>
+    public string Encrypt(string plaintext, byte[] key);
+
+    /// <summary>
+    /// Decrypts an "ENC:v1:{iv}:{ciphertext}:{tag}" formatted string.
+    /// Returns the original plaintext.
+    /// Throws if the tag verification fails (tampered data).
+    /// </summary>
+    public string Decrypt(string encryptedValue, byte[] key);
+
+    /// <summary>
+    /// Checks if a string value is in encrypted format (starts with "ENC:").
+    /// </summary>
+    public bool IsEncrypted(string value);
+}
+```
+
+**Implementation Notes:**
+- Uses `System.Security.Cryptography.AesGcm` (.NET built-in, no external dependencies)
+- Generates a random 12-byte IV per encryption call (never reuses IVs)
+- 128-bit authentication tag for tamper detection
+- Thread-safe (no shared mutable state)
+
+### 5. EncryptedFieldResolver
+
+Service that resolves which properties on an entity type are marked `[Encrypted]` and caches the result.
+
+```csharp
+namespace MintPlayer.Spark.Encryption.Services;
+
+public class EncryptedFieldResolver
+{
+    /// <summary>
+    /// Returns the PropertyInfo[] for all properties on the given type
+    /// that are marked with [Encrypted]. Results are cached per type.
+    /// </summary>
+    public PropertyInfo[] GetEncryptedProperties(Type entityType);
+
+    /// <summary>
+    /// Determines which encryption key to use for the given entity type.
+    /// If the type has [Replicated(SourceModule = "X")], returns ModuleKeys["X"].
+    /// Otherwise returns OwnKey.
+    /// </summary>
+    public byte[] GetDecryptionKey(Type entityType);
+
+    /// <summary>
+    /// Returns OwnKey (always used for encryption).
+    /// </summary>
+    public byte[] GetEncryptionKey();
+}
+```
+
+**Caching:** Uses `ConcurrentDictionary<Type, PropertyInfo[]>` to avoid repeated reflection.
+
+### 6. RavenDB Session Integration
+
+The encryption/decryption hooks into RavenDB's document store conventions using `OnBeforeStore` and `OnAfterSaveChanges` for encryption, and a custom session wrapper or `OnBeforeQuery`/`OnAfterConversionToEntity` for decryption.
+
+#### Encryption Hook (Before Store)
+
+Register on the `IDocumentStore` using RavenDB's `OnBeforeStore` session event:
+
+```csharp
+store.OnBeforeStore += (sender, args) =>
+{
+    var entityType = args.Entity.GetType();
+    var encryptedProps = resolver.GetEncryptedProperties(entityType);
+    if (encryptedProps.Length == 0) return;
+
+    var key = resolver.GetEncryptionKey();
+    foreach (var prop in encryptedProps)
+    {
+        var value = prop.GetValue(args.Entity);
+        if (value == null) continue;
+
+        var plaintext = ConvertToString(value, prop.PropertyType);
+        var encrypted = encryptionService.Encrypt(plaintext, key);
+
+        // Store encrypted value in the document metadata or directly
+        // Use args.DocumentMetadata or modify the entity
+    }
+};
+```
+
+#### Decryption Hook (After Load)
+
+Register on the `IDocumentStore` using the session's `OnAfterConversionToEntity` event:
+
+```csharp
+store.OnAfterConversionToEntity += (sender, args) =>
+{
+    var entityType = args.Entity.GetType();
+    var encryptedProps = resolver.GetEncryptedProperties(entityType);
+    if (encryptedProps.Length == 0) return;
+
+    var key = resolver.GetDecryptionKey(entityType);
+    foreach (var prop in encryptedProps)
+    {
+        var value = prop.GetValue(args.Entity);
+        if (value is not string strValue) continue;
+        if (!encryptionService.IsEncrypted(strValue)) continue;
+
+        var plaintext = encryptionService.Decrypt(strValue, key);
+        var typed = ConvertFromString(plaintext, prop.PropertyType);
+        prop.SetValue(args.Entity, typed);
+    }
+};
+```
+
+Since `[Encrypted]` is restricted to `string` properties, the RavenDB document stores a string and the CLR type is a string — no type conversion is needed. The `OnBeforeStore` hook replaces the plaintext string with the encrypted string, and the `OnAfterConversionToEntity` hook replaces the encrypted string with the decrypted plaintext.
+
+### 7. ETL Script Compatibility
+
+**ETL scripts require no changes.** Encrypted fields appear as normal string values in the RavenDB document. The ETL script copies them as-is:
+
+```javascript
+// Existing ETL script — works unchanged with encrypted fields
+loadToCars({
+    LicensePlate: this.LicensePlate,
+    VinNumber: this.VinNumber,  // Encrypted blob, copied as-is
+    '@metadata': {
+        '@collection': 'Cars'
+    }
+});
+```
+
+The receiving application (HR) decrypts using `ModuleKeys["Fleet"]` when loading the replicated document.
+
+### 8. Extension Methods
+
+```csharp
+namespace MintPlayer.Spark.Encryption.Extensions;
+
+public static class SparkEncryptionExtensions
+{
+    /// <summary>
+    /// Registers encryption services and configuration.
+    /// </summary>
+    public static IServiceCollection AddSparkEncryption(
+        this IServiceCollection services,
+        Action<SparkEncryptionOptions> configure);
+
+    /// <summary>
+    /// Applies encryption/decryption hooks to the RavenDB document store.
+    /// Must be called after AddSpark() and before the app starts handling requests.
+    /// </summary>
+    public static WebApplication UseSparkEncryption(this WebApplication app);
+}
+```
+
+#### Registration in Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSpark(builder.Configuration);
+builder.Services.AddSparkMessaging();
+builder.Services.AddSparkReplication(opt => { ... });
+builder.Services.AddSparkEncryption(opt =>
+{
+    var section = builder.Configuration.GetSection("SparkEncryption");
+    opt.OwnKey = section["OwnKey"]!;
+    opt.ModuleKeys = section.GetSection("ModuleKeys").Get<Dictionary<string, string>>() ?? new();
+});
+
+var app = builder.Build();
+
+app.UseSpark();
+app.UseSparkEncryption();  // Must be called after UseSpark()
+app.CreateSparkIndexes();
+app.CreateSparkMessagingIndexes();
+app.UseSparkReplication();
+
+app.MapSpark();
+app.MapSparkReplication();
+
+app.Run();
+```
+
+---
+
+## Demo Application Changes
+
+### Fleet: Add Encrypted VinNumber
+
+**File**: `Demo/Fleet/Fleet.Library/Entities/Car.cs`
+
+```csharp
+using MintPlayer.Spark.Encryption.Abstractions;
+
+namespace Fleet.Library.Entities;
+
+public class Car
+{
+    public string? Id { get; set; }
+    public string LicensePlate { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public int Year { get; set; }
+    public string? Color { get; set; }
+
+    [Encrypted]
+    public string VinNumber { get; set; } = string.Empty;
+}
+```
+
+### HR: Replicated Car with Encrypted VinNumber
+
+**File**: `Demo/HR/HR.Library/Replicated/Car.cs`
+
+```csharp
+using MintPlayer.Spark.Encryption.Abstractions;
+using MintPlayer.Spark.Replication.Abstractions;
+
+namespace HR.Library.Replicated;
+
+[Replicated(
+    SourceModule = "Fleet",
+    SourceCollection = "Cars",
+    EtlScript = """
+        loadToCars({
+            LicensePlate: this.LicensePlate,
+            Model: this.Model,
+            Year: this.Year,
+            Color: this.Color,
+            VinNumber: this.VinNumber,
+            '@metadata': {
+                '@collection': 'Cars'
+            }
+        });
+    """)]
+public class Car
+{
+    public string? Id { get; set; }
+    public string LicensePlate { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public int Year { get; set; }
+    public string? Color { get; set; }
+
+    [Encrypted]
+    public string VinNumber { get; set; } = string.Empty;
+}
+```
+
+### ETL Script Note
+
+The ETL script now includes `VinNumber: this.VinNumber` — this copies the encrypted string as-is from Fleet's database to HR's database. No decryption happens during ETL. HR's application decrypts using `ModuleKeys["Fleet"]` when loading the Car entity.
+
+---
+
+## Key Generation
+
+A helper command or utility should be provided to generate AES-256 keys:
+
+```csharp
+// Generate a new 256-bit AES key
+using System.Security.Cryptography;
+var key = new byte[32]; // 256 bits
+RandomNumberGenerator.Fill(key);
+Console.WriteLine(Convert.ToBase64String(key));
+```
+
+This could be exposed as a CLI command:
+
+```bash
+dotnet run --spark-generate-encryption-key
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Abstractions
+
+1. [ ] Create `MintPlayer.Spark.Encryption.Abstractions` project
+2. [ ] Implement `EncryptedAttribute`
+3. [ ] Implement `SparkEncryptionOptions`
+
+### Phase 2: Core Encryption Library
+
+4. [ ] Create `MintPlayer.Spark.Encryption` project
+5. [ ] Implement `FieldEncryptionService` (AES-256-GCM encrypt/decrypt)
+6. [ ] Implement `EncryptedFieldResolver` (reflection + caching)
+7. [ ] Implement RavenDB session hooks (`OnBeforeStore`, `OnAfterConversionToEntity`)
+8. [ ] Implement `SparkEncryptionExtensions` (`AddSparkEncryption`, `UseSparkEncryption`)
+
+### Phase 3: Demo Application Integration
+
+9. [ ] Add `[Encrypted]` to `Car.VinNumber` in Fleet
+10. [ ] Add `[Encrypted]` to `Car.VinNumber` in HR's replicated Car
+11. [ ] Update ETL script to include VinNumber
+12. [ ] Configure encryption keys in both apps' `appsettings.json`
+13. [ ] Test end-to-end: Fleet stores encrypted → ETL copies → HR decrypts
+
+### Phase 4: Polish
+
+14. [ ] Add backward compatibility (plaintext values encrypted on next save)
+15. [ ] Add key generation CLI command (`--spark-generate-encryption-key`)
+16. [ ] Add logging for encryption/decryption operations
+17. [ ] Add validation: warn if `[Encrypted]` is used on a property that's indexed in a queryable way
+
+---
+
+## Files to Create
+
+### New Projects
+
+- `MintPlayer.Spark.Encryption.Abstractions/MintPlayer.Spark.Encryption.Abstractions.csproj`
+- `MintPlayer.Spark.Encryption/MintPlayer.Spark.Encryption.csproj`
+
+### New Files (Abstractions)
+
+- `EncryptedAttribute.cs`
+- `Configuration/SparkEncryptionOptions.cs`
+
+### New Files (Encryption Library)
+
+- `Services/FieldEncryptionService.cs`
+- `Services/EncryptedFieldResolver.cs`
+- `Conventions/EncryptionSessionListeners.cs`
+- `Extensions/SparkEncryptionExtensions.cs`
+
+### Modified Files
+
+- `MintPlayer.Spark.sln` — add new projects
+- `Demo/Fleet/Fleet.Library/Entities/Car.cs` — add `[Encrypted]` on VinNumber
+- `Demo/Fleet/Fleet/appsettings.json` — add `SparkEncryption` section
+- `Demo/Fleet/Fleet/Program.cs` — add `AddSparkEncryption()` and `UseSparkEncryption()`
+- `Demo/HR/HR.Library/Replicated/Car.cs` — add `[Encrypted]` on VinNumber, add VinNumber to ETL script
+- `Demo/HR/HR/appsettings.json` — add `SparkEncryption` section
+- `Demo/HR/HR/Program.cs` — add `AddSparkEncryption()` and `UseSparkEncryption()`
+
+---
+
+## Security Considerations
+
+### Key Management
+
+- Keys MUST NOT be committed to source control
+- Use `appsettings.Production.json` (gitignored) or environment variables in production
+- `appsettings.Development.json` may contain development-only keys for local testing
+- Key rotation: implement a `--spark-rotate-encryption-key` command that re-encrypts all documents with a new key (future enhancement)
+
+### Encryption Algorithm
+
+- **AES-256-GCM** — authenticated encryption providing both confidentiality and integrity
+- 12-byte random IV per encryption (never reused)
+- 128-bit authentication tag for tamper detection
+- Uses `System.Security.Cryptography.AesGcm` — no external crypto dependencies
+
+### Threat Model
+
+| Threat | Mitigation |
+|--------|------------|
+| Database breach (attacker reads RavenDB files) | Encrypted fields are ciphertext — unusable without the key |
+| ETL copies sensitive data between databases | Data remains encrypted — only apps with the key can read it |
+| Key compromised for one module | Only that module's data is exposed (per-module isolation) |
+| Tampered ciphertext | GCM authentication tag verification fails → exception thrown |
+| IV reuse | Fresh random IV generated per encryption call |
+
+### Limitations
+
+- **Encrypted fields cannot be queried or sorted in RavenDB indexes** — ciphertext is not meaningful for comparison
+- **`[Encrypted]` is restricted to `string` properties** — non-string types are not supported
+- **No key rotation mechanism** in the initial implementation (planned for future)
+- **Model synchronization** should be aware that `[Encrypted]` string properties store ciphertext, not user-visible strings
+
+---
+
+## Design Decisions
+
+1. **String-only encryption**: `[Encrypted]` is restricted to `string` properties. Most sensitive data is string-typed (VIN, SSN, email, etc.), and this avoids JSON deserialization mismatches.
+
+2. **Backend-only concern**: Encryption is transparent to the frontend. The Angular app receives decrypted values via the API and renders normal text inputs. No UI indicators needed.
+
+3. **Auto-generate dev keys**: In development mode, `UseSparkEncryption()` will auto-generate and persist an AES-256 key to `appsettings.Development.json` if `SparkEncryption:OwnKey` is not configured. This removes friction for local development.
+
+---
+
+*This document is a living specification and will be updated as the project evolves.*


### PR DESCRIPTION
## Summary

- Adds `MintPlayer.Spark.Encryption.Abstractions` project with `[Encrypted]` attribute and `SparkEncryptionOptions` (OwnKey + ModuleKeys)
- Adds `MintPlayer.Spark.Encryption` project with AES-256-GCM encrypt/decrypt, hooking into `IDocumentStore.OnBeforeStore` / `OnAfterConversionToEntity` events
- Encrypted values stored as opaque `ENC:v1:{iv}:{ciphertext}:{tag}` blobs — safe for RavenDB ETL replication between modules
- Cross-module key resolution via `[Replicated(SourceModule)]` attribute — consuming modules decrypt with the source module's key
- Startup validation throws if `[Encrypted]` is used on non-string properties
- Auto-generates a dev key in Development mode when `OwnKey` is not configured
- Demo: Fleet `Car.VinNumber` encrypted at rest, replicated as encrypted blob to HR, decrypted on read in both modules

## Test plan

- [ ] `dotnet build MintPlayer.Spark.sln` compiles with no errors
- [ ] Temporarily add `[Encrypted]` to an `int` property → confirm startup throws `InvalidOperationException`
- [ ] Start Fleet app, create a Car with VinNumber → verify RavenDB document shows `ENC:v1:...` blob
- [ ] Load Car via Fleet API → confirm plaintext VinNumber is returned
- [ ] Start both Fleet + HR → create Car in Fleet → verify encrypted VinNumber blob replicates to HR database → load Car in HR → confirm decrypted VinNumber

🤖 Generated with [Claude Code](https://claude.com/claude-code)