### PR TITLE
fix: Fix webhook pipeline and upgrade to preview.26

### DIFF
--- a/Demo/DemoApp/DemoApp/DemoApp.csproj
+++ b/Demo/DemoApp/DemoApp/DemoApp.csproj
@@ -12,9 +12,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.4.0" />
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.5.0" />
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Demo/Fleet/Fleet/Fleet.csproj
+++ b/Demo/Fleet/Fleet/Fleet.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.4.0" />
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.5.0" />
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Demo/HR/HR/HR.csproj
+++ b/Demo/HR/HR/HR.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.4.0" />
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.5.0" />
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Demo/WebhooksDemo/WebhooksDemo/WebhooksDemo.csproj
+++ b/Demo/WebhooksDemo/WebhooksDemo/WebhooksDemo.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.4.0" />
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.AspNetCore.SpaServices" Version="10.5.0" />
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
+++ b/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
@@ -8,7 +8,7 @@
 
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Extension methods for WebSocket (ReadMessage, WriteMessage, ReadObject, WriteObject)</Description>
@@ -23,7 +23,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
+++ b/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Abstractions</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions and shared models for MintPlayer.Spark low-code framework.</Description>

--- a/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
+++ b/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Authorization</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Optional authorization package for MintPlayer.Spark low-code framework. Provides group-based access control for PersistentObjects and Queries.</Description>
@@ -26,12 +26,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.17.0" GeneratePathProperty="true" />
-		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.18.0" GeneratePathProperty="true" />
+		<PackageReference Include="RavenDB.Client" Version="7.2.1" />
 	</ItemGroup>
 
 	<!-- Global usings required by the MintPlayer.AspNetCore.Endpoints source generator output -->
@@ -51,13 +51,10 @@
 		These targets apply when the package is installed via NuGet.
 		buildTransitive makes them flow to transitive consumers as well.
 		-->
-		<None Include="Targets\spark-authorization.props" Pack="true"
-		      PackagePath="buildTransitive/$(PackageId).props" />
-		<None Include="Targets\spark-authorization.targets" Pack="true"
-		      PackagePath="buildTransitive/$(PackageId).targets" />
+		<None Include="Targets\spark-authorization.props" Pack="true" PackagePath="buildTransitive/$(PackageId).props" />
+		<None Include="Targets\spark-authorization.targets" Pack="true" PackagePath="buildTransitive/$(PackageId).targets" />
 		<!-- Template file for generated setup TypeScript -->
-		<None Include="Targets\spark-auth.setup.template.ts" Pack="true"
-		      PackagePath="buildTransitive/" />
+		<None Include="Targets\spark-auth.setup.template.ts" Pack="true" PackagePath="buildTransitive/" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
+++ b/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging.Abstractions</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Messaging: IMessageBus, IRecipient, and MessageQueueAttribute.</Description>

--- a/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
+++ b/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Durable message bus for MintPlayer.Spark with RavenDB persistence, scoped recipients, queue isolation, and retry logic.</Description>
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+		<PackageReference Include="RavenDB.Client" Version="7.2.1" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
+++ b/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication.Abstractions</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Replication: ReplicatedAttribute, ModuleInformation, and ETL script models.</Description>

--- a/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
+++ b/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cross-module ETL replication for MintPlayer.Spark using RavenDB ETL tasks and the durable message bus.</Description>
@@ -28,12 +28,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.17.0" GeneratePathProperty="true" />
-		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.18.0" GeneratePathProperty="true" />
+		<PackageReference Include="RavenDB.Client" Version="7.2.1" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
+++ b/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark low-code framework. Auto-generates DI registration for Actions classes.</Description>
@@ -33,6 +33,7 @@
 
     <ItemGroup>
       <PackageReference Update="Microsoft.CodeAnalysis" Version="5.0.0" />
-      <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+      <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+      <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     </ItemGroup>
 </Project>

--- a/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
+++ b/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.SubscriptionWorker</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>RavenDB subscription worker framework for MintPlayer.Spark with built-in retry logic, incremental backoff, and ASP.NET Core lifecycle management.</Description>
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+		<PackageReference Include="RavenDB.Client" Version="7.2.1" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -8,11 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
+++ b/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub.DevTunnel</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Development tunneling for MintPlayer.Spark GitHub webhooks — smee.io tunnel and WebSocket dev client for receiving production-forwarded webhooks locally.</Description>
@@ -25,11 +25,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.17.0" GeneratePathProperty="true" />
+		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.18.0" GeneratePathProperty="true" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Smee.IO.Client" Version="1.0.16" />
 	</ItemGroup>

--- a/MintPlayer.Spark.Webhooks.GitHub/Extensions/SparkBuilderExtensions.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Extensions/SparkBuilderExtensions.cs
@@ -33,9 +33,6 @@ public static class SparkBuilderExtensions
         // Register services (source-generated from [Register] attributes)
         builder.Services.AddSparkWebhooksGitHubServices();
 
-        // Manual registration: source generator doesn't support class-typed registrations yet
-        builder.Services.AddScoped<WebhookEventProcessor, SparkWebhookEventProcessor>();
-
         // Register dev WebSocket forwarding service if DevelopmentAppId is configured
         if (options.DevelopmentAppId.HasValue)
         {

--- a/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
+++ b/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>GitHub webhook integration for MintPlayer.Spark — broadcasts typed webhook events to the Spark message bus with support for production-to-dev WebSocket forwarding.</Description>
@@ -26,14 +26,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.17.0" GeneratePathProperty="true" />
+		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.18.0" GeneratePathProperty="true" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Octokit" Version="13.0.1" />
-		<PackageReference Include="Octokit.Webhooks.AspNetCore" Version="2.2.3" />
+		<PackageReference Include="Octokit" Version="14.0.0" />
+		<PackageReference Include="Octokit.Webhooks.AspNetCore" Version="3.2.1" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Webhooks.GitHub/Services/SparkWebhookEventProcessor.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Services/SparkWebhookEventProcessor.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using MintPlayer.SourceGenerators.Attributes;
@@ -19,7 +18,7 @@ using Octokit.Webhooks.Events.Repository;
 
 namespace MintPlayer.Spark.Webhooks.GitHub.Services;
 
-// [Register(typeof(WebhookEventProcessor), ServiceLifetime.Scoped)] — source generator doesn't support class-typed registrations yet
+[Register(typeof(WebhookEventProcessor), ServiceLifetime.Scoped)]
 internal partial class SparkWebhookEventProcessor : WebhookEventProcessor
 {
     [Inject] private readonly IMessageBus _messageBus;
@@ -32,7 +31,7 @@ internal partial class SparkWebhookEventProcessor : WebhookEventProcessor
     private string? _rawBody;
     private IDictionary<string, StringValues>? _rawHeaders;
 
-    public override async Task ProcessWebhookAsync(IDictionary<string, StringValues> headers, string body)
+    public override async ValueTask ProcessWebhookAsync(IDictionary<string, StringValues> headers, string body, CancellationToken cancellationToken = default)
     {
         // Octokit uses case-sensitive dictionary — make it case-insensitive
         var caseInsensitiveHeaders = new Dictionary<string, StringValues>(headers, StringComparer.OrdinalIgnoreCase);
@@ -68,54 +67,44 @@ internal partial class SparkWebhookEventProcessor : WebhookEventProcessor
         _rawHeaders = caseInsensitiveHeaders;
         _rawBody = body;
 
-        await base.ProcessWebhookAsync(caseInsensitiveHeaders, body);
+        await base.ProcessWebhookAsync(caseInsensitiveHeaders, body, cancellationToken);
     }
 
     // --- Event overrides: each delegates to the shared generic helper ---
 
-    protected override Task ProcessPushWebhookAsync(
-        WebhookHeaders headers, PushEvent pushEvent)
-        => HandleWebhookAsync(headers, pushEvent);
+    protected override ValueTask ProcessPushWebhookAsync(WebhookHeaders headers, PushEvent pushEvent, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, pushEvent, cancellationToken);
 
-    protected override Task ProcessIssuesWebhookAsync(
-        WebhookHeaders headers, IssuesEvent issuesEvent, IssuesAction action)
-        => HandleWebhookAsync(headers, issuesEvent);
+    protected override ValueTask ProcessIssuesWebhookAsync(WebhookHeaders headers, IssuesEvent issuesEvent, IssuesAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, issuesEvent, cancellationToken);
 
-    protected override Task ProcessIssueCommentWebhookAsync(
-        WebhookHeaders headers, IssueCommentEvent issueCommentEvent, IssueCommentAction action)
-        => HandleWebhookAsync(headers, issueCommentEvent);
+    protected override ValueTask ProcessIssueCommentWebhookAsync(WebhookHeaders headers, IssueCommentEvent issueCommentEvent, IssueCommentAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, issueCommentEvent, cancellationToken);
 
-    protected override Task ProcessPullRequestWebhookAsync(
-        WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action)
-        => HandleWebhookAsync(headers, pullRequestEvent);
+    protected override ValueTask ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, pullRequestEvent, cancellationToken);
 
-    protected override Task ProcessPullRequestReviewWebhookAsync(
-        WebhookHeaders headers, PullRequestReviewEvent pullRequestReviewEvent, PullRequestReviewAction action)
-        => HandleWebhookAsync(headers, pullRequestReviewEvent);
+    protected override ValueTask ProcessPullRequestReviewWebhookAsync(WebhookHeaders headers, PullRequestReviewEvent pullRequestReviewEvent, PullRequestReviewAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, pullRequestReviewEvent, cancellationToken);
 
-    protected override Task ProcessPullRequestReviewCommentWebhookAsync(
-        WebhookHeaders headers, PullRequestReviewCommentEvent pullRequestReviewCommentEvent, PullRequestReviewCommentAction action)
-        => HandleWebhookAsync(headers, pullRequestReviewCommentEvent);
+    protected override ValueTask ProcessPullRequestReviewCommentWebhookAsync(WebhookHeaders headers, PullRequestReviewCommentEvent pullRequestReviewCommentEvent, PullRequestReviewCommentAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, pullRequestReviewCommentEvent, cancellationToken);
 
-    protected override Task ProcessCheckRunWebhookAsync(
-        WebhookHeaders headers, CheckRunEvent checkRunEvent, CheckRunAction action)
-        => HandleWebhookAsync(headers, checkRunEvent);
+    protected override ValueTask ProcessCheckRunWebhookAsync(WebhookHeaders headers, CheckRunEvent checkRunEvent, CheckRunAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, checkRunEvent, cancellationToken);
 
-    protected override Task ProcessCheckSuiteWebhookAsync(
-        WebhookHeaders headers, CheckSuiteEvent checkSuiteEvent, CheckSuiteAction action)
-        => HandleWebhookAsync(headers, checkSuiteEvent);
+    protected override ValueTask ProcessCheckSuiteWebhookAsync(WebhookHeaders headers, CheckSuiteEvent checkSuiteEvent, CheckSuiteAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, checkSuiteEvent, cancellationToken);
 
-    protected override Task ProcessInstallationWebhookAsync(
-        WebhookHeaders headers, InstallationEvent installationEvent, InstallationAction action)
-        => HandleWebhookAsync(headers, installationEvent);
+    protected override ValueTask ProcessInstallationWebhookAsync(WebhookHeaders headers, InstallationEvent installationEvent, InstallationAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, installationEvent, cancellationToken);
 
-    protected override Task ProcessRepositoryWebhookAsync(
-        WebhookHeaders headers, RepositoryEvent repositoryEvent, RepositoryAction action)
-        => HandleWebhookAsync(headers, repositoryEvent);
+    protected override ValueTask ProcessRepositoryWebhookAsync(WebhookHeaders headers, RepositoryEvent repositoryEvent, RepositoryAction action, CancellationToken cancellationToken = default)
+        => HandleWebhookAsync(headers, repositoryEvent, cancellationToken);
 
     // --- Shared handler ---
 
-    private async Task HandleWebhookAsync<TEvent>(WebhookHeaders headers, TEvent evt)
+    private async ValueTask HandleWebhookAsync<TEvent>(WebhookHeaders headers, TEvent evt, CancellationToken cancellationToken = default)
         where TEvent : WebhookEvent
     {
         var installationId = evt.Installation?.Id ?? 0;
@@ -131,7 +120,7 @@ internal partial class SparkWebhookEventProcessor : WebhookEventProcessor
             RepositoryFullName = repoFullName,
             EventJson = _rawBody ?? string.Empty,
         };
-        await _messageBus.BroadcastAsync(typedMessage);
+        await _messageBus.BroadcastAsync(typedMessage, cancellationToken);
 
         // Broadcast catch-all message
         var catchAllMessage = new GitHubWebhookMessage
@@ -142,6 +131,6 @@ internal partial class SparkWebhookEventProcessor : WebhookEventProcessor
             EventType = headers.Event ?? string.Empty,
             EventJson = _rawBody ?? string.Empty,
         };
-        await _messageBus.BroadcastAsync(catchAllMessage);
+        await _messageBus.BroadcastAsync(catchAllMessage, cancellationToken);
     }
 }

--- a/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark</PackageId>
-		<Version>10.0.0-preview.25</Version>
+		<Version>10.0.0-preview.26</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Low-code .NET framework for building data-driven web applications with minimal boilerplate. Uses PersistentObject pattern to eliminate DTOs and repository layers.</Description>
@@ -34,12 +34,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.17.0">
+		<PackageReference Include="MintPlayer.SourceGenerators" Version="10.18.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.17.0" GeneratePathProperty="true" />
-		<PackageReference Include="RavenDB.Client" Version="7.1.5" />
+		<PackageReference Include="MintPlayer.SourceGenerators.Attributes" Version="10.18.0" GeneratePathProperty="true" />
+		<PackageReference Include="RavenDB.Client" Version="7.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- **Queue name mismatch**: typed webhook messages were broadcast with custom queue names (`spark-github-issues`) but subscription workers listen on `Type.FullName` — removed the override so both sides agree
- **Octokit serialization**: Octokit's `WebhookConverter` doesn't support `Write` (System.Text.Json) and Newtonsoft can't deserialize abstract event types — store raw JSON in `EventJson`, provide a computed `Event` property that lazily deserializes via System.Text.Json
- **MessageBus serializer**: switched from System.Text.Json to Newtonsoft.Json for message persistence to avoid Octokit converter conflicts
- **Package upgrades**: Octokit 14.0.0, Octokit.Webhooks.AspNetCore 3.2.1 (ValueTask + CancellationToken), MintPlayer.SourceGenerators 10.18.0 (class-typed `[Register]`), RavenDB.Client 7.2.1, all packages bumped to preview.26

## Test plan
- [x] Verified webhook delivery from GitHub App returns 200
- [x] Confirmed `LogAllWebhooks` (catch-all) processes messages successfully
- [x] Confirmed `LogIssues` (typed) processes messages and replies to GitHub issues
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)