### PR TITLE
test: QueryExecutor + SparkTestDriver Raven-backed integration pattern

### DIFF
--- a/.github/workflows/dotnet-build-master.yml
+++ b/.github/workflows/dotnet-build-master.yml
@@ -57,6 +57,8 @@ jobs:
 
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+      env:
+        RAVENDB_LICENSE: ${{ secrets.RAVENDB_LICENSE }}
 
     - name: Pack
       run: dotnet pack --no-build --configuration Release /p:ContinuousIntegrationBuild=true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,3 +52,4 @@ jobs:
       run: npx nx affected --target=test --exclude=@spark-demo/*,DemoApp,DemoApp.Library,Fleet,Fleet.Library,HR,HR.Library,WebhooksDemo,WebhooksDemo.Library
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+        RAVENDB_LICENSE: ${{ secrets.RAVENDB_LICENSE }}

--- a/MintPlayer.Spark.Testing/SparkTestDriver.cs
+++ b/MintPlayer.Spark.Testing/SparkTestDriver.cs
@@ -1,4 +1,5 @@
 using Raven.Client.Documents;
+using Raven.Embedded;
 using Raven.TestDriver;
 
 namespace MintPlayer.Spark.Testing;
@@ -6,14 +7,38 @@ namespace MintPlayer.Spark.Testing;
 /// <summary>
 /// xUnit-friendly base class for Spark tests that need an in-memory RavenDB instance.
 /// Implements <see cref="IAsyncLifetime"/> so setup and disposal run per test class
-/// (use xUnit's default behavior — one instance per test method).
+/// (one instance per test method, by xUnit's default).
+///
+/// RavenDB 7.x requires a license even for the embedded TestDriver. We load it from:
+///   1. <c>RAVENDB_LICENSE</c> env var (CI-friendly, JSON content)
+///   2. <c>raven-license.log</c> at the repository root (local development)
+///
+/// If neither is present, tests that derive from this class will fail at
+/// <see cref="InitializeAsync"/> with a clear message — see <see cref="LicenseHelper"/>.
 /// </summary>
 public abstract class SparkTestDriver : RavenTestDriver, IAsyncLifetime
 {
+    static SparkTestDriver()
+    {
+        var license = LicenseHelper.LoadOrNull();
+        if (license is not null)
+        {
+            ConfigureServer(new TestServerOptions
+            {
+                Licensing = new ServerOptions.LicensingOptions
+                {
+                    License = license,
+                    EulaAccepted = true,
+                },
+            });
+        }
+    }
+
     protected IDocumentStore Store { get; private set; } = null!;
 
     public virtual Task InitializeAsync()
     {
+        LicenseHelper.EnsureAvailable();
         Store = GetDocumentStore();
         return Task.CompletedTask;
     }
@@ -22,5 +47,54 @@ public abstract class SparkTestDriver : RavenTestDriver, IAsyncLifetime
     {
         Store.Dispose();
         return Task.CompletedTask;
+    }
+}
+
+internal static class LicenseHelper
+{
+    private const string EnvVar = "RAVENDB_LICENSE";
+    private const string LocalFileName = "raven-license.log";
+
+    public static string? LoadOrNull()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(EnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv;
+
+        var fromFile = TryReadRepoRootLicense();
+        return fromFile;
+    }
+
+    public static void EnsureAvailable()
+    {
+        if (LoadOrNull() is null)
+        {
+            throw new InvalidOperationException(
+                $"RavenDB license not found. Set the '{EnvVar}' environment variable to the JSON " +
+                $"license content, or place a '{LocalFileName}' file at the repository root. " +
+                "See https://ravendb.net/buy for community/developer licenses.");
+        }
+    }
+
+    private static string? TryReadRepoRootLicense()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, LocalFileName);
+            if (File.Exists(candidate))
+            {
+                try
+                {
+                    return File.ReadAllText(candidate);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
     }
 }

--- a/MintPlayer.Spark.Tests/Services/QueryExecutorIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/QueryExecutorIntegrationTests.cs
@@ -1,0 +1,202 @@
+using System.Linq;
+using System.Reflection;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using NSubstitute;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Integration tests for QueryExecutor that exercise real RavenDB through SparkTestDriver.
+/// Database queries reflect on a SparkContext subclass for the IQueryable property; these
+/// tests use a fixture context with seeded Person documents.
+/// </summary>
+public class QueryExecutorIntegrationTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("eeeeeeee-2222-2222-2222-222222222222");
+
+    public class Person
+    {
+        public string? Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+    }
+
+    public class TestSparkContext : SparkContext
+    {
+        public IRavenQueryable<Person> People => Session.Query<Person>();
+    }
+
+    private readonly IModelLoader _modelLoader = Substitute.For<IModelLoader>();
+    private readonly ISparkContextResolver _contextResolver = Substitute.For<ISparkContextResolver>();
+    private readonly IIndexRegistry _indexRegistry = Substitute.For<IIndexRegistry>();
+    private readonly IPermissionService _permissionService = Substitute.For<IPermissionService>();
+    private readonly IActionsResolver _actionsResolver = Substitute.For<IActionsResolver>();
+    private readonly IReferenceResolver _referenceResolver = Substitute.For<IReferenceResolver>();
+
+    private QueryExecutor CreateExecutor()
+    {
+        // EntityMapper is concrete + uses real reflection — give it a real instance.
+        var entityMapper = new EntityMapper(_modelLoader);
+
+        // Default substitutions
+        _modelLoader.GetEntityType(PersonTypeId).Returns(PersonTypeDefinition());
+        _modelLoader.GetEntityTypeByClrType(typeof(Person).FullName!).Returns(PersonTypeDefinition());
+
+        _contextResolver.ResolveContext(Arg.Any<IAsyncDocumentSession>())
+            .Returns(ci =>
+            {
+                var ctx = new TestSparkContext();
+                typeof(SparkContext)
+                    .GetProperty(nameof(SparkContext.Session))!
+                    .SetValue(ctx, ci.Arg<IAsyncDocumentSession>());
+                return ctx;
+            });
+
+        _indexRegistry.GetRegistrationForCollectionType(typeof(Person)).Returns((IndexRegistration?)null);
+        _referenceResolver.GetReferenceProperties(typeof(Person), typeof(Person))
+            .Returns(new List<(PropertyInfo Property, ReferenceAttribute Attribute)>());
+        _referenceResolver.ResolveReferencedDocumentsAsync(
+            Arg.Any<IAsyncDocumentSession>(),
+            Arg.Any<IList<object>>(),
+            Arg.Any<List<(PropertyInfo Property, ReferenceAttribute Attribute)>>())
+            .Returns(new Dictionary<string, object>());
+
+        return new QueryExecutor(
+            Store, entityMapper, _modelLoader, _contextResolver,
+            _indexRegistry, _permissionService, _actionsResolver, _referenceResolver);
+    }
+
+    private static EntityTypeDefinition PersonTypeDefinition() => new()
+    {
+        Id = PersonTypeId,
+        Name = "Person",
+        ClrType = typeof(Person).FullName!,
+        DisplayAttribute = "LastName",
+        Attributes =
+        [
+            new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+            new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+        ]
+    };
+
+    private async Task SeedPeopleAsync(params (string id, string first, string last)[] people)
+    {
+        using var session = Store.OpenAsyncSession();
+        foreach (var (id, first, last) in people)
+        {
+            await session.StoreAsync(new Person { FirstName = first, LastName = last }, id);
+        }
+        await session.SaveChangesAsync();
+        WaitForIndexing(Store);
+    }
+
+    private static SparkQuery DatabasePeopleQuery() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "AllPeople",
+        Source = "Database.People",
+    };
+
+    [Fact]
+    public async Task Database_query_returns_all_seeded_documents()
+    {
+        await SeedPeopleAsync(
+            ("people/1", "Alice", "Smith"),
+            ("people/2", "Bob", "Jones"),
+            ("people/3", "Carol", "Davis"));
+
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(DatabasePeopleQuery());
+
+        result.TotalRecords.Should().Be(3);
+        result.Data.Select(p => p.Id).Should().BeEquivalentTo(["people/1", "people/2", "people/3"]);
+    }
+
+    [Fact]
+    public async Task Database_query_calls_permission_service_with_Query_action()
+    {
+        await SeedPeopleAsync(("people/1", "Alice", "Smith"));
+        var executor = CreateExecutor();
+
+        await executor.ExecuteQueryAsync(DatabasePeopleQuery());
+
+        await _permissionService.Received(1).EnsureAuthorizedAsync("Query", "Person", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Database_query_propagates_permission_denial()
+    {
+        await SeedPeopleAsync(("people/1", "Alice", "Smith"));
+        _permissionService
+            .EnsureAuthorizedAsync("Query", "Person", Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new SparkAccessDeniedException("denied")));
+        var executor = CreateExecutor();
+
+        var act = () => executor.ExecuteQueryAsync(DatabasePeopleQuery());
+
+        await act.Should().ThrowAsync<SparkAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task Search_filters_results_by_attribute_value_substring()
+    {
+        await SeedPeopleAsync(
+            ("people/1", "Alice", "Smith"),
+            ("people/2", "Bob", "Jones"),
+            ("people/3", "Carol", "Davis"));
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(DatabasePeopleQuery(), search: "alice");
+
+        result.TotalRecords.Should().Be(1);
+        result.Data.Should().ContainSingle().Which.Id.Should().Be("people/1");
+    }
+
+    [Fact]
+    public async Task Search_is_case_insensitive()
+    {
+        await SeedPeopleAsync(
+            ("people/1", "Alice", "Smith"),
+            ("people/2", "Bob", "Jones"));
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(DatabasePeopleQuery(), search: "SMITH");
+
+        result.TotalRecords.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Pagination_skips_and_takes_correctly()
+    {
+        await SeedPeopleAsync(
+            Enumerable.Range(1, 10)
+                .Select(i => ($"people/{i}", $"First{i}", $"Last{i}"))
+                .ToArray());
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(DatabasePeopleQuery(), skip: 3, take: 4);
+
+        result.TotalRecords.Should().Be(10);   // unfiltered total
+        result.Data.Count().Should().Be(4);    // only the page
+        result.Skip.Should().Be(3);
+        result.Take.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Empty_database_returns_empty_result()
+    {
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(DatabasePeopleQuery());
+
+        result.TotalRecords.Should().Be(0);
+        result.Data.Should().BeEmpty();
+    }
+}

--- a/MintPlayer.Spark.Tests/Services/QueryExecutorUnitTests.cs
+++ b/MintPlayer.Spark.Tests/Services/QueryExecutorUnitTests.cs
@@ -1,0 +1,145 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Services;
+using NSubstitute;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Pure-mock unit tests for QueryExecutor — covers source parsing, empty-path
+/// short-circuits, and search/pagination logic without spinning up RavenDB.
+/// Integration tests for happy-path execution live in QueryExecutorIntegrationTests.
+/// </summary>
+public class QueryExecutorUnitTests
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("dddddddd-1111-1111-1111-111111111111");
+
+    private readonly IDocumentStore _store = Substitute.For<IDocumentStore>();
+    private readonly IEntityMapper _entityMapper = Substitute.For<IEntityMapper>();
+    private readonly IModelLoader _modelLoader = Substitute.For<IModelLoader>();
+    private readonly ISparkContextResolver _contextResolver = Substitute.For<ISparkContextResolver>();
+    private readonly IIndexRegistry _indexRegistry = Substitute.For<IIndexRegistry>();
+    private readonly IPermissionService _permissionService = Substitute.For<IPermissionService>();
+    private readonly IActionsResolver _actionsResolver = Substitute.For<IActionsResolver>();
+    private readonly IReferenceResolver _referenceResolver = Substitute.For<IReferenceResolver>();
+
+    public QueryExecutorUnitTests()
+    {
+        _store.OpenAsyncSession().Returns(Substitute.For<IAsyncDocumentSession>());
+    }
+
+    private QueryExecutor CreateExecutor() => new(
+        _store, _entityMapper, _modelLoader, _contextResolver,
+        _indexRegistry, _permissionService, _actionsResolver, _referenceResolver);
+
+    private static SparkQuery Q(string source) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "TestQuery",
+        Source = source,
+    };
+
+    [Fact]
+    public async Task Throws_when_source_has_no_known_prefix()
+    {
+        var executor = CreateExecutor();
+
+        var act = () => executor.ExecuteQueryAsync(Q("Invalid.Stuff"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains("invalid Source") && e.Message.Contains("TestQuery"));
+    }
+
+    [Fact]
+    public async Task Throws_when_source_is_empty_string()
+    {
+        var executor = CreateExecutor();
+
+        var act = () => executor.ExecuteQueryAsync(Q(string.Empty));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Database_query_returns_empty_when_SparkContext_unresolved()
+    {
+        _contextResolver.ResolveContext(Arg.Any<IAsyncDocumentSession>()).Returns((SparkContext?)null);
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("Database.People"));
+
+        result.Data.Should().BeEmpty();
+        result.TotalRecords.Should().Be(0);
+    }
+
+    private sealed class EmptyContext : SparkContext { }
+
+    [Fact]
+    public async Task Database_query_returns_empty_when_property_does_not_exist_on_context()
+    {
+        _contextResolver.ResolveContext(Arg.Any<IAsyncDocumentSession>()).Returns(new EmptyContext());
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("Database.NoSuchProperty"));
+
+        result.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Custom_query_returns_empty_when_EntityType_is_not_set()
+    {
+        // EntityType is null on SparkQuery → ResolveEntityTypeDefinition returns null → empty
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("Custom.SomeMethod"));
+
+        result.Data.Should().BeEmpty();
+        result.TotalRecords.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Custom_prefix_match_is_case_insensitive()
+    {
+        var executor = CreateExecutor();
+
+        // No EntityType → empty data, but the prefix-matching branch was taken without throwing
+        var result = await executor.ExecuteQueryAsync(Q("custom.Anything"));
+
+        result.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Database_prefix_match_is_case_insensitive()
+    {
+        _contextResolver.ResolveContext(Arg.Any<IAsyncDocumentSession>()).Returns((SparkContext?)null);
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("DATABASE.People"));
+
+        result.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Pagination_skip_and_take_default_to_full_result_set()
+    {
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("Database.People"));
+
+        result.Skip.Should().Be(0);
+        result.Take.Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Pagination_skip_and_take_are_propagated_to_result_envelope()
+    {
+        var executor = CreateExecutor();
+
+        var result = await executor.ExecuteQueryAsync(Q("Database.People"), skip: 25, take: 10);
+
+        result.Skip.Should().Be(25);
+        result.Take.Should().Be(10);
+    }
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/SparkTestDriverSmokeTests.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/SparkTestDriverSmokeTests.cs
@@ -1,0 +1,29 @@
+using MintPlayer.Spark.Testing;
+
+namespace MintPlayer.Spark.Tests._Infrastructure;
+
+public class SparkTestDriverSmokeTests : SparkTestDriver
+{
+    private class Widget
+    {
+        public string? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task Document_store_round_trips_a_document()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Widget { Name = "Acme" }, "widgets/1");
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = Store.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<Widget>("widgets/1");
+            loaded.Should().NotBeNull();
+            loaded!.Name.Should().Be("Acme");
+        }
+    }
+}

--- a/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -35,6 +35,8 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="MintPlayer.Spark.Tests" />
+		<!-- Allows NSubstitute (Castle DynamicProxy) to mock internal interfaces -->
+		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

Establishes the **Raven-backed integration test pattern** and uses it to cover `QueryExecutor` end-to-end. Test count goes 109 → **126**.

### Tests added (17)

| File | Count | Type |
|---|---|---|
| `_Infrastructure/SparkTestDriverSmokeTests.cs` | 1 | Smoke test — proves `SparkTestDriver` + license loader + `RavenDB.TestDriver` round-trips a document |
| `Services/QueryExecutorUnitTests.cs` | 9 | Pure-mock unit tests — source-prefix parsing, empty-path short-circuits, pagination math, case-insensitivity |
| `Services/QueryExecutorIntegrationTests.cs` | 7 | Real RavenDB via `SparkTestDriver` — seed → query → search → page → permission flow, including `SparkAccessDeniedException` propagation |

### Infrastructure changes that unlock future work

- **`SparkTestDriver` license loader** (`MintPlayer.Spark.Testing/SparkTestDriver.cs`): RavenDB 7.x requires a license even for the embedded TestDriver. Loader reads `RAVENDB_LICENSE` env var first (CI-friendly), then walks up from `AppContext.BaseDirectory` looking for a gitignored `raven-license.log` (local development). Throws an actionable error if neither is present.
- **`InternalsVisibleTo("DynamicProxyGenAssembly2")`** on `MintPlayer.Spark` — lets NSubstitute (Castle DynamicProxy) mock internal interfaces like `IReferenceResolver`. Removes friction for any future test of internal services.

### CI

- `pull-request.yml` and `dotnet-build-master.yml` now pass `RAVENDB_LICENSE` through to the test step. The secret is already configured in the repo.

## Test plan

- [x] `dotnet test MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj` locally → 126/126 pass
- [x] CI `nx affected --target=test` runs green with `RAVENDB_LICENSE` secret wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)