### PR TITLE
test: ng-spark-auth — SparkAuthService, guard, interceptor

### DIFF
--- a/node_packages/ng-spark-auth/core/src/spark-auth.service.spec.ts
+++ b/node_packages/ng-spark-auth/core/src/spark-auth.service.spec.ts
@@ -1,0 +1,212 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { SparkAuthService } from './spark-auth.service';
+import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
+
+/** Microtask flush — let pending awaited Promises resolve before the next HTTP expectation. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('SparkAuthService', () => {
+  let service: SparkAuthService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+      ],
+    });
+    service = TestBed.inject(SparkAuthService);
+    http = TestBed.inject(HttpTestingController);
+
+    // Service constructor calls checkAuth() — flush the initial /me call as 401
+    http.expectOne('/spark/auth/me').flush(null, { status: 401, statusText: 'Unauthorized' });
+  });
+
+  it('starts unauthenticated', () => {
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.user()).toBeNull();
+  });
+
+  it('login posts credentials, refreshes csrf, then re-checks auth', async () => {
+    const promise = service.login('user@example.com', 'password123');
+
+    const loginReq = http.expectOne('/spark/auth/login?useCookies=true');
+    expect(loginReq.request.method).toBe('POST');
+    expect(loginReq.request.body).toEqual({ email: 'user@example.com', password: 'password123' });
+    loginReq.flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/csrf-refresh').flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/me').flush({
+      isAuthenticated: true,
+      userName: 'user',
+      email: 'user@example.com',
+      roles: [],
+    });
+
+    await promise;
+
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.user()?.email).toBe('user@example.com');
+  });
+
+  it('login propagates server errors', async () => {
+    const promise = service.login('user@example.com', 'wrong');
+
+    http.expectOne('/spark/auth/login?useCookies=true')
+      .flush({ detail: 'Invalid credentials' }, { status: 401, statusText: 'Unauthorized' });
+
+    await expect(promise).rejects.toBeDefined();
+  });
+
+  it('loginTwoFactor posts the 2FA code', async () => {
+    const promise = service.loginTwoFactor('123456');
+
+    const req = http.expectOne('/spark/auth/login?useCookies=true');
+    expect(req.request.body).toEqual({ twoFactorCode: '123456', twoFactorRecoveryCode: undefined });
+    req.flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/csrf-refresh').flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/me').flush({
+      isAuthenticated: true, userName: 'u', email: 'u@x', roles: [],
+    });
+
+    await promise;
+    expect(service.isAuthenticated()).toBe(true);
+  });
+
+  it('loginTwoFactor accepts a recovery code', async () => {
+    const promise = service.loginTwoFactor('', 'RECOVERY-CODE');
+
+    const req = http.expectOne('/spark/auth/login?useCookies=true');
+    expect(req.request.body.twoFactorRecoveryCode).toBe('RECOVERY-CODE');
+    req.flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/csrf-refresh').flush(null);
+    await flush();
+
+    http.expectOne('/spark/auth/me').flush({
+      isAuthenticated: true, userName: 'u', email: 'u@x', roles: [],
+    });
+
+    await promise;
+  });
+
+  it('register posts email and password', async () => {
+    const promise = service.register('new@example.com', 'pw');
+
+    const req = http.expectOne('/spark/auth/register');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email: 'new@example.com', password: 'pw' });
+    req.flush(null);
+
+    await promise;
+  });
+
+  it('logout clears the user signal after csrf refresh', async () => {
+    // arrange: authenticate first
+    const loginPromise = service.login('user@x', 'pw');
+    http.expectOne('/spark/auth/login?useCookies=true').flush(null);
+    await flush();
+    http.expectOne('/spark/auth/csrf-refresh').flush(null);
+    await flush();
+    http.expectOne('/spark/auth/me').flush({
+      isAuthenticated: true, userName: 'u', email: 'u@x', roles: [],
+    });
+    await loginPromise;
+    expect(service.isAuthenticated()).toBe(true);
+
+    // act
+    const logoutPromise = service.logout();
+    http.expectOne('/spark/auth/logout').flush(null);
+    await flush();
+    http.expectOne('/spark/auth/csrf-refresh').flush(null);
+    await logoutPromise;
+
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.user()).toBeNull();
+  });
+
+  it('checkAuth sets the user on a successful /me response', async () => {
+    const promise = service.checkAuth();
+    http.expectOne('/spark/auth/me').flush({
+      isAuthenticated: true,
+      userName: 'jane',
+      email: 'jane@example.com',
+      roles: ['admin'],
+    });
+
+    const result = await promise;
+
+    expect(result?.userName).toBe('jane');
+    expect(service.user()?.roles).toEqual(['admin']);
+  });
+
+  it('checkAuth sets user to null on a 401 response', async () => {
+    const promise = service.checkAuth();
+    http.expectOne('/spark/auth/me').flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(service.user()).toBeNull();
+  });
+
+  it('forgotPassword posts the email', async () => {
+    const promise = service.forgotPassword('forgot@example.com');
+
+    const req = http.expectOne('/spark/auth/forgotPassword');
+    expect(req.request.body).toEqual({ email: 'forgot@example.com' });
+    req.flush(null);
+
+    await promise;
+  });
+
+  it('resetPassword posts email, code and new password', async () => {
+    const promise = service.resetPassword('user@example.com', 'CODE-123', 'newPw');
+
+    const req = http.expectOne('/spark/auth/resetPassword');
+    expect(req.request.body).toEqual({
+      email: 'user@example.com',
+      resetCode: 'CODE-123',
+      newPassword: 'newPw',
+    });
+    req.flush(null);
+
+    await promise;
+  });
+
+  it('uses configured apiBasePath when overridden', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SPARK_AUTH_CONFIG, useValue: { ...defaultSparkAuthConfig, apiBasePath: '/custom/auth' } },
+      ],
+    });
+    const customService = TestBed.inject(SparkAuthService);
+    const customHttp = TestBed.inject(HttpTestingController);
+
+    customHttp.expectOne('/custom/auth/me').flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    const promise = customService.forgotPassword('a@b.c');
+    customHttp.expectOne('/custom/auth/forgotPassword').flush(null);
+    await promise;
+  });
+});

--- a/node_packages/ng-spark-auth/guards/src/spark-auth.guard.spec.ts
+++ b/node_packages/ng-spark-auth/guards/src/spark-auth.guard.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { UrlTree, type ActivatedRouteSnapshot, type RouterStateSnapshot } from '@angular/router';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { sparkAuthGuard } from './spark-auth.guard';
+import { SparkAuthService } from '@mintplayer/ng-spark-auth/core';
+import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
+
+describe('sparkAuthGuard', () => {
+  let isAuthenticated = false;
+
+  function configure(config = defaultSparkAuthConfig) {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: SPARK_AUTH_CONFIG, useValue: config },
+        {
+          provide: SparkAuthService,
+          useValue: { isAuthenticated: () => isAuthenticated },
+        },
+      ],
+    });
+  }
+
+  function runGuard(targetUrl: string): boolean | UrlTree {
+    return TestBed.runInInjectionContext(() =>
+      sparkAuthGuard(
+        {} as ActivatedRouteSnapshot,
+        { url: targetUrl } as RouterStateSnapshot,
+      ),
+    ) as boolean | UrlTree;
+  }
+
+  beforeEach(() => {
+    isAuthenticated = false;
+  });
+
+  it('returns true when the user is authenticated', () => {
+    isAuthenticated = true;
+    configure();
+
+    expect(runGuard('/anything')).toBe(true);
+  });
+
+  it('returns a UrlTree to the configured login route when unauthenticated', () => {
+    configure();
+
+    const result = runGuard('/protected/page');
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect((result as UrlTree).toString().startsWith('/login')).toBe(true);
+  });
+
+  it('preserves the requested URL as returnUrl on the redirect', () => {
+    configure();
+
+    const tree = runGuard('/protected/page?x=1') as UrlTree;
+
+    expect(tree.queryParams['returnUrl']).toBe('/protected/page?x=1');
+  });
+
+  it('respects a custom loginUrl from the config', () => {
+    configure({ ...defaultSparkAuthConfig, loginUrl: '/auth/signin' });
+
+    const tree = runGuard('/somewhere') as UrlTree;
+
+    expect(tree.toString().startsWith('/auth/signin')).toBe(true);
+  });
+});

--- a/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
+++ b/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import {
+  HttpClient,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+import { Router } from '@angular/router';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { sparkAuthInterceptor } from './spark-auth.interceptor';
+import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
+
+describe('sparkAuthInterceptor', () => {
+  let http: HttpClient;
+  let httpTesting: HttpTestingController;
+  let router: { navigate: ReturnType<typeof vi.fn>; url: string };
+
+  beforeEach(() => {
+    router = { navigate: vi.fn(), url: '/current/page' };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([sparkAuthInterceptor])),
+        provideHttpClientTesting(),
+        { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  it('passes successful responses through untouched', async () => {
+    const promise = new Promise<unknown>((resolve, reject) => {
+      http.get('/some/data').subscribe({ next: resolve, error: reject });
+    });
+
+    httpTesting.expectOne('/some/data').flush({ ok: true });
+
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the login URL on a 401 from a non-api endpoint', () => {
+    http.get('/some/protected/page').subscribe({ error: () => undefined });
+
+    httpTesting.expectOne('/some/protected/page')
+      .flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(router.navigate).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['/login'],
+      { queryParams: { returnUrl: '/current/page' } },
+    );
+  });
+
+  it('does NOT navigate on a 401 from an api endpoint (no redirect loop)', () => {
+    http.get('/spark/auth/me').subscribe({ error: () => undefined });
+
+    httpTesting.expectOne('/spark/auth/me')
+      .flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate on non-401 errors (e.g. 500)', () => {
+    http.get('/some/data').subscribe({ error: () => undefined });
+
+    httpTesting.expectOne('/some/data')
+      .flush(null, { status: 500, statusText: 'Server Error' });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate on 403 (forbidden, not auth-required)', () => {
+    http.get('/some/data').subscribe({ error: () => undefined });
+
+    httpTesting.expectOne('/some/data')
+      .flush(null, { status: 403, statusText: 'Forbidden' });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/node_packages/ng-spark-auth/src/test-setup.ts
+++ b/node_packages/ng-spark-auth/src/test-setup.ts
@@ -1,0 +1,3 @@
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: true });

--- a/node_packages/ng-spark-auth/vitest.config.ts
+++ b/node_packages/ng-spark-auth/vitest.config.ts
@@ -1,9 +1,12 @@
+import angular from '@analogjs/vite-plugin-angular';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  plugins: [angular()],
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
     include: ['**/*.spec.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/out-tsc/**'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
         "tslib": "2.8.1"
       },
       "devDependencies": {
+        "@analogjs/vite-plugin-angular": "^2.4.8",
+        "@analogjs/vitest-angular": "^2.4.8",
         "@angular/build": "21.1.5",
         "@angular/cli": "21.1.5",
         "@angular/compiler-cli": "21.1.6",
@@ -332,6 +334,56 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@analogjs/vite-plugin-angular": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-2.4.8.tgz",
+      "integrity": "sha512-+oGNG90coJtMMUi8+dNnaMsoDxUMMF/B9xmt9+bwouylMuckPwEFFxDGosoCSxjxVF9hI2k/1W+VjWKZVWlEGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyglobby": "^0.2.14",
+        "ts-morph": "^21.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
+      "peerDependencies": {
+        "@angular-devkit/build-angular": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/build": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular-devkit/build-angular": {
+          "optional": true
+        },
+        "@angular/build": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@analogjs/vitest-angular": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@analogjs/vitest-angular/-/vitest-angular-2.4.8.tgz",
+      "integrity": "sha512-gO4UmyXFXUum19sUP+V/phWLwI/CRYXPWZPYglf0HY+VTx8SIOPnw9Rw9KaeHiF3fI4ySzTezcS2sm1km762NA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
+      "peerDependencies": {
+        "@analogjs/vite-plugin-angular": "*",
+        "@angular-devkit/architect": ">=0.1500.0 < 0.2200.0",
+        "@angular-devkit/schematics": ">=17.0.0",
+        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+        "zone.js": ">=0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "zone.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/architect": {
@@ -7717,6 +7769,69 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.22.0.tgz",
+      "integrity": "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.3",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -8767,6 +8882,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -11865,6 +11987,22 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -12994,6 +13132,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -14552,6 +14697,17 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-21.0.1.tgz",
+      "integrity": "sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.22.0",
+        "code-block-writer": "^12.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "tslib": "2.8.1"
   },
   "devDependencies": {
+    "@analogjs/vite-plugin-angular": "^2.4.8",
+    "@analogjs/vitest-angular": "^2.4.8",
     "@angular/build": "21.1.5",
     "@angular/cli": "21.1.5",
     "@angular/compiler-cli": "21.1.6",


### PR DESCRIPTION
## Summary

Establishes the **Angular component-test pattern** with TestBed via `@analogjs/vitest-angular` and uses it to cover the security-critical auth surface of `ng-spark-auth`. Test count goes 136 → **157** (126 .NET + 31 Angular).

### Tests added (21)

| File | Count | What |
|---|---|---|
| `core/src/spark-auth.service.spec.ts` | 12 | Login/2FA/register/logout/checkAuth/forgotPassword/resetPassword via `HttpTestingController`, signal state transitions, custom apiBasePath |
| `guards/src/spark-auth.guard.spec.ts` | 4 | Authenticated → true; unauthenticated → `UrlTree(loginUrl)` with `returnUrl` query param; custom loginUrl |
| `interceptors/src/spark-auth.interceptor.spec.ts` | 5 | 401 from non-api → navigate to login; 401 from api → no navigation (avoids redirect loop); 500/403 don't trigger nav |

### Infrastructure

- `npm i -D @analogjs/vite-plugin-angular @analogjs/vitest-angular`
- `node_packages/ng-spark-auth/vitest.config.ts` wires the Angular Vite plugin
- `node_packages/ng-spark-auth/src/test-setup.ts` calls `setupTestBed({ zoneless: true })` — both libraries are zoneless

### Patterns established (notes in commit message)

- Sequential awaited `firstValueFrom(http.post(...))` calls need a microtask flush between `expectOne` calls — provided as a `flush()` helper.
- `CanActivateFn` tests must use `TestBed.runInInjectionContext`, **not** the imported `runInInjectionContext` from `@angular/core`.

## Test plan

- [x] `npx vitest run` in `node_packages/ng-spark-auth/` → 26/26 pass
- [x] `nx run-many --target=test --projects=@mintplayer/ng-spark,@mintplayer/ng-spark-auth,MintPlayer.Spark.Tests` → all green (157 total)
- [ ] CI `nx affected --target=test` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)