### PR TITLE
test: PersistentObject GET + LIST endpoints (HTTP integration pattern)

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/GetEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/GetEndpointTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+public class GetEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("11111111-aaaa-aaaa-aaaa-111111111111");
+
+    private SparkEndpointFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = _factory.CreateClient();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Get_returns_404_when_entity_type_is_unknown()
+    {
+        var unknownTypeId = Guid.NewGuid();
+
+        var response = await _client.GetAsync($"/spark/po/{unknownTypeId}/people%2F1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_returns_404_when_entity_type_is_known_but_id_does_not_exist()
+    {
+        var response = await _client.GetAsync($"/spark/po/{PersonTypeId}/people%2Fdoes-not-exist");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_resolves_entity_type_by_alias()
+    {
+        var response = await _client.GetAsync($"/spark/po/person/people%2Fdoes-not-exist");
+
+        // Alias resolves → entity type known → falls through to "id not found"
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_returns_persistent_object_for_existing_document()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = "Alice", LastName = "Smith" }, "people/1");
+            await session.SaveChangesAsync();
+        }
+        WaitForIndexing(Store);
+
+        var response = await _client.GetAsync($"/spark/po/{PersonTypeId}/people%2F1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"id\":\"people/1\"");
+        body.Should().Contain("Alice");
+        body.Should().Contain("Smith");
+    }
+}
+
+public static class TestModels
+{
+    public static EntityTypeFile Person(Guid id) => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = id,
+            Name = "Person",
+            ClrType = typeof(Person).FullName!,
+            DisplayAttribute = "LastName",
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+            ],
+        }
+    };
+}

--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/ListEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/ListEndpointTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+public class ListEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("22222222-bbbb-bbbb-bbbb-222222222222");
+
+    private SparkEndpointFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = _factory.CreateClient();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task List_returns_404_when_entity_type_is_unknown()
+    {
+        var unknownTypeId = Guid.NewGuid();
+
+        var response = await _client.GetAsync($"/spark/po/{unknownTypeId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_returns_empty_array_when_no_documents_exist()
+    {
+        var response = await _client.GetAsync($"/spark/po/{PersonTypeId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task List_returns_all_seeded_documents()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = "Alice", LastName = "Smith" }, "people/1");
+            await session.StoreAsync(new Person { FirstName = "Bob", LastName = "Jones" }, "people/2");
+            await session.StoreAsync(new Person { FirstName = "Carol", LastName = "Davis" }, "people/3");
+            await session.SaveChangesAsync();
+        }
+        WaitForIndexing(Store);
+
+        var response = await _client.GetAsync($"/spark/po/{PersonTypeId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetArrayLength().Should().Be(3);
+        body.Should().Contain("\"id\":\"people/1\"");
+        body.Should().Contain("\"id\":\"people/2\"");
+        body.Should().Contain("\"id\":\"people/3\"");
+    }
+
+    [Fact]
+    public async Task List_resolves_entity_type_by_alias()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = "Alice", LastName = "Smith" }, "people/1");
+            await session.SaveChangesAsync();
+        }
+        WaitForIndexing(Store);
+
+        var response = await _client.GetAsync("/spark/po/person");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Alice");
+    }
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MintPlayer.Spark;
+using MintPlayer.Spark.Abstractions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+
+namespace MintPlayer.Spark.Tests._Infrastructure;
+
+/// <summary>
+/// Boots a minimal in-memory Spark host wired against an externally-provided
+/// <see cref="IDocumentStore"/> (typically supplied by <see cref="MintPlayer.Spark.Testing.SparkTestDriver"/>).
+///
+/// Each instance writes its model JSON files into a per-test temp content root so that
+/// <c>ModelLoader</c> sees only the entity types declared by the test.
+/// Uses TestServer/IHost directly rather than WebApplicationFactory&lt;T&gt; — the latter
+/// requires the host assembly to expose a Main entry point, which the test project doesn't.
+/// </summary>
+public sealed class SparkEndpointFactory : IAsyncDisposable
+{
+    private readonly IHost _host;
+    private readonly string _contentRoot;
+
+    public SparkEndpointFactory(IDocumentStore testStore, EntityTypeFile[] models)
+    {
+        _contentRoot = Path.Combine(Path.GetTempPath(), "spark-endpoint-tests-" + Guid.NewGuid().ToString("N"));
+        var modelDir = Path.Combine(_contentRoot, "App_Data", "Model");
+        Directory.CreateDirectory(modelDir);
+
+        foreach (var model in models)
+        {
+            var path = Path.Combine(modelDir, model.PersistentObject.Name + ".json");
+            File.WriteAllText(path, JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        _host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost
+                    .UseTestServer()
+                    .UseContentRoot(_contentRoot)
+                    .UseEnvironment("Testing")
+                    .ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddSpark(spark => spark.UseContext<TestSparkContext>());
+
+                        var existing = services.Single(d => d.ServiceType == typeof(IDocumentStore));
+                        services.Remove(existing);
+                        services.AddSingleton(testStore);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseSpark();
+                        app.UseEndpoints(endpoints => endpoints.MapSpark());
+                    });
+            })
+            .Build();
+
+        _host.Start();
+    }
+
+    public HttpClient CreateClient() => _host.GetTestClient();
+
+    public T GetService<T>() where T : notnull => _host.Services.GetRequiredService<T>();
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        try
+        {
+            if (Directory.Exists(_contentRoot))
+                Directory.Delete(_contentRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup
+        }
+    }
+}
+
+/// <summary>
+/// Minimal SparkContext for endpoint tests. Tests that need additional collections
+/// can subclass or extend this via a custom fixture.
+/// </summary>
+public sealed class TestSparkContext : SparkContext
+{
+    public IRavenQueryable<Person> People => Session.Query<Person>();
+    public IRavenQueryable<Company> Companies => Session.Query<Company>();
+}
+
+public sealed class Person
+{
+    public string? Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+}
+
+public sealed class Company
+{
+    public string? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary

First HTTP-level integration tests against real Spark middleware + RavenDB. Test count goes 157 → **165** (134 .NET + 31 Angular).

### Tests added (8)

| File | Count | What |
|---|---|---|
| `Endpoints/PersistentObject/GetEndpointTests.cs` | 4 | `GET /spark/po/{type}/{id}` — unknown type → 404; unknown id → 404; alias resolution; happy path returning a mapped PO |
| `Endpoints/PersistentObject/ListEndpointTests.cs` | 4 | `GET /spark/po/{type}` — unknown type → 404; empty array; all seeded docs; alias resolution |

### Infrastructure (`_Infrastructure/SparkEndpointFactory.cs`)

A reusable HTTP host for endpoint tests:
- Boots an in-memory Spark stack via **TestServer + IHost** (NOT `WebApplicationFactory<T>` — that wants a `Main` entry point the test project doesn't have).
- Per-test temp content root with `App_Data/Model/*.json` so `ModelLoader` only sees the entity types the test declared.
- Replaces `AddSpark`'s `IDocumentStore` registration with the externally-supplied `SparkTestDriver` store, so endpoints exercise real RavenDB without ever touching the configured `RavenDb.Urls`.
- Lifecycle: tests inherit `SparkTestDriver` and override `InitializeAsync`/`DisposeAsync` to construct/dispose the factory after `base.InitializeAsync` provisions the store.

### Scoped out for next batch

POST/PUT/DELETE need an XSRF-TOKEN cookie + header (Spark's `UseSpark` wires `UseAntiforgery()`). Two clean approaches: disable antiforgery in the Testing environment, or seed a valid token from `IAntiforgery` before each request. Deferred to keep this slice focused on the read path.

## Test plan

- [x] `dotnet test MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj` → 134/134 pass locally
- [ ] CI `nx affected --target=test` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)