### PR TITLE
test: PersistentObject Create/Update/Delete + antiforgery test client

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/CreateEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/CreateEndpointTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+public class CreateEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("33333333-cccc-cccc-cccc-333333333333");
+
+    private SparkEndpointFactory _factory = null!;
+    private SparkTestClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = await _factory.CreateAuthorizedClientAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private static object NewPersonRequest(string firstName, string lastName) => new
+    {
+        persistentObject = new
+        {
+            name = "Person",
+            objectTypeId = PersonTypeId,
+            attributes = new[]
+            {
+                new { name = "FirstName", value = (object)firstName },
+                new { name = "LastName", value = (object)lastName },
+            }
+        }
+    };
+
+    [Fact]
+    public async Task Create_returns_404_when_entity_type_is_unknown()
+    {
+        var unknownTypeId = Guid.NewGuid();
+
+        var response = await _client.PostJsonAsync($"/spark/po/{unknownTypeId}", NewPersonRequest("Alice", "Smith"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_returns_201_and_persists_a_new_document()
+    {
+        var response = await _client.PostJsonAsync($"/spark/po/{PersonTypeId}", NewPersonRequest("Alice", "Smith"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Alice");
+        body.Should().Contain("Smith");
+
+        // Verify the document made it to RavenDB
+        WaitForIndexing(Store);
+        using var session = Store.OpenAsyncSession();
+        var stored = await session.Query<Person>().ToListAsync();
+        stored.Should().ContainSingle()
+            .Which.FirstName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task Create_resolves_entity_type_by_alias()
+    {
+        var response = await _client.PostJsonAsync("/spark/po/person", NewPersonRequest("Bob", "Jones"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Create_returns_400_when_request_body_fails_validation()
+    {
+        // Required field missing — validation pipeline rejects before persisting
+        var typeWithRequired = TestModels.PersonWithRequiredLastName(Guid.Parse("44444444-cccc-cccc-cccc-444444444444"));
+        await using var factory = new SparkEndpointFactory(Store, [typeWithRequired]);
+        using var client = await factory.CreateAuthorizedClientAsync();
+
+        var response = await client.PostJsonAsync(
+            $"/spark/po/{typeWithRequired.PersistentObject.Id}",
+            new
+            {
+                persistentObject = new
+                {
+                    name = "Person",
+                    objectTypeId = typeWithRequired.PersistentObject.Id,
+                    attributes = new[]
+                    {
+                        new { name = "FirstName", value = (object)"Alice" },
+                        // LastName intentionally missing
+                    },
+                },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/DeleteEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/DeleteEndpointTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+public class DeleteEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("66666666-eeee-eeee-eeee-666666666666");
+
+    private SparkEndpointFactory _factory = null!;
+    private SparkTestClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = await _factory.CreateAuthorizedClientAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Delete_returns_404_when_entity_type_is_unknown()
+    {
+        var unknownTypeId = Guid.NewGuid();
+
+        var response = await _client.DeleteAsync($"/spark/po/{unknownTypeId}/people%2F1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_returns_404_when_id_does_not_exist()
+    {
+        var response = await _client.DeleteAsync($"/spark/po/{PersonTypeId}/people%2Fdoes-not-exist");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_returns_204_and_removes_the_document()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = "Alice", LastName = "Smith" }, "people/1");
+            await session.SaveChangesAsync();
+        }
+
+        var response = await _client.DeleteAsync($"/spark/po/{PersonTypeId}/people%2F1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        WaitForIndexing(Store);
+        using var verify = Store.OpenAsyncSession();
+        var stored = await verify.LoadAsync<Person>("people/1");
+        stored.Should().BeNull();
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/GetEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/GetEndpointTests.cs
@@ -90,4 +90,20 @@ public static class TestModels
             ],
         }
     };
+
+    public static EntityTypeFile PersonWithRequiredLastName(Guid id) => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = id,
+            Name = "Person",
+            ClrType = typeof(Person).FullName!,
+            DisplayAttribute = "LastName",
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string", IsRequired = true },
+            ],
+        }
+    };
 }

--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/UpdateEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/UpdateEndpointTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+public class UpdateEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("55555555-dddd-dddd-dddd-555555555555");
+
+    private SparkEndpointFactory _factory = null!;
+    private SparkTestClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = await _factory.CreateAuthorizedClientAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private static object UpdatePersonRequest(string firstName, string lastName) => new
+    {
+        persistentObject = new
+        {
+            name = "Person",
+            objectTypeId = PersonTypeId,
+            attributes = new[]
+            {
+                new { name = "FirstName", value = (object)firstName },
+                new { name = "LastName", value = (object)lastName },
+            }
+        }
+    };
+
+    [Fact]
+    public async Task Update_returns_404_when_entity_type_is_unknown()
+    {
+        var unknownTypeId = Guid.NewGuid();
+
+        var response = await _client.PutJsonAsync($"/spark/po/{unknownTypeId}/people%2F1", UpdatePersonRequest("A", "B"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Update_returns_404_when_id_does_not_exist()
+    {
+        var response = await _client.PutJsonAsync(
+            $"/spark/po/{PersonTypeId}/people%2Fdoes-not-exist",
+            UpdatePersonRequest("A", "B"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Update_modifies_existing_document_and_returns_200()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = "Alice", LastName = "Smith" }, "people/1");
+            await session.SaveChangesAsync();
+        }
+
+        var response = await _client.PutJsonAsync(
+            $"/spark/po/{PersonTypeId}/people%2F1",
+            UpdatePersonRequest("Alicia", "Smith-Jones"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        WaitForIndexing(Store);
+        using var verify = Store.OpenAsyncSession();
+        var stored = await verify.LoadAsync<Person>("people/1");
+        stored.FirstName.Should().Be("Alicia");
+        stored.LastName.Should().Be("Smith-Jones");
+    }
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
@@ -71,6 +71,48 @@ public sealed class SparkEndpointFactory : IAsyncDisposable
 
     public T GetService<T>() where T : notnull => _host.Services.GetRequiredService<T>();
 
+    /// <summary>
+    /// Performs a warmup GET so Spark's antiforgery middleware writes both the antiforgery
+    /// validation cookie (.AspNetCore.Antiforgery.*) and the readable XSRF-TOKEN cookie.
+    /// Returns the raw <c>Cookie</c> header value (combining both cookies) and the
+    /// X-XSRF-TOKEN request token to attach to mutating requests.
+    /// TestServer's HttpClient does not auto-manage cookies, so callers must thread these
+    /// through explicitly — see <see cref="SparkTestClient"/> for a wrapper that does this.
+    /// </summary>
+    public async Task<(string CookieHeader, string XsrfToken)> MintAntiforgeryAsync()
+    {
+        using var client = CreateClient();
+        var response = await client.GetAsync("/spark/po/__warmup__");
+
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+            throw new InvalidOperationException("Warmup request did not return any Set-Cookie headers.");
+
+        string? antiforgeryCookie = null;
+        string? xsrfToken = null;
+
+        foreach (var raw in setCookies)
+        {
+            var nameValue = raw.Split(';', 2)[0];
+            var eq = nameValue.IndexOf('=');
+            if (eq < 0) continue;
+            var name = nameValue[..eq];
+            var value = nameValue[(eq + 1)..];
+
+            if (name.StartsWith(".AspNetCore.Antiforgery", StringComparison.Ordinal))
+                antiforgeryCookie = nameValue;
+            else if (name == "XSRF-TOKEN")
+            {
+                xsrfToken = Uri.UnescapeDataString(value);
+            }
+        }
+
+        if (antiforgeryCookie is null || xsrfToken is null)
+            throw new InvalidOperationException(
+                $"Warmup did not yield both antiforgery cookies. Got: '{string.Join(" | ", setCookies)}'");
+
+        return (antiforgeryCookie + "; XSRF-TOKEN=" + Uri.EscapeDataString(xsrfToken), xsrfToken);
+    }
+
     public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();

--- a/MintPlayer.Spark.Tests/_Infrastructure/SparkTestClient.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/SparkTestClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Json;
+
+namespace MintPlayer.Spark.Tests._Infrastructure;
+
+/// <summary>
+/// Convenience wrapper around an HttpClient that attaches the cached antiforgery
+/// cookie + X-XSRF-TOKEN header to every mutating request. Get a configured
+/// instance via <see cref="SparkEndpointFactory.CreateAuthorizedClientAsync"/>.
+/// </summary>
+public sealed class SparkTestClient : IDisposable
+{
+    private readonly HttpClient _inner;
+    private readonly string _cookieHeader;
+    private readonly string _xsrfToken;
+
+    internal SparkTestClient(HttpClient inner, string cookieHeader, string xsrfToken)
+    {
+        _inner = inner;
+        _cookieHeader = cookieHeader;
+        _xsrfToken = xsrfToken;
+    }
+
+    public Task<HttpResponseMessage> GetAsync(string url) => _inner.GetAsync(url);
+
+    public Task<HttpResponseMessage> PostJsonAsync<T>(string url, T body) =>
+        SendAsync(HttpMethod.Post, url, JsonContent.Create(body));
+
+    public Task<HttpResponseMessage> PutJsonAsync<T>(string url, T body) =>
+        SendAsync(HttpMethod.Put, url, JsonContent.Create(body));
+
+    public Task<HttpResponseMessage> DeleteAsync(string url) =>
+        SendAsync(HttpMethod.Delete, url, content: null);
+
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, HttpContent? content)
+    {
+        var request = new HttpRequestMessage(method, url) { Content = content };
+        request.Headers.Add("Cookie", _cookieHeader);
+        request.Headers.Add("X-XSRF-TOKEN", _xsrfToken);
+        return await _inner.SendAsync(request);
+    }
+
+    public void Dispose() => _inner.Dispose();
+}
+
+public static class SparkEndpointFactoryExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="SparkTestClient"/> that has already done a warmup GET to mint
+    /// antiforgery tokens and will attach them to every Post/Put/Delete request.
+    /// </summary>
+    public static async Task<SparkTestClient> CreateAuthorizedClientAsync(this SparkEndpointFactory factory)
+    {
+        var (cookieHeader, xsrfToken) = await factory.MintAntiforgeryAsync();
+        return new SparkTestClient(factory.CreateClient(), cookieHeader, xsrfToken);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the PersistentObject endpoint coverage and establishes the antiforgery-token pattern for mutating endpoint tests. Test count goes 165 → **175** (144 .NET + 31 Angular).

### Tests added (10)

| File | Count | What |
|---|---|---|
| `Endpoints/PersistentObject/CreateEndpointTests.cs` | 4 | `POST /spark/po/{type}` — unknown type → 404, persists doc → 201, alias resolution, validation rejects → 400 |
| `Endpoints/PersistentObject/UpdateEndpointTests.cs` | 3 | `PUT /spark/po/{type}/{id}` — unknown type → 404, unknown id → 404, modifies doc → 200 (verified against Raven) |
| `Endpoints/PersistentObject/DeleteEndpointTests.cs` | 3 | `DELETE /spark/po/{type}/{id}` — unknown type → 404, unknown id → 404, deletes doc → 204 (verified against Raven) |

### Antiforgery infrastructure (`_Infrastructure/SparkTestClient.cs`)

- `SparkEndpointFactory.MintAntiforgeryAsync()` does a warmup GET so Spark's antiforgery middleware writes both the `.AspNetCore.Antiforgery.*` validation cookie and the readable `XSRF-TOKEN` cookie. Returns the combined `Cookie` header value + the `X-XSRF-TOKEN` value.
- `SparkTestClient` wraps an `HttpClient` and auto-attaches both on every Post/Put/Delete. Test boilerplate becomes `_client = await _factory.CreateAuthorizedClientAsync()`.
- This mirrors what `@mintplayer/ng-spark-auth`'s `HttpClient` does in production: pick up XSRF-TOKEN from cookies, attach as header.

### Note on antiforgery enforcement

The negative case "POST without token → rejected" was attempted but observed to return 201 instead of 400 — `RequireAntiforgeryTokenAttribute` metadata doesn't appear to be picked up on minimal-API endpoints in this test configuration (or JSON requests bypass the middleware's form-centric validation). The token-mint pattern is provided as canonical anyway. Worth a separate investigation if antiforgery enforcement is intended to be a hard contract.

## Test plan

- [x] `dotnet test` → 144/144 pass locally
- [ ] CI `nx affected --target=test` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)