### PR TITLE
test: ng-spark — wire analog plugin + cover all 22 pipes

### DIFF
--- a/node_packages/ng-spark/pipes/src/di-pipes.spec.ts
+++ b/node_packages/ng-spark/pipes/src/di-pipes.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { TranslateKeyPipe } from './translate-key.pipe';
+import { ResolveTranslationPipe } from './resolve-translation.pipe';
+import { AsDetailDisplayValuePipe } from './as-detail-display-value.pipe';
+import { ReferenceDisplayValuePipe } from './reference-display-value.pipe';
+import { SparkLanguageService } from '@mintplayer/ng-spark/services';
+
+class FakeLanguageService {
+  t(key: string): string {
+    const map: Record<string, string> = {
+      notSet: '(not set)',
+      notSelected: '(not selected)',
+      clickToEdit: '(click to edit)',
+      hello: 'Hello',
+    };
+    return map[key] ?? key;
+  }
+}
+
+function createPipe<T>(pipeType: new (...args: any[]) => T): T {
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: SparkLanguageService, useClass: FakeLanguageService },
+      pipeType as any,
+    ],
+  });
+  return TestBed.inject(pipeType as any) as T;
+}
+
+describe('TranslateKeyPipe', () => {
+  it('returns the translated string for the given key', () => {
+    const pipe = createPipe(TranslateKeyPipe);
+    expect(pipe.transform('hello')).toBe('Hello');
+  });
+
+  it('falls back to the key itself when not found', () => {
+    const pipe = createPipe(TranslateKeyPipe);
+    expect(pipe.transform('unknown.key')).toBe('unknown.key');
+  });
+});
+
+// ResolveTranslationPipe is pure (no DI), but kept here next to its language-aware sibling for symmetry
+describe('ResolveTranslationPipe (DI-free smoke)', () => {
+  it('resolves nested translations directly', () => {
+    const pipe = new ResolveTranslationPipe();
+    expect(pipe.transform({ en: 'Hello' } as any)).toBe('Hello');
+  });
+});
+
+describe('AsDetailDisplayValuePipe', () => {
+  it('returns the (not set) translation when value is missing', () => {
+    const pipe = createPipe(AsDetailDisplayValuePipe);
+    const attr = { name: 'addr' } as any;
+    expect(pipe.transform(attr, {}, {})).toBe('(not set)');
+  });
+
+  it('formats via displayFormat template when type defines one', () => {
+    const pipe = createPipe(AsDetailDisplayValuePipe);
+    const attr = { name: 'addr' } as any;
+    const types = { addr: { displayFormat: '{Street}, {City}' } } as any;
+    const formData = { addr: { Street: 'Main', City: 'Brussels' } };
+    expect(pipe.transform(attr, formData, types)).toBe('Main, Brussels');
+  });
+
+  it('uses displayAttribute when no displayFormat', () => {
+    const pipe = createPipe(AsDetailDisplayValuePipe);
+    const attr = { name: 'addr' } as any;
+    const types = { addr: { displayAttribute: 'City' } } as any;
+    expect(pipe.transform(attr, { addr: { City: 'Brussels' } }, types)).toBe('Brussels');
+  });
+
+  it('falls back to common property names (Name)', () => {
+    const pipe = createPipe(AsDetailDisplayValuePipe);
+    const attr = { name: 'addr' } as any;
+    expect(pipe.transform(attr, { addr: { Name: 'Acme' } }, {})).toBe('Acme');
+  });
+
+  it('falls back to (click to edit) translation when nothing matches', () => {
+    const pipe = createPipe(AsDetailDisplayValuePipe);
+    const attr = { name: 'addr' } as any;
+    expect(pipe.transform(attr, { addr: { Unknown: 'x' } }, {})).toBe('(click to edit)');
+  });
+});
+
+describe('ReferenceDisplayValuePipe', () => {
+  it('returns the (not selected) translation when no id is selected', () => {
+    const pipe = createPipe(ReferenceDisplayValuePipe);
+    expect(pipe.transform({ name: 'Owner' } as any, {}, {})).toBe('(not selected)');
+  });
+
+  it('returns the breadcrumb of the matching option', () => {
+    const pipe = createPipe(ReferenceDisplayValuePipe);
+    const opts = { Owner: [{ id: 'p/1', breadcrumb: 'Alice', name: 'p1' } as any] };
+    expect(pipe.transform({ name: 'Owner' } as any, { Owner: 'p/1' }, opts)).toBe('Alice');
+  });
+
+  it('falls back to name when no breadcrumb', () => {
+    const pipe = createPipe(ReferenceDisplayValuePipe);
+    const opts = { Owner: [{ id: 'p/1', name: 'Alice' } as any] };
+    expect(pipe.transform({ name: 'Owner' } as any, { Owner: 'p/1' }, opts)).toBe('Alice');
+  });
+
+  it('returns the raw id when no matching option', () => {
+    const pipe = createPipe(ReferenceDisplayValuePipe);
+    expect(pipe.transform({ name: 'Owner' } as any, { Owner: 'p/missing' }, { Owner: [] })).toBe('p/missing');
+  });
+});

--- a/node_packages/ng-spark/pipes/src/pure-pipes.spec.ts
+++ b/node_packages/ng-spark/pipes/src/pure-pipes.spec.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from 'vitest';
+import { ArrayValuePipe } from './array-value.pipe';
+import { AsDetailCellValuePipe } from './as-detail-cell-value.pipe';
+import { AsDetailColumnsPipe } from './as-detail-columns.pipe';
+import { AsDetailTypePipe } from './as-detail-type.pipe';
+import { AttributeValuePipe } from './attribute-value.pipe';
+import { CanCreateDetailRowPipe } from './can-create-detail-row.pipe';
+import { CanDeleteDetailRowPipe } from './can-delete-detail-row.pipe';
+import { ErrorForAttributePipe } from './error-for-attribute.pipe';
+import { InlineRefOptionsPipe } from './inline-ref-options.pipe';
+import { InputTypePipe } from './input-type.pipe';
+import { LookupDisplayTypePipe } from './lookup-display-type.pipe';
+import { LookupDisplayValuePipe } from './lookup-display-value.pipe';
+import { LookupOptionsPipe } from './lookup-options.pipe';
+import { RawAttributeValuePipe } from './raw-attribute-value.pipe';
+import { ReferenceAttrValuePipe } from './reference-attr-value.pipe';
+import { ReferenceLinkRoutePipe } from './reference-link-route.pipe';
+import { ResolveTranslationPipe } from './resolve-translation.pipe';
+import { RouterLinkPipe } from './router-link.pipe';
+import { ELookupDisplayType } from '@mintplayer/ng-spark/models';
+
+// ---------------------------------------------------------------------------
+// arrayValue
+// ---------------------------------------------------------------------------
+describe('ArrayValuePipe', () => {
+  const pipe = new ArrayValuePipe();
+
+  it('returns the array value of an attribute', () => {
+    const item = { attributes: [{ name: 'rows', value: [{ a: 1 }, { a: 2 }] }] } as any;
+    expect(pipe.transform('rows', item)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it('returns empty array when attribute missing', () => {
+    expect(pipe.transform('rows', { attributes: [] } as any)).toEqual([]);
+  });
+
+  it('returns empty array when value is not an array', () => {
+    const item = { attributes: [{ name: 'rows', value: 'not-array' }] } as any;
+    expect(pipe.transform('rows', item)).toEqual([]);
+  });
+
+  it('returns empty array when item is null', () => {
+    expect(pipe.transform('rows', null)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asDetailCellValue
+// ---------------------------------------------------------------------------
+describe('AsDetailCellValuePipe', () => {
+  const pipe = new AsDetailCellValuePipe();
+
+  it('returns empty string for null cell value', () => {
+    expect(pipe.transform({ City: null }, { name: 'addr' } as any, { name: 'City', dataType: 'string' } as any, {})).toBe('');
+  });
+
+  it('returns the raw value for non-reference cells', () => {
+    expect(pipe.transform({ City: 'Brussels' }, { name: 'addr' } as any, { name: 'City', dataType: 'string' } as any, {})).toBe('Brussels');
+  });
+
+  it('resolves Reference value via asDetailRefOptions breadcrumb', () => {
+    const refOptions = { addr: { Country: [{ id: 'BE', breadcrumb: 'Belgium', name: 'BE' } as any] } };
+    const result = pipe.transform(
+      { Country: 'BE' },
+      { name: 'addr' } as any,
+      { name: 'Country', dataType: 'Reference', query: 'countries' } as any,
+      refOptions);
+    expect(result).toBe('Belgium');
+  });
+
+  it('falls back to raw value when reference id not found in options', () => {
+    const result = pipe.transform(
+      { Country: 'XX' },
+      { name: 'addr' } as any,
+      { name: 'Country', dataType: 'Reference', query: 'countries' } as any,
+      { addr: { Country: [] } });
+    expect(result).toBe('XX');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asDetailColumns
+// ---------------------------------------------------------------------------
+describe('AsDetailColumnsPipe', () => {
+  const pipe = new AsDetailColumnsPipe();
+
+  it('returns visible attributes sorted by order', () => {
+    const types = {
+      addr: {
+        attributes: [
+          { name: 'City', isVisible: true, order: 2 },
+          { name: 'Hidden', isVisible: false, order: 1 },
+          { name: 'Street', isVisible: true, order: 1 },
+        ],
+      },
+    } as any;
+    const result = pipe.transform({ name: 'addr' } as any, types);
+    expect(result.map(c => c.name)).toEqual(['Street', 'City']);
+  });
+
+  it('returns empty when type not found', () => {
+    expect(pipe.transform({ name: 'addr' } as any, {})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asDetailType
+// ---------------------------------------------------------------------------
+describe('AsDetailTypePipe', () => {
+  const pipe = new AsDetailTypePipe();
+
+  it('returns the matching type', () => {
+    const type = { id: '1', name: 'Address' } as any;
+    expect(pipe.transform({ name: 'addr' } as any, { addr: type })).toBe(type);
+  });
+
+  it('returns null when not found', () => {
+    expect(pipe.transform({ name: 'addr' } as any, {})).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attributeValue (covers most decision branches; complex pipe)
+// ---------------------------------------------------------------------------
+describe('AttributeValuePipe', () => {
+  const pipe = new AttributeValuePipe();
+
+  it('returns empty string when item is null', () => {
+    expect(pipe.transform('Name', null, null, {}, [])).toBe('');
+  });
+
+  it('returns breadcrumb when present', () => {
+    const item = { attributes: [{ name: 'Owner', value: 'people/1', breadcrumb: 'Alice' }] } as any;
+    expect(pipe.transform('Owner', item, null, {}, [])).toBe('Alice');
+  });
+
+  it('formats AsDetail array as count summary (plural)', () => {
+    const item = { attributes: [{ name: 'Jobs', value: [{}, {}, {}] }] } as any;
+    const entityType = { attributes: [{ name: 'Jobs', dataType: 'AsDetail' }] } as any;
+    expect(pipe.transform('Jobs', item, entityType, {}, [])).toBe('3 items');
+  });
+
+  it('formats AsDetail array singular', () => {
+    const item = { attributes: [{ name: 'Jobs', value: [{}] }] } as any;
+    const entityType = { attributes: [{ name: 'Jobs', dataType: 'AsDetail' }] } as any;
+    expect(pipe.transform('Jobs', item, entityType, {}, [])).toBe('1 item');
+  });
+
+  it('resolves lookup reference value via translation', () => {
+    const item = { attributes: [{ name: 'Status', value: 'active' }] } as any;
+    const entityType = { attributes: [{ name: 'Status', lookupReferenceType: 'StatusRef' }] } as any;
+    const lookupRefOptions = {
+      StatusRef: { values: [{ key: 'active', values: { en: 'Active', fr: 'Actif' } }] },
+    } as any;
+    expect(pipe.transform('Status', item, entityType, lookupRefOptions, [])).toBe('Active');
+  });
+
+  it('returns raw value as fallback', () => {
+    const item = { attributes: [{ name: 'Name', value: 'Acme' }] } as any;
+    expect(pipe.transform('Name', item, null, {}, [])).toBe('Acme');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canCreateDetailRow / canDeleteDetailRow
+// ---------------------------------------------------------------------------
+describe('CanCreateDetailRowPipe', () => {
+  const pipe = new CanCreateDetailRowPipe();
+  it('returns the canCreate permission', () => {
+    expect(pipe.transform({ name: 'rows' } as any, { rows: { canCreate: false } as any })).toBe(false);
+  });
+  it('defaults to true when no permission entry exists', () => {
+    expect(pipe.transform({ name: 'rows' } as any, {})).toBe(true);
+  });
+});
+
+describe('CanDeleteDetailRowPipe', () => {
+  const pipe = new CanDeleteDetailRowPipe();
+  it('returns the canDelete permission', () => {
+    expect(pipe.transform({ name: 'rows' } as any, { rows: { canDelete: true } as any })).toBe(true);
+  });
+  it('defaults to true when no permission entry exists', () => {
+    expect(pipe.transform({ name: 'rows' } as any, {})).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// errorForAttribute
+// ---------------------------------------------------------------------------
+describe('ErrorForAttributePipe', () => {
+  const pipe = new ErrorForAttributePipe();
+  it('returns the resolved error message for the attribute', () => {
+    const errors = [{ attributeName: 'Email', errorMessage: { en: 'Invalid email' } } as any];
+    expect(pipe.transform('Email', errors)).toBe('Invalid email');
+  });
+  it('returns null when no error matches', () => {
+    expect(pipe.transform('Email', [])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inlineRefOptions
+// ---------------------------------------------------------------------------
+describe('InlineRefOptionsPipe', () => {
+  const pipe = new InlineRefOptionsPipe();
+  it('returns the nested option list', () => {
+    const opts = { addr: { Country: [{ id: '1' } as any] } };
+    expect(pipe.transform({ name: 'addr' } as any, { name: 'Country' } as any, opts)).toEqual([{ id: '1' }]);
+  });
+  it('returns empty when no entry', () => {
+    expect(pipe.transform({ name: 'addr' } as any, { name: 'Country' } as any, {})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inputType
+// ---------------------------------------------------------------------------
+describe('InputTypePipe', () => {
+  const pipe = new InputTypePipe();
+  it.each([
+    ['number', 'number'],
+    ['decimal', 'number'],
+    ['boolean', 'checkbox'],
+    ['datetime', 'datetime-local'],
+    ['date', 'date'],
+    ['color', 'color'],
+    ['string', 'text'],
+    ['unknown-type', 'text'],
+  ])('maps %s → %s', (input, expected) => {
+    expect(pipe.transform(input)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lookupDisplayType
+// ---------------------------------------------------------------------------
+describe('LookupDisplayTypePipe', () => {
+  const pipe = new LookupDisplayTypePipe();
+  it('returns the lookup ref displayType', () => {
+    const opts = { StatusRef: { displayType: ELookupDisplayType.Modal } } as any;
+    expect(pipe.transform({ lookupReferenceType: 'StatusRef' } as any, opts)).toBe(ELookupDisplayType.Modal);
+  });
+  it('defaults to Dropdown when no lookupReferenceType', () => {
+    expect(pipe.transform({} as any, {})).toBe(ELookupDisplayType.Dropdown);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lookupDisplayValue
+// ---------------------------------------------------------------------------
+describe('LookupDisplayValuePipe', () => {
+  const pipe = new LookupDisplayValuePipe();
+  it('returns the resolved translation for the selected key', () => {
+    const opts = {
+      StatusRef: { values: [{ key: 'active', isActive: true, values: { en: 'Active' } }] },
+    } as any;
+    expect(pipe.transform({ name: 'Status', lookupReferenceType: 'StatusRef' } as any, { Status: 'active' }, opts)).toBe('Active');
+  });
+  it('returns empty string when value is missing', () => {
+    expect(pipe.transform({ name: 'Status' } as any, {}, {})).toBe('');
+  });
+  it('returns the raw key when selection not found in options', () => {
+    expect(pipe.transform({ name: 'Status', lookupReferenceType: 'X' } as any, { Status: 'foo' }, { X: { values: [] } } as any)).toBe('foo');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lookupOptions
+// ---------------------------------------------------------------------------
+describe('LookupOptionsPipe', () => {
+  const pipe = new LookupOptionsPipe();
+  it('returns active values', () => {
+    const opts = {
+      StatusRef: {
+        values: [
+          { key: 'a', isActive: true },
+          { key: 'b', isActive: false },
+          { key: 'c', isActive: true },
+        ],
+      },
+    } as any;
+    const result = pipe.transform({ lookupReferenceType: 'StatusRef' } as any, opts);
+    expect(result.map(v => v.key)).toEqual(['a', 'c']);
+  });
+
+  it('returns empty when no lookupReferenceType', () => {
+    expect(pipe.transform({} as any, {})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rawAttributeValue
+// ---------------------------------------------------------------------------
+describe('RawAttributeValuePipe', () => {
+  const pipe = new RawAttributeValuePipe();
+  it('returns the raw value', () => {
+    const item = { attributes: [{ name: 'X', value: 42 }] } as any;
+    expect(pipe.transform('X', item)).toBe(42);
+  });
+  it('returns undefined when not found', () => {
+    expect(pipe.transform('X', { attributes: [] } as any)).toBeUndefined();
+  });
+  it('handles null item', () => {
+    expect(pipe.transform('X', null)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// referenceAttrValue
+// ---------------------------------------------------------------------------
+describe('ReferenceAttrValuePipe', () => {
+  const pipe = new ReferenceAttrValuePipe();
+  it('prefers breadcrumb over raw value', () => {
+    const item = { attributes: [{ name: 'Owner', value: 'p/1', breadcrumb: 'Alice' }] } as any;
+    expect(pipe.transform(item, 'Owner')).toBe('Alice');
+  });
+  it('falls back to raw value when breadcrumb absent', () => {
+    const item = { attributes: [{ name: 'Owner', value: 'p/1' }] } as any;
+    expect(pipe.transform(item, 'Owner')).toBe('p/1');
+  });
+  it('returns empty when attribute missing', () => {
+    expect(pipe.transform({ attributes: [] } as any, 'Owner')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// referenceLinkRoute
+// ---------------------------------------------------------------------------
+describe('ReferenceLinkRoutePipe', () => {
+  const pipe = new ReferenceLinkRoutePipe();
+  it('builds /po/{alias}/{id} route', () => {
+    const types = [{ id: 't1', clrType: 'TestApp.Person', alias: 'person' }] as any;
+    expect(pipe.transform('TestApp.Person', 'people/1', types)).toEqual(['/po', 'person', 'people/1']);
+  });
+  it('falls back to id when alias missing', () => {
+    const types = [{ id: 't1', clrType: 'TestApp.Person' }] as any;
+    expect(pipe.transform('TestApp.Person', 'people/1', types)).toEqual(['/po', 't1', 'people/1']);
+  });
+  it('returns null when target type not found', () => {
+    expect(pipe.transform('Unknown', 'p/1', [])).toBeNull();
+  });
+  it('returns null when referenceId is empty', () => {
+    expect(pipe.transform('TestApp.Person', null, [])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTranslation
+// ---------------------------------------------------------------------------
+describe('ResolveTranslationPipe', () => {
+  const pipe = new ResolveTranslationPipe();
+  it('resolves a TranslatedString', () => {
+    expect(pipe.transform({ en: 'Hello' } as any)).toBe('Hello');
+  });
+  it('returns the fallback when value is undefined', () => {
+    expect(pipe.transform(undefined, 'fallback')).toBe('fallback');
+  });
+  it('returns empty string when no value and no fallback', () => {
+    expect(pipe.transform(undefined)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routerLink
+// ---------------------------------------------------------------------------
+describe('RouterLinkPipe', () => {
+  const pipe = new RouterLinkPipe();
+  it('builds /query/{alias} for query units', () => {
+    expect(pipe.transform({ type: 'query', alias: 'cars' } as any)).toEqual(['/query', 'cars']);
+  });
+  it('builds /po/{alias} for persistentObject units', () => {
+    expect(pipe.transform({ type: 'persistentObject', alias: 'person' } as any)).toEqual(['/po', 'person']);
+  });
+  it('falls back to /query/{queryId} when alias missing', () => {
+    expect(pipe.transform({ type: 'query', queryId: 'q-uuid' } as any)).toEqual(['/query', 'q-uuid']);
+  });
+  it('returns / for unknown type', () => {
+    expect(pipe.transform({ type: 'unknown' } as any)).toEqual(['/']);
+  });
+});

--- a/node_packages/ng-spark/src/test-setup.ts
+++ b/node_packages/ng-spark/src/test-setup.ts
@@ -1,0 +1,3 @@
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: true });

--- a/node_packages/ng-spark/vitest.config.ts
+++ b/node_packages/ng-spark/vitest.config.ts
@@ -1,9 +1,24 @@
+import angular from '@analogjs/vite-plugin-angular';
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  plugins: [angular()],
+  resolve: {
+    alias: [
+      // Mirror tsconfig.base.json paths so source files can use the package-style imports
+      // they ship with (e.g. `@mintplayer/ng-spark/services`).
+      { find: /^@mintplayer\/ng-spark\/(.+)$/, replacement: path.join(root, '$1', 'index.ts') },
+      { find: '@mintplayer/ng-spark', replacement: path.join(root, 'src/public-api.ts') },
+    ],
+  },
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
     include: ['**/*.spec.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/out-tsc/**'],
   },


### PR DESCRIPTION
## Summary

Mirrors the analog plugin setup from \`ng-spark-auth\` into \`ng-spark\` and mass-covers the pipe surface. **+70 new tests; ng-spark goes from 5 → 75/75 green. Total monorepo 245 tests** (144 .NET + 31 ng-spark-auth + 75 ng-spark).

### Tests added (70)

| File | Count | What |
|---|---|---|
| \`pipes/src/pure-pipes.spec.ts\` | 58 | All 18 DI-free pipes — happy paths + nulls/missing keys/fallbacks; \`inputType\` covered with \`it.each\` for the 8-way data-type → input-type mapping |
| \`pipes/src/di-pipes.spec.ts\` | 12 | The 3 pipes that \`inject(SparkLanguageService)\` — TestBed-wired with a \`FakeLanguageService\` |

### Infrastructure

- \`node_packages/ng-spark/vitest.config.ts\` — adds \`@analogjs/vite-plugin-angular\` and a \`resolve.alias\` mirror of \`tsconfig.base.json\` so the source files keep using their package-style imports (e.g. \`@mintplayer/ng-spark/services\`) at test time without needing a built \`dist/\`.
- \`node_packages/ng-spark/src/test-setup.ts\` — \`setupTestBed({ zoneless: true })\`, identical to \`ng-spark-auth\`.

The existing \`IconNamePipe\` spec (5 tests) is untouched and continues to pass.

### Pattern

Pure pipes are tested with \`new PipeName()\` and plain Vitest. DI-needing pipes use a small helper:

\`\`\`ts
function createPipe<T>(pipeType: new () => T): T {
  TestBed.configureTestingModule({
    providers: [{ provide: SparkLanguageService, useClass: FakeLanguageService }, pipeType],
  });
  return TestBed.inject(pipeType);
}
\`\`\`

Same approach will work for component tests once those start landing.

## Test plan

- [x] \`npx vitest run\` in \`node_packages/ng-spark/\` → 75/75 pass
- [x] \`nx run-many --target=test --projects=@mintplayer/ng-spark,@mintplayer/ng-spark-auth,MintPlayer.Spark.Tests\` → all green (245 total)
- [ ] CI \`nx affected --target=test\` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)