### PR TITLE
test: Query endpoints — Get, List, Execute

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/Queries/ExecuteQueryEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Queries/ExecuteQueryEndpointTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+using TestModels = MintPlayer.Spark.Tests.Endpoints.PersistentObject.TestModels;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Queries;
+
+public class ExecuteQueryEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("aaaa3333-3333-3333-3333-aaaaaaaaaaaa");
+    private static readonly Guid AllPeopleQueryId = Guid.Parse("bbbb3333-3333-3333-3333-bbbbbbbbbbbb");
+
+    private SparkEndpointFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var personType = TestModels.Person(PersonTypeId);
+        personType.Queries =
+        [
+            new SparkQuery
+            {
+                Id = AllPeopleQueryId,
+                Name = "AllPeople",
+                Source = "Database.People",
+            },
+        ];
+
+        _factory = new SparkEndpointFactory(Store, [personType]);
+        _client = _factory.CreateClient();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task SeedAsync(params (string id, string first, string last)[] people)
+    {
+        using var session = Store.OpenAsyncSession();
+        foreach (var (id, first, last) in people)
+            await session.StoreAsync(new Person { FirstName = first, LastName = last }, id);
+        await session.SaveChangesAsync();
+        WaitForIndexing(Store);
+    }
+
+    [Fact]
+    public async Task Execute_returns_404_when_query_unknown()
+    {
+        var response = await _client.GetAsync($"/spark/queries/{Guid.NewGuid()}/execute");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Execute_returns_seeded_results()
+    {
+        await SeedAsync(
+            ("people/1", "Alice", "Smith"),
+            ("people/2", "Bob", "Jones"));
+
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}/execute");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetProperty("totalRecords").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Execute_returns_empty_envelope_with_no_data()
+    {
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}/execute");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetProperty("totalRecords").GetInt32().Should().Be(0);
+        parsed.RootElement.GetProperty("data").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Execute_applies_search_filter_case_insensitively()
+    {
+        await SeedAsync(
+            ("people/1", "Alice", "Smith"),
+            ("people/2", "Bob", "Jones"),
+            ("people/3", "Carol", "Davis"));
+
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}/execute?search=ALICE");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetProperty("totalRecords").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Execute_honors_skip_and_take_query_parameters()
+    {
+        await SeedAsync(
+            Enumerable.Range(1, 10)
+                .Select(i => ($"people/{i}", $"First{i}", $"Last{i}"))
+                .ToArray());
+
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}/execute?skip=3&take=4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetProperty("totalRecords").GetInt32().Should().Be(10);
+        parsed.RootElement.GetProperty("skip").GetInt32().Should().Be(3);
+        parsed.RootElement.GetProperty("take").GetInt32().Should().Be(4);
+        parsed.RootElement.GetProperty("data").GetArrayLength().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Execute_falls_back_to_default_pagination_when_params_missing()
+    {
+        await SeedAsync(("people/1", "A", "B"));
+
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}/execute");
+
+        var parsed = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        parsed.RootElement.GetProperty("skip").GetInt32().Should().Be(0);
+        parsed.RootElement.GetProperty("take").GetInt32().Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Execute_resolves_query_by_alias()
+    {
+        await SeedAsync(("people/1", "Alice", "Smith"));
+
+        var response = await _client.GetAsync("/spark/queries/allpeople/execute");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Queries/GetQueryEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Queries/GetQueryEndpointTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using TestModels = MintPlayer.Spark.Tests.Endpoints.PersistentObject.TestModels;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Queries;
+
+public class GetQueryEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("aaaa1111-1111-1111-1111-aaaaaaaaaaaa");
+    private static readonly Guid AllPeopleQueryId = Guid.Parse("bbbb1111-1111-1111-1111-bbbbbbbbbbbb");
+
+    private SparkEndpointFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var personType = TestModels.Person(PersonTypeId);
+        personType.Queries =
+        [
+            new SparkQuery
+            {
+                Id = AllPeopleQueryId,
+                Name = "AllPeople",
+                Source = "Database.People",
+            },
+        ];
+
+        _factory = new SparkEndpointFactory(Store, [personType]);
+        _client = _factory.CreateClient();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Get_returns_404_when_query_id_unknown()
+    {
+        var response = await _client.GetAsync($"/spark/queries/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_returns_query_definition_by_GUID()
+    {
+        var response = await _client.GetAsync($"/spark/queries/{AllPeopleQueryId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"name\":\"AllPeople\"");
+        body.Should().Contain("\"source\":\"Database.People\"");
+    }
+
+    [Fact]
+    public async Task Get_resolves_query_by_alias()
+    {
+        // Auto-generated alias: "GetX" → "x"; for "AllPeople" the alias is "allpeople"
+        var response = await _client.GetAsync("/spark/queries/allpeople");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"name\":\"AllPeople\"");
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Queries/ListQueriesEndpointTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Queries/ListQueriesEndpointTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using TestModels = MintPlayer.Spark.Tests.Endpoints.PersistentObject.TestModels;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Queries;
+
+public class ListQueriesEndpointTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("aaaa2222-2222-2222-2222-aaaaaaaaaaaa");
+    private static readonly Guid AllPeopleQueryId = Guid.Parse("bbbb2222-2222-2222-2222-bbbbbbbbbbbb");
+    private static readonly Guid OnlyAdminsQueryId = Guid.Parse("cccc2222-2222-2222-2222-cccccccccccc");
+
+    [Fact]
+    public async Task List_returns_empty_when_no_queries_defined()
+    {
+        var personType = TestModels.Person(Guid.NewGuid()); // no Queries
+        await using var factory = new SparkEndpointFactory(Store, [personType]);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/spark/queries");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task List_returns_all_queries_across_all_entity_types()
+    {
+        var personType = TestModels.Person(PersonTypeId);
+        personType.Queries =
+        [
+            new SparkQuery { Id = AllPeopleQueryId, Name = "AllPeople", Source = "Database.People" },
+            new SparkQuery { Id = OnlyAdminsQueryId, Name = "OnlyAdmins", Source = "Custom.GetAdmins", EntityType = "Person" },
+        ];
+
+        await using var factory = new SparkEndpointFactory(Store, [personType]);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/spark/queries");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var parsed = JsonDocument.Parse(body);
+        parsed.RootElement.GetArrayLength().Should().Be(2);
+        body.Should().Contain("AllPeople");
+        body.Should().Contain("OnlyAdmins");
+    }
+}


### PR DESCRIPTION
## Summary

+12 endpoint integration tests for `/spark/queries/*`. Total monorepo **257 tests** (156 .NET + 31 ng-spark-auth + 75 ng-spark — was 245).

### Tests added

| File | Count | What |
|---|---|---|
| `Endpoints/Queries/GetQueryEndpointTests.cs` | 3 | `GET /spark/queries/{id}` — unknown → 404, found by GUID, resolves by alias |
| `Endpoints/Queries/ListQueriesEndpointTests.cs` | 2 | `GET /spark/queries` — empty array when no queries; returns all queries across all entity types |
| `Endpoints/Queries/ExecuteQueryEndpointTests.cs` | 7 | `GET /spark/queries/{id}/execute` — unknown → 404, returns seeded results, empty envelope, case-insensitive `search`, `skip`+`take`, default pagination, alias resolution |

All built on the existing `SparkEndpointFactory` + `SparkTestDriver` infra. Queries are declared by adding a `Queries` array to the `EntityTypeFile` JSON the factory writes — same pipeline used by production demo apps.

### Scoped out

- **`StreamExecuteQuery`** (WebSocket via `/spark/queries/{id}/stream`). TestServer does support WebSockets via `Server.CreateWebSocketClient()` but the diff-engine + IAsyncEnumerable + cancellation interplay deserves a focused batch. Tracked.

## Test plan

- [x] `dotnet test` → 156/156 .NET pass locally
- [ ] CI `nx affected --target=test` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)