### PR TITLE
test: ng-spark — RetryActionService, IconRegistry, IconComponent, RetryActionModal

### DIFF
--- a/node_packages/ng-spark/icon/src/spark-icon.component.spec.ts
+++ b/node_packages/ng-spark/icon/src/spark-icon.component.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { SparkIconComponent } from './spark-icon.component';
+import { SparkIconRegistry } from '@mintplayer/ng-spark/services';
+
+describe('SparkIconComponent', () => {
+  let registry: SparkIconRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [SparkIconComponent] });
+    registry = TestBed.inject(SparkIconRegistry);
+  });
+
+  it('renders the SVG span when the icon is registered', () => {
+    registry.register('test-svg', '<svg data-test="ok"><circle /></svg>');
+
+    const fixture = TestBed.createComponent(SparkIconComponent);
+    fixture.componentRef.setInput('name', 'test-svg');
+    fixture.detectChanges();
+
+    const span = fixture.nativeElement.querySelector('span') as HTMLElement | null;
+    expect(span).not.toBeNull();
+    expect(span!.innerHTML).toContain('<svg');
+  });
+
+  it('falls back to <i class="bi bi-{name}"> when the icon is not registered', () => {
+    const fixture = TestBed.createComponent(SparkIconComponent);
+    fixture.componentRef.setInput('name', 'definitely-unregistered');
+    fixture.detectChanges();
+
+    const i = fixture.nativeElement.querySelector('i') as HTMLElement | null;
+    expect(i).not.toBeNull();
+    expect(i!.className).toContain('bi');
+    expect(i!.className).toContain('bi-definitely-unregistered');
+
+    const span = fixture.nativeElement.querySelector('span') as HTMLElement | null;
+    expect(span).toBeNull();
+  });
+
+  it('switches between registered and fallback when input changes', () => {
+    registry.register('icon-a', '<svg id="a" />');
+
+    const fixture = TestBed.createComponent(SparkIconComponent);
+    fixture.componentRef.setInput('name', 'icon-a');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('span')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('i')).toBeNull();
+
+    fixture.componentRef.setInput('name', 'unregistered');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('span')).toBeNull();
+    expect(fixture.nativeElement.querySelector('i')).not.toBeNull();
+  });
+});

--- a/node_packages/ng-spark/retry-action-modal/src/spark-retry-action-modal.component.spec.ts
+++ b/node_packages/ng-spark/retry-action-modal/src/spark-retry-action-modal.component.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { SparkRetryActionModalComponent } from './spark-retry-action-modal.component';
+import { RetryActionService } from '@mintplayer/ng-spark/services';
+import { RetryActionPayload } from '@mintplayer/ng-spark/models';
+
+const samplePayload: RetryActionPayload = {
+  step: 'confirm-overwrite',
+  title: 'Overwrite the existing record?',
+  message: 'This will replace the current values.',
+  options: ['Overwrite', 'Cancel'],
+  defaultOption: 'Cancel',
+  persistentObject: { id: 'p/1', name: 'Person', objectTypeId: 't/1', attributes: [] } as any,
+};
+
+describe('SparkRetryActionModalComponent', () => {
+  let service: RetryActionService;
+  let component: SparkRetryActionModalComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [SparkRetryActionModalComponent] });
+    service = TestBed.inject(RetryActionService);
+    const fixture = TestBed.createComponent(SparkRetryActionModalComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('isOpen() is false when no payload is set', () => {
+    expect(component.isOpen()).toBe(false);
+  });
+
+  it('isOpen() becomes true once the service publishes a payload', () => {
+    service.show(samplePayload);
+
+    expect(component.isOpen()).toBe(true);
+  });
+
+  it('onOption() forwards the choice to RetryActionService and clears the payload', async () => {
+    const promise = service.show(samplePayload);
+
+    component.onOption('Overwrite');
+
+    const result = await promise;
+    expect(result.option).toBe('Overwrite');
+    expect(result.step).toBe('confirm-overwrite');
+    expect(service.payload()).toBeNull();
+  });
+
+  it('onOption() does nothing when no payload is active (no throw, no resolution)', () => {
+    expect(() => component.onOption('Cancel')).not.toThrow();
+  });
+});

--- a/node_packages/ng-spark/services/src/retry-action.service.spec.ts
+++ b/node_packages/ng-spark/services/src/retry-action.service.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { RetryActionService } from './retry-action.service';
+import { RetryActionPayload } from '@mintplayer/ng-spark/models';
+
+const payload: RetryActionPayload = {
+  step: 'confirm-overwrite',
+  title: 'Overwrite?',
+  message: 'A newer version exists.',
+  options: ['Overwrite', 'Cancel'],
+  defaultOption: 'Cancel',
+  persistentObject: { id: 'p/1', name: 'Person', objectTypeId: 't/1', attributes: [] } as any,
+};
+
+describe('RetryActionService', () => {
+  it('payload signal starts as null', () => {
+    const service = new RetryActionService();
+    expect(service.payload()).toBeNull();
+  });
+
+  it('show() sets the payload signal and returns a pending promise', () => {
+    const service = new RetryActionService();
+
+    const promise = service.show(payload);
+
+    expect(service.payload()).toBe(payload);
+    expect(promise).toBeInstanceOf(Promise);
+  });
+
+  it('respond() resolves the show() promise with the result and clears the payload', async () => {
+    const service = new RetryActionService();
+
+    const promise = service.show(payload);
+    service.respond({ step: payload.step, option: 'Overwrite', persistentObject: payload.persistentObject });
+
+    const result = await promise;
+    expect(result.option).toBe('Overwrite');
+    expect(result.step).toBe('confirm-overwrite');
+    expect(service.payload()).toBeNull();
+  });
+
+  it('respond() before show() does not throw', () => {
+    const service = new RetryActionService();
+
+    expect(() =>
+      service.respond({ step: 'x', option: 'Cancel', persistentObject: {} as any }),
+    ).not.toThrow();
+  });
+
+  it('a second show() supersedes the first payload', () => {
+    const service = new RetryActionService();
+    service.show(payload);
+
+    const second: RetryActionPayload = { ...payload, step: 'second' };
+    service.show(second);
+
+    expect(service.payload()).toBe(second);
+  });
+});

--- a/node_packages/ng-spark/services/src/spark-icon-registry.spec.ts
+++ b/node_packages/ng-spark/services/src/spark-icon-registry.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { SparkIconRegistry } from './spark-icon-registry';
+import { SPARK_BUILT_IN_ICONS } from './spark-built-in-icons';
+
+describe('SparkIconRegistry', () => {
+  let registry: SparkIconRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    registry = TestBed.inject(SparkIconRegistry);
+  });
+
+  it('seeds the registry with all built-in icons on construction', () => {
+    for (const name of Object.keys(SPARK_BUILT_IN_ICONS)) {
+      expect(registry.has(name)).toBe(true);
+    }
+  });
+
+  it('get() returns a SafeHtml for a built-in icon', () => {
+    const firstBuiltIn = Object.keys(SPARK_BUILT_IN_ICONS)[0];
+    expect(registry.get(firstBuiltIn)).toBeDefined();
+  });
+
+  it('has() returns false for an unknown name', () => {
+    expect(registry.has('definitely-not-an-icon-name')).toBe(false);
+  });
+
+  it('register() adds a new icon that is then visible via get/has', () => {
+    registry.register('custom-x', '<svg><circle /></svg>');
+
+    expect(registry.has('custom-x')).toBe(true);
+    expect(registry.get('custom-x')).toBeDefined();
+  });
+
+  it('register() overwrites an existing icon with the new svg', () => {
+    const firstBuiltIn = Object.keys(SPARK_BUILT_IN_ICONS)[0];
+    const before = registry.get(firstBuiltIn);
+
+    registry.register(firstBuiltIn, '<svg><rect /></svg>');
+
+    const after = registry.get(firstBuiltIn);
+    expect(after).not.toBe(before); // new SafeHtml instance
+  });
+});


### PR DESCRIPTION
## Summary

First batch of ng-spark **service + component** tests, building on the analog plugin wired in PR #103. **+17 tests; ng-spark goes 75 → 92/92 green.** Total monorepo **274 tests** (156 .NET + 26 ng-spark-auth + 92 ng-spark).

### Tests added (17)

| File | Count | What |
|---|---|---|
| \`services/src/retry-action.service.spec.ts\` | 5 | payload signal lifecycle, show()/respond() promise, double-show, respond-without-show |
| \`services/src/spark-icon-registry.spec.ts\` | 5 | built-in icon seeding, get/has/register, overwrite |
| \`icon/src/spark-icon.component.spec.ts\` | 3 | Renders SVG span when registered; falls back to \`<i class="bi bi-{name}">\`; reactively switches when input changes |
| \`retry-action-modal/src/spark-retry-action-modal.component.spec.ts\` | 4 | isOpen() reflects payload; onOption() forwards to service and clears payload; safe when no payload active |

### Component testing pattern proven

\`SparkRetryActionModalComponent\` imports a stack of \`@mintplayer/ng-bootstrap\` modal directives. **TestBed handles them transparently** — no shallow rendering or mocking required. The \`createPipe\` helper pattern from #103 generalizes cleanly to components.

\`SparkIconComponent\` uses Angular 21 signal inputs (\`input.required<string>()\`); tests use \`fixture.componentRef.setInput(name, value)\` + \`fixture.detectChanges()\` and verify against the rendered DOM.

## Test plan

- [x] \`npx vitest run\` in \`node_packages/ng-spark/\` → 92/92 pass
- [x] \`nx run-many --target=test --projects=@mintplayer/ng-spark,@mintplayer/ng-spark-auth,MintPlayer.Spark.Tests\` → all green
- [ ] CI \`nx affected --target=test\` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)