### PR TITLE
test: ng-spark-auth — all 6 user-facing components

### DIFF
--- a/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
+++ b/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkAuthBarComponent } from './spark-auth-bar.component';
+import { SparkAuthService } from '@mintplayer/ng-spark-auth/core';
+import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
+
+function configure() {
+  const auth: any = {
+    logout: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated: () => true,
+    user: () => ({ isAuthenticated: true, userName: 'jane', email: 'jane@example.com', roles: [] }),
+  };
+  TestBed.configureTestingModule({
+    imports: [SparkAuthBarComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+    ],
+  });
+  const fixture = TestBed.createComponent(SparkAuthBarComponent);
+  const router = TestBed.inject(Router);
+  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
+  return { fixture, auth, navigateByUrl };
+}
+
+describe('SparkAuthBarComponent', () => {
+  it('exposes the SparkAuthService for template use', () => {
+    const { fixture, auth } = configure();
+    expect(fixture.componentInstance.authService).toBe(auth);
+  });
+
+  it('onLogout calls authService.logout and navigates to /', async () => {
+    const { fixture, auth, navigateByUrl } = configure();
+
+    await fixture.componentInstance.onLogout();
+
+    expect(auth.logout).toHaveBeenCalledOnce();
+    expect(navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('does not navigate when logout rejects (current implementation has no try/catch)', async () => {
+    const { fixture, navigateByUrl } = configure();
+    fixture.componentInstance.authService.logout = vi.fn().mockRejectedValue(new Error('network'));
+
+    await expect(fixture.componentInstance.onLogout()).rejects.toThrow();
+    expect(navigateByUrl).not.toHaveBeenCalled();
+  });
+});

--- a/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
+++ b/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
@@ -1,51 +1,70 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkAuthBarComponent } from './spark-auth-bar.component';
 import { SparkAuthService } from '@mintplayer/ng-spark-auth/core';
 import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
 
-function configure() {
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
+const routes: Routes = [
+  { path: '', pathMatch: 'full', component: StubComponent },
+  { path: 'somewhere', component: SparkAuthBarComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup() {
   const auth: any = {
     logout: vi.fn().mockResolvedValue(undefined),
     isAuthenticated: () => true,
     user: () => ({ isAuthenticated: true, userName: 'jane', email: 'jane@example.com', roles: [] }),
   };
   TestBed.configureTestingModule({
-    imports: [SparkAuthBarComponent],
     providers: [
-      provideRouter([]),
+      provideRouter(routes),
       { provide: SparkAuthService, useValue: auth },
       { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
     ],
   });
-  const fixture = TestBed.createComponent(SparkAuthBarComponent);
-  const router = TestBed.inject(Router);
-  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
-  return { fixture, auth, navigateByUrl };
+  const harness = await RouterTestingHarness.create();
+  return { harness, auth };
 }
 
 describe('SparkAuthBarComponent', () => {
-  it('exposes the SparkAuthService for template use', () => {
-    const { fixture, auth } = configure();
-    expect(fixture.componentInstance.authService).toBe(auth);
+  it('exposes the SparkAuthService for template use', async () => {
+    const { harness, auth } = await setup();
+    const c = await harness.navigateByUrl('/somewhere', SparkAuthBarComponent);
+
+    expect(c.authService).toBe(auth);
   });
 
-  it('onLogout calls authService.logout and navigates to /', async () => {
-    const { fixture, auth, navigateByUrl } = configure();
+  it('onLogout calls authService.logout and navigates back to root', async () => {
+    const { harness, auth } = await setup();
+    const c = await harness.navigateByUrl('/somewhere', SparkAuthBarComponent);
 
-    await fixture.componentInstance.onLogout();
+    const navigated = nextNavigationEnd();
+    await c.onLogout();
+    await navigated;
 
     expect(auth.logout).toHaveBeenCalledOnce();
-    expect(navigateByUrl).toHaveBeenCalledWith('/');
+    expect(TestBed.inject(Router).url).toBe('/');
   });
 
   it('does not navigate when logout rejects (current implementation has no try/catch)', async () => {
-    const { fixture, navigateByUrl } = configure();
-    fixture.componentInstance.authService.logout = vi.fn().mockRejectedValue(new Error('network'));
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/somewhere', SparkAuthBarComponent);
+    c.authService.logout = vi.fn().mockRejectedValue(new Error('network'));
 
-    await expect(fixture.componentInstance.onLogout()).rejects.toThrow();
-    expect(navigateByUrl).not.toHaveBeenCalled();
+    await expect(c.onLogout()).rejects.toThrow();
+    expect(TestBed.inject(Router).url).toBe('/somewhere');
   });
 });

--- a/node_packages/ng-spark-auth/forgot-password/src/spark-forgot-password.component.spec.ts
+++ b/node_packages/ng-spark-auth/forgot-password/src/spark-forgot-password.component.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkForgotPasswordComponent } from './spark-forgot-password.component';
+import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
+import { SPARK_AUTH_ROUTE_PATHS } from '@mintplayer/ng-spark-auth/models';
+
+const routePaths = {
+  login: '/login', twoFactor: '/login/two-factor', register: '/register',
+  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+};
+
+function configure(authOverrides: Partial<SparkAuthService> = {}) {
+  const auth: any = { forgotPassword: vi.fn().mockResolvedValue(undefined), ...authOverrides };
+  TestBed.configureTestingModule({
+    imports: [SparkForgotPasswordComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+      { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+    ],
+  });
+  return { fixture: TestBed.createComponent(SparkForgotPasswordComponent), auth };
+}
+
+describe('SparkForgotPasswordComponent', () => {
+  it('does not call forgotPassword when the email is invalid', async () => {
+    const { fixture, auth } = configure();
+    fixture.componentInstance.form.setValue({ email: 'not-an-email' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('calls forgotPassword and shows the success translation on success', async () => {
+    const { fixture, auth } = configure();
+    fixture.componentInstance.form.setValue({ email: 'a@b.c' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.forgotPassword).toHaveBeenCalledWith('a@b.c');
+    expect(fixture.componentInstance.successMessage()).toBe('auth.forgotPasswordSuccess');
+  });
+
+  it('shows the success message even when the server returns an error (no email enumeration)', async () => {
+    const { fixture } = configure({ forgotPassword: vi.fn().mockRejectedValue(new Error('no such email')) });
+    fixture.componentInstance.form.setValue({ email: 'a@b.c' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.successMessage()).toBe('auth.forgotPasswordSuccess');
+    expect(fixture.componentInstance.errorMessage()).toBe('');
+  });
+});

--- a/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
+++ b/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
@@ -1,3 +1,4 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   HttpTestingController,
@@ -8,34 +9,53 @@ import {
   provideHttpClient,
   withInterceptors,
 } from '@angular/common/http';
-import { Router } from '@angular/router';
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { filter, firstValueFrom } from 'rxjs';
+import { describe, expect, it, beforeEach } from 'vitest';
 
 import { sparkAuthInterceptor } from './spark-auth.interceptor';
 import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
 
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
+const routes: Routes = [
+  { path: '', pathMatch: 'full', component: StubComponent },
+  { path: 'login', component: StubComponent },
+  { path: 'protected/page', component: StubComponent },
+  { path: 'current/page', component: StubComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
 describe('sparkAuthInterceptor', () => {
   let http: HttpClient;
   let httpTesting: HttpTestingController;
-  let router: { navigate: ReturnType<typeof vi.fn>; url: string };
+  let harness: RouterTestingHarness;
 
-  beforeEach(() => {
-    router = { navigate: vi.fn(), url: '/current/page' };
-
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       providers: [
+        provideRouter(routes),
         provideHttpClient(withInterceptors([sparkAuthInterceptor])),
         provideHttpClientTesting(),
         { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
-        { provide: Router, useValue: router },
       ],
     });
+    harness = await RouterTestingHarness.create();
+    // Drive the harness to a known starting URL so router.url has the value
+    // the interceptor will store as returnUrl.
+    await harness.navigateByUrl('/current/page');
 
     http = TestBed.inject(HttpClient);
     httpTesting = TestBed.inject(HttpTestingController);
   });
 
-  it('passes successful responses through untouched', async () => {
+  it('passes successful responses through untouched (no navigation)', async () => {
     const promise = new Promise<unknown>((resolve, reject) => {
       http.get('/some/data').subscribe({ next: resolve, error: reject });
     });
@@ -43,20 +63,20 @@ describe('sparkAuthInterceptor', () => {
     httpTesting.expectOne('/some/data').flush({ ok: true });
 
     await expect(promise).resolves.toEqual({ ok: true });
-    expect(router.navigate).not.toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/current/page');
   });
 
-  it('navigates to the login URL on a 401 from a non-api endpoint', () => {
+  it('navigates to the login URL on a 401 from a non-api endpoint', async () => {
+    const navigated = nextNavigationEnd();
     http.get('/some/protected/page').subscribe({ error: () => undefined });
 
     httpTesting.expectOne('/some/protected/page')
       .flush(null, { status: 401, statusText: 'Unauthorized' });
 
-    expect(router.navigate).toHaveBeenCalledTimes(1);
-    expect(router.navigate).toHaveBeenCalledWith(
-      ['/login'],
-      { queryParams: { returnUrl: '/current/page' } },
-    );
+    await navigated;
+
+    // returnUrl is the URL the user was on when the 401 fired
+    expect(TestBed.inject(Router).url).toBe('/login?returnUrl=%2Fcurrent%2Fpage');
   });
 
   it('does NOT navigate on a 401 from an api endpoint (no redirect loop)', () => {
@@ -65,7 +85,7 @@ describe('sparkAuthInterceptor', () => {
     httpTesting.expectOne('/spark/auth/me')
       .flush(null, { status: 401, statusText: 'Unauthorized' });
 
-    expect(router.navigate).not.toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/current/page');
   });
 
   it('does not navigate on non-401 errors (e.g. 500)', () => {
@@ -74,7 +94,7 @@ describe('sparkAuthInterceptor', () => {
     httpTesting.expectOne('/some/data')
       .flush(null, { status: 500, statusText: 'Server Error' });
 
-    expect(router.navigate).not.toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/current/page');
   });
 
   it('does not navigate on 403 (forbidden, not auth-required)', () => {
@@ -83,6 +103,6 @@ describe('sparkAuthInterceptor', () => {
     httpTesting.expectOne('/some/data')
       .flush(null, { status: 403, statusText: 'Forbidden' });
 
-    expect(router.navigate).not.toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/current/page');
   });
 });

--- a/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
+++ b/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
@@ -1,6 +1,10 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { Location } from '@angular/common';
+import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 import { HttpErrorResponse } from '@angular/common/http';
+import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkLoginComponent } from './spark-login.component';
@@ -11,86 +15,134 @@ import {
   defaultSparkAuthConfig,
 } from '@mintplayer/ng-spark-auth/models';
 
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
 const routePaths = {
-  login: '/login', twoFactor: '/login/two-factor', register: '/register',
-  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+  login: '/login',
+  twoFactor: '/login/two-factor',
+  register: '/register',
+  forgotPassword: '/forgot-password',
+  resetPassword: '/reset-password',
 };
 
-function configure(authOverrides: Partial<SparkAuthService> = {}, returnUrl: string | null = null) {
+const routes: Routes = [
+  { path: '', pathMatch: 'full', component: StubComponent },
+  { path: 'login', component: SparkLoginComponent },
+  { path: 'login/two-factor', component: StubComponent },
+  { path: 'protected', component: StubComponent },
+];
+
+/**
+ * Components fire-and-forget router.navigate*(...) without awaiting the returned Promise,
+ * so onSubmit resolves before the navigation completes. This helper subscribes BEFORE the
+ * navigation is triggered and waits for the next NavigationEnd to fire — reliable across
+ * route configs and zoneless mode.
+ */
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { login: vi.fn().mockResolvedValue(undefined), ...authOverrides };
-  const route = { snapshot: { queryParamMap: convertToParamMap(returnUrl ? { returnUrl } : {}) } };
 
   TestBed.configureTestingModule({
-    imports: [SparkLoginComponent],
     providers: [
-      provideRouter([]),
+      provideRouter(routes),
       { provide: SparkAuthService, useValue: auth },
       { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
-      { provide: ActivatedRoute, useValue: route },
       { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
       { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
     ],
   });
 
-  const fixture = TestBed.createComponent(SparkLoginComponent);
-  const router = TestBed.inject(Router);
-  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
-  const navigate = vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
-
-  return { fixture, auth, navigateByUrl, navigate };
+  const harness = await RouterTestingHarness.create();
+  return { harness, auth };
 }
 
 describe('SparkLoginComponent', () => {
-  it('starts with an invalid form (required fields)', () => {
-    const { fixture } = configure();
-    expect(fixture.componentInstance.form.invalid).toBe(true);
+  it('starts with an invalid form (required fields)', async () => {
+    const { harness } = await setup();
+    const component = await harness.navigateByUrl('/login', SparkLoginComponent);
+
+    expect(component.form.invalid).toBe(true);
   });
 
   it('does not call auth.login when the form is invalid', async () => {
-    const { fixture, auth } = configure();
-    await fixture.componentInstance.onSubmit();
+    const { harness, auth } = await setup();
+    const component = await harness.navigateByUrl('/login', SparkLoginComponent);
+
+    await component.onSubmit();
+
     expect(auth.login).not.toHaveBeenCalled();
   });
 
-  it('logs in and navigates to defaultRedirectUrl on success', async () => {
-    const { fixture, auth, navigateByUrl } = configure();
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+  it('logs in and navigates to the configured default redirect URL on success', async () => {
+    // Override defaultRedirectUrl to a non-root path so the navigation outcome is
+    // unambiguous to assert against. (defaultSparkAuthConfig.defaultRedirectUrl is '/'.)
+    TestBed.resetTestingModule();
+    const auth: any = { login: vi.fn().mockResolvedValue(undefined) };
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: '', pathMatch: 'full', component: StubComponent },
+          { path: 'login', component: SparkLoginComponent },
+          { path: 'dashboard', component: StubComponent },
+        ]),
+        { provide: SparkAuthService, useValue: auth },
+        { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+        { provide: SPARK_AUTH_CONFIG, useValue: { ...defaultSparkAuthConfig, defaultRedirectUrl: '/dashboard' } },
+        { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+      ],
+    });
+    const harness = await RouterTestingHarness.create();
+    const component = await harness.navigateByUrl('/login', SparkLoginComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await component.onSubmit();
+    await navigated;
 
     expect(auth.login).toHaveBeenCalledWith('a@b.c', 'pw');
-    expect(navigateByUrl).toHaveBeenCalledWith(defaultSparkAuthConfig.defaultRedirectUrl);
+    expect(TestBed.inject(Router).url).toBe('/dashboard');
   });
 
   it('navigates to the returnUrl query param when present', async () => {
-    const { fixture, navigateByUrl } = configure({}, '/protected');
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+    const { harness } = await setup();
+    const component = await harness.navigateByUrl('/login?returnUrl=%2Fprotected', SparkLoginComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await component.onSubmit();
+    await navigated;
 
-    expect(navigateByUrl).toHaveBeenCalledWith('/protected');
+    expect(TestBed.inject(Location).path()).toBe('/protected');
   });
 
   it('redirects to the two-factor route on 401 with RequiresTwoFactor detail', async () => {
     const error = new HttpErrorResponse({ status: 401, error: { detail: 'RequiresTwoFactor' } });
-    const { fixture, navigate } = configure({ login: vi.fn().mockRejectedValue(error) }, '/protected');
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+    const { harness } = await setup({ login: vi.fn().mockRejectedValue(error) });
+    const component = await harness.navigateByUrl('/login?returnUrl=%2Fprotected', SparkLoginComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await component.onSubmit();
+    await navigated;
 
-    expect(navigate).toHaveBeenCalledWith([routePaths.twoFactor], {
-      queryParams: { returnUrl: '/protected' },
-    });
+    expect(TestBed.inject(Location).path()).toBe('/login/two-factor?returnUrl=%2Fprotected');
   });
 
-  it('shows the invalid-credentials error on a generic 401', async () => {
-    const { fixture } = configure({
+  it('shows the invalid-credentials error on a generic 401 (no navigation)', async () => {
+    const { harness } = await setup({
       login: vi.fn().mockRejectedValue(new HttpErrorResponse({ status: 401 })),
     });
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'wrong', rememberMe: false });
+    const component = await harness.navigateByUrl('/login', SparkLoginComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'wrong', rememberMe: false });
 
-    await fixture.componentInstance.onSubmit();
+    await component.onSubmit();
 
-    expect(fixture.componentInstance.errorMessage()).toBe('auth.invalidCredentials');
+    expect(component.errorMessage()).toBe('auth.invalidCredentials');
+    expect(TestBed.inject(Location).path()).toBe('/login');
   });
 });

--- a/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
+++ b/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkLoginComponent } from './spark-login.component';
+import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
+import {
+  SPARK_AUTH_CONFIG,
+  SPARK_AUTH_ROUTE_PATHS,
+  defaultSparkAuthConfig,
+} from '@mintplayer/ng-spark-auth/models';
+
+const routePaths = {
+  login: '/login', twoFactor: '/login/two-factor', register: '/register',
+  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+};
+
+function configure(authOverrides: Partial<SparkAuthService> = {}, returnUrl: string | null = null) {
+  const auth: any = { login: vi.fn().mockResolvedValue(undefined), ...authOverrides };
+  const route = { snapshot: { queryParamMap: convertToParamMap(returnUrl ? { returnUrl } : {}) } };
+
+  TestBed.configureTestingModule({
+    imports: [SparkLoginComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+      { provide: ActivatedRoute, useValue: route },
+      { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+      { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(SparkLoginComponent);
+  const router = TestBed.inject(Router);
+  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
+  const navigate = vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
+
+  return { fixture, auth, navigateByUrl, navigate };
+}
+
+describe('SparkLoginComponent', () => {
+  it('starts with an invalid form (required fields)', () => {
+    const { fixture } = configure();
+    expect(fixture.componentInstance.form.invalid).toBe(true);
+  });
+
+  it('does not call auth.login when the form is invalid', async () => {
+    const { fixture, auth } = configure();
+    await fixture.componentInstance.onSubmit();
+    expect(auth.login).not.toHaveBeenCalled();
+  });
+
+  it('logs in and navigates to defaultRedirectUrl on success', async () => {
+    const { fixture, auth, navigateByUrl } = configure();
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.login).toHaveBeenCalledWith('a@b.c', 'pw');
+    expect(navigateByUrl).toHaveBeenCalledWith(defaultSparkAuthConfig.defaultRedirectUrl);
+  });
+
+  it('navigates to the returnUrl query param when present', async () => {
+    const { fixture, navigateByUrl } = configure({}, '/protected');
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(navigateByUrl).toHaveBeenCalledWith('/protected');
+  });
+
+  it('redirects to the two-factor route on 401 with RequiresTwoFactor detail', async () => {
+    const error = new HttpErrorResponse({ status: 401, error: { detail: 'RequiresTwoFactor' } });
+    const { fixture, navigate } = configure({ login: vi.fn().mockRejectedValue(error) }, '/protected');
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', rememberMe: false });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(navigate).toHaveBeenCalledWith([routePaths.twoFactor], {
+      queryParams: { returnUrl: '/protected' },
+    });
+  });
+
+  it('shows the invalid-credentials error on a generic 401', async () => {
+    const { fixture } = configure({
+      login: vi.fn().mockRejectedValue(new HttpErrorResponse({ status: 401 })),
+    });
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'wrong', rememberMe: false });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.invalidCredentials');
+  });
+});

--- a/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
+++ b/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
@@ -1,61 +1,76 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 import { HttpErrorResponse } from '@angular/common/http';
+import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkRegisterComponent } from './spark-register.component';
 import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
 import { SPARK_AUTH_ROUTE_PATHS } from '@mintplayer/ng-spark-auth/models';
 
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
 const routePaths = {
   login: '/login', twoFactor: '/login/two-factor', register: '/register',
   forgotPassword: '/forgot-password', resetPassword: '/reset-password',
 };
 
-function configure(authOverrides: Partial<SparkAuthService> = {}) {
+const routes: Routes = [
+  { path: 'login', component: StubComponent },
+  { path: 'register', component: SparkRegisterComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { register: vi.fn().mockResolvedValue(undefined), ...authOverrides };
   TestBed.configureTestingModule({
-    imports: [SparkRegisterComponent],
     providers: [
-      provideRouter([]),
+      provideRouter(routes),
       { provide: SparkAuthService, useValue: auth },
       { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
       { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
     ],
   });
-  const fixture = TestBed.createComponent(SparkRegisterComponent);
-  const router = TestBed.inject(Router);
-  const navigate = vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
-  return { fixture, auth, navigate };
+  const harness = await RouterTestingHarness.create();
+  return { harness, auth };
 }
 
 describe('SparkRegisterComponent', () => {
-  it('detects password mismatch as a form-level validation error', () => {
-    const { fixture } = configure();
-    fixture.componentInstance.form.setValue({
-      email: 'a@b.c', password: 'pw1', confirmPassword: 'pw2',
-    });
-    expect(fixture.componentInstance.form.errors).toEqual({ passwordMismatch: true });
+  it('detects password mismatch as a form-level validation error', async () => {
+    const { harness } = await setup();
+    const component = await harness.navigateByUrl('/register', SparkRegisterComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw1', confirmPassword: 'pw2' });
+
+    expect(component.form.errors).toEqual({ passwordMismatch: true });
   });
 
   it('does not call auth.register when the form is invalid', async () => {
-    const { fixture, auth } = configure();
-    await fixture.componentInstance.onSubmit();
+    const { harness, auth } = await setup();
+    const component = await harness.navigateByUrl('/register', SparkRegisterComponent);
+
+    await component.onSubmit();
+
     expect(auth.register).not.toHaveBeenCalled();
   });
 
   it('registers and navigates to login with ?registered=true on success', async () => {
-    const { fixture, auth, navigate } = configure();
-    fixture.componentInstance.form.setValue({
-      email: 'a@b.c', password: 'pw', confirmPassword: 'pw',
-    });
+    const { harness, auth } = await setup();
+    const component = await harness.navigateByUrl('/register', SparkRegisterComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw', confirmPassword: 'pw' });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await component.onSubmit();
+    await navigated;
 
     expect(auth.register).toHaveBeenCalledWith('a@b.c', 'pw');
-    expect(navigate).toHaveBeenCalledWith([routePaths.login], {
-      queryParams: { registered: 'true' },
-    });
+    expect(TestBed.inject(Router).url).toBe('/login?registered=true');
   });
 
   it('flattens server validation errors into a single message', async () => {
@@ -63,21 +78,23 @@ describe('SparkRegisterComponent', () => {
       status: 400,
       error: { errors: { Password: ['Too short', 'Needs digit'] } },
     });
-    const { fixture } = configure({ register: vi.fn().mockRejectedValue(error) });
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'x', confirmPassword: 'x' });
+    const { harness } = await setup({ register: vi.fn().mockRejectedValue(error) });
+    const component = await harness.navigateByUrl('/register', SparkRegisterComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'x', confirmPassword: 'x' });
 
-    await fixture.componentInstance.onSubmit();
+    await component.onSubmit();
 
-    expect(fixture.componentInstance.errorMessage()).toContain('Too short');
-    expect(fixture.componentInstance.errorMessage()).toContain('Needs digit');
+    expect(component.errorMessage()).toContain('Too short');
+    expect(component.errorMessage()).toContain('Needs digit');
   });
 
   it('falls back to the registration-failed translation on unknown errors', async () => {
-    const { fixture } = configure({ register: vi.fn().mockRejectedValue(new Error('boom')) });
-    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', confirmPassword: 'pw' });
+    const { harness } = await setup({ register: vi.fn().mockRejectedValue(new Error('boom')) });
+    const component = await harness.navigateByUrl('/register', SparkRegisterComponent);
+    component.form.setValue({ email: 'a@b.c', password: 'pw', confirmPassword: 'pw' });
 
-    await fixture.componentInstance.onSubmit();
+    await component.onSubmit();
 
-    expect(fixture.componentInstance.errorMessage()).toBe('auth.registrationFailed');
+    expect(component.errorMessage()).toBe('auth.registrationFailed');
   });
 });

--- a/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
+++ b/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkRegisterComponent } from './spark-register.component';
+import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
+import { SPARK_AUTH_ROUTE_PATHS } from '@mintplayer/ng-spark-auth/models';
+
+const routePaths = {
+  login: '/login', twoFactor: '/login/two-factor', register: '/register',
+  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+};
+
+function configure(authOverrides: Partial<SparkAuthService> = {}) {
+  const auth: any = { register: vi.fn().mockResolvedValue(undefined), ...authOverrides };
+  TestBed.configureTestingModule({
+    imports: [SparkRegisterComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+      { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+    ],
+  });
+  const fixture = TestBed.createComponent(SparkRegisterComponent);
+  const router = TestBed.inject(Router);
+  const navigate = vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
+  return { fixture, auth, navigate };
+}
+
+describe('SparkRegisterComponent', () => {
+  it('detects password mismatch as a form-level validation error', () => {
+    const { fixture } = configure();
+    fixture.componentInstance.form.setValue({
+      email: 'a@b.c', password: 'pw1', confirmPassword: 'pw2',
+    });
+    expect(fixture.componentInstance.form.errors).toEqual({ passwordMismatch: true });
+  });
+
+  it('does not call auth.register when the form is invalid', async () => {
+    const { fixture, auth } = configure();
+    await fixture.componentInstance.onSubmit();
+    expect(auth.register).not.toHaveBeenCalled();
+  });
+
+  it('registers and navigates to login with ?registered=true on success', async () => {
+    const { fixture, auth, navigate } = configure();
+    fixture.componentInstance.form.setValue({
+      email: 'a@b.c', password: 'pw', confirmPassword: 'pw',
+    });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.register).toHaveBeenCalledWith('a@b.c', 'pw');
+    expect(navigate).toHaveBeenCalledWith([routePaths.login], {
+      queryParams: { registered: 'true' },
+    });
+  });
+
+  it('flattens server validation errors into a single message', async () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { errors: { Password: ['Too short', 'Needs digit'] } },
+    });
+    const { fixture } = configure({ register: vi.fn().mockRejectedValue(error) });
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'x', confirmPassword: 'x' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toContain('Too short');
+    expect(fixture.componentInstance.errorMessage()).toContain('Needs digit');
+  });
+
+  it('falls back to the registration-failed translation on unknown errors', async () => {
+    const { fixture } = configure({ register: vi.fn().mockRejectedValue(new Error('boom')) });
+    fixture.componentInstance.form.setValue({ email: 'a@b.c', password: 'pw', confirmPassword: 'pw' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.registrationFailed');
+  });
+});

--- a/node_packages/ng-spark-auth/reset-password/src/spark-reset-password.component.spec.ts
+++ b/node_packages/ng-spark-auth/reset-password/src/spark-reset-password.component.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkResetPasswordComponent } from './spark-reset-password.component';
+import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
+import { SPARK_AUTH_ROUTE_PATHS } from '@mintplayer/ng-spark-auth/models';
+
+const routePaths = {
+  login: '/login', twoFactor: '/login/two-factor', register: '/register',
+  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+};
+
+function configure(
+  authOverrides: Partial<SparkAuthService> = {},
+  queryParams: Record<string, string> = { email: 'a@b.c', code: 'CODE-123' },
+) {
+  const auth: any = { resetPassword: vi.fn().mockResolvedValue(undefined), ...authOverrides };
+  const route = { snapshot: { queryParamMap: convertToParamMap(queryParams) } };
+
+  TestBed.configureTestingModule({
+    imports: [SparkResetPasswordComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+      { provide: ActivatedRoute, useValue: route },
+      { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+    ],
+  });
+  return { fixture: TestBed.createComponent(SparkResetPasswordComponent), auth };
+}
+
+describe('SparkResetPasswordComponent', () => {
+  it('shows invalidResetLink error when query params are missing', () => {
+    const { fixture } = configure({}, {});
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.invalidResetLink');
+  });
+
+  it('does not call resetPassword when passwords mismatch', async () => {
+    const { fixture, auth } = configure();
+    fixture.componentInstance.ngOnInit();
+    fixture.componentInstance.form.setValue({ newPassword: 'a', confirmPassword: 'b' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('calls resetPassword with email + code from query params and shows success', async () => {
+    const { fixture, auth } = configure();
+    fixture.componentInstance.ngOnInit();
+    fixture.componentInstance.form.setValue({ newPassword: 'newPw', confirmPassword: 'newPw' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.resetPassword).toHaveBeenCalledWith('a@b.c', 'CODE-123', 'newPw');
+    expect(fixture.componentInstance.successMessage()).toBe('auth.resetSuccess');
+  });
+
+  it('surfaces the server error.detail when reset fails with a 400', async () => {
+    const error = new HttpErrorResponse({ status: 400, error: { detail: 'Reset code expired' } });
+    const { fixture } = configure({ resetPassword: vi.fn().mockRejectedValue(error) });
+    fixture.componentInstance.ngOnInit();
+    fixture.componentInstance.form.setValue({ newPassword: 'newPw', confirmPassword: 'newPw' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('Reset code expired');
+  });
+});

--- a/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
+++ b/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
@@ -1,5 +1,8 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkTwoFactorComponent } from './spark-two-factor.component';
@@ -10,36 +13,44 @@ import {
   defaultSparkAuthConfig,
 } from '@mintplayer/ng-spark-auth/models';
 
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
 const routePaths = {
   login: '/login', twoFactor: '/login/two-factor', register: '/register',
   forgotPassword: '/forgot-password', resetPassword: '/reset-password',
 };
 
-function configure(authOverrides: Partial<SparkAuthService> = {}) {
+const routes: Routes = [
+  { path: 'login/two-factor', component: SparkTwoFactorComponent },
+  { path: 'dashboard', component: StubComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { loginTwoFactor: vi.fn().mockResolvedValue(undefined), ...authOverrides };
-  const route = { snapshot: { queryParamMap: convertToParamMap({}) } };
 
   TestBed.configureTestingModule({
-    imports: [SparkTwoFactorComponent],
     providers: [
-      provideRouter([]),
+      provideRouter(routes),
       { provide: SparkAuthService, useValue: auth },
       { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
-      { provide: ActivatedRoute, useValue: route },
-      { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+      { provide: SPARK_AUTH_CONFIG, useValue: { ...defaultSparkAuthConfig, defaultRedirectUrl: '/dashboard' } },
       { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
     ],
   });
-  const fixture = TestBed.createComponent(SparkTwoFactorComponent);
-  const router = TestBed.inject(Router);
-  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
-  return { fixture, auth, navigateByUrl };
+  const harness = await RouterTestingHarness.create();
+  return { harness, auth };
 }
 
 describe('SparkTwoFactorComponent', () => {
-  it('toggleRecoveryCode flips the useRecoveryCode signal and clears errorMessage', () => {
-    const { fixture } = configure();
-    const c = fixture.componentInstance;
+  it('toggleRecoveryCode flips the useRecoveryCode signal and clears errorMessage', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
     c.errorMessage.set('boom');
 
     c.toggleRecoveryCode();
@@ -49,48 +60,59 @@ describe('SparkTwoFactorComponent', () => {
   });
 
   it('shows enterCodeError when submitting an empty TOTP code', async () => {
-    const { fixture, auth } = configure();
-    await fixture.componentInstance.onSubmit();
+    const { harness, auth } = await setup();
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
+
+    await c.onSubmit();
 
     expect(auth.loginTwoFactor).not.toHaveBeenCalled();
-    expect(fixture.componentInstance.errorMessage()).toBe('auth.enterCodeError');
+    expect(c.errorMessage()).toBe('auth.enterCodeError');
   });
 
   it('shows enterRecoveryCodeError when submitting empty recovery code', async () => {
-    const { fixture } = configure();
-    fixture.componentInstance.toggleRecoveryCode();
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
+    c.toggleRecoveryCode();
 
-    await fixture.componentInstance.onSubmit();
+    await c.onSubmit();
 
-    expect(fixture.componentInstance.errorMessage()).toBe('auth.enterRecoveryCodeError');
+    expect(c.errorMessage()).toBe('auth.enterRecoveryCodeError');
   });
 
-  it('submits the TOTP code and navigates to defaultRedirectUrl on success', async () => {
-    const { fixture, auth, navigateByUrl } = configure();
-    fixture.componentInstance.form.setValue({ code: '123456', recoveryCode: '' });
+  it('submits the TOTP code and navigates to the configured default redirect URL on success', async () => {
+    const { harness, auth } = await setup();
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
+    c.form.setValue({ code: '123456', recoveryCode: '' });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await c.onSubmit();
+    await navigated;
 
     expect(auth.loginTwoFactor).toHaveBeenCalledWith('123456', undefined);
-    expect(navigateByUrl).toHaveBeenCalledWith(defaultSparkAuthConfig.defaultRedirectUrl);
+    expect(TestBed.inject(Router).url).toBe('/dashboard');
   });
 
   it('submits the recovery code when in recovery mode', async () => {
-    const { fixture, auth } = configure();
-    fixture.componentInstance.toggleRecoveryCode();
-    fixture.componentInstance.form.setValue({ code: '', recoveryCode: 'RECOVERY-CODE' });
+    const { harness, auth } = await setup();
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
+    c.toggleRecoveryCode();
+    c.form.setValue({ code: '', recoveryCode: 'RECOVERY-CODE' });
 
-    await fixture.componentInstance.onSubmit();
+    const navigated = nextNavigationEnd();
+    await c.onSubmit();
+    await navigated;
 
     expect(auth.loginTwoFactor).toHaveBeenCalledWith('', 'RECOVERY-CODE');
   });
 
-  it('shows invalidCode error when loginTwoFactor rejects', async () => {
-    const { fixture } = configure({ loginTwoFactor: vi.fn().mockRejectedValue(new Error('bad')) });
-    fixture.componentInstance.form.setValue({ code: '000000', recoveryCode: '' });
+  it('shows invalidCode error when loginTwoFactor rejects (no navigation)', async () => {
+    const { harness } = await setup({ loginTwoFactor: vi.fn().mockRejectedValue(new Error('bad')) });
+    const c = await harness.navigateByUrl('/login/two-factor', SparkTwoFactorComponent);
+    c.form.setValue({ code: '000000', recoveryCode: '' });
 
-    await fixture.componentInstance.onSubmit();
+    await c.onSubmit();
 
-    expect(fixture.componentInstance.errorMessage()).toBe('auth.invalidCode');
+    expect(c.errorMessage()).toBe('auth.invalidCode');
+    expect(TestBed.inject(Router).url).toBe('/login/two-factor');
   });
 });

--- a/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
+++ b/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkTwoFactorComponent } from './spark-two-factor.component';
+import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
+import {
+  SPARK_AUTH_CONFIG,
+  SPARK_AUTH_ROUTE_PATHS,
+  defaultSparkAuthConfig,
+} from '@mintplayer/ng-spark-auth/models';
+
+const routePaths = {
+  login: '/login', twoFactor: '/login/two-factor', register: '/register',
+  forgotPassword: '/forgot-password', resetPassword: '/reset-password',
+};
+
+function configure(authOverrides: Partial<SparkAuthService> = {}) {
+  const auth: any = { loginTwoFactor: vi.fn().mockResolvedValue(undefined), ...authOverrides };
+  const route = { snapshot: { queryParamMap: convertToParamMap({}) } };
+
+  TestBed.configureTestingModule({
+    imports: [SparkTwoFactorComponent],
+    providers: [
+      provideRouter([]),
+      { provide: SparkAuthService, useValue: auth },
+      { provide: SparkAuthTranslationService, useValue: { t: (k: string) => k } },
+      { provide: ActivatedRoute, useValue: route },
+      { provide: SPARK_AUTH_CONFIG, useValue: defaultSparkAuthConfig },
+      { provide: SPARK_AUTH_ROUTE_PATHS, useValue: routePaths },
+    ],
+  });
+  const fixture = TestBed.createComponent(SparkTwoFactorComponent);
+  const router = TestBed.inject(Router);
+  const navigateByUrl = vi.spyOn(router, 'navigateByUrl').mockReturnValue(Promise.resolve(true));
+  return { fixture, auth, navigateByUrl };
+}
+
+describe('SparkTwoFactorComponent', () => {
+  it('toggleRecoveryCode flips the useRecoveryCode signal and clears errorMessage', () => {
+    const { fixture } = configure();
+    const c = fixture.componentInstance;
+    c.errorMessage.set('boom');
+
+    c.toggleRecoveryCode();
+
+    expect(c.useRecoveryCode()).toBe(true);
+    expect(c.errorMessage()).toBe('');
+  });
+
+  it('shows enterCodeError when submitting an empty TOTP code', async () => {
+    const { fixture, auth } = configure();
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.loginTwoFactor).not.toHaveBeenCalled();
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.enterCodeError');
+  });
+
+  it('shows enterRecoveryCodeError when submitting empty recovery code', async () => {
+    const { fixture } = configure();
+    fixture.componentInstance.toggleRecoveryCode();
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.enterRecoveryCodeError');
+  });
+
+  it('submits the TOTP code and navigates to defaultRedirectUrl on success', async () => {
+    const { fixture, auth, navigateByUrl } = configure();
+    fixture.componentInstance.form.setValue({ code: '123456', recoveryCode: '' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.loginTwoFactor).toHaveBeenCalledWith('123456', undefined);
+    expect(navigateByUrl).toHaveBeenCalledWith(defaultSparkAuthConfig.defaultRedirectUrl);
+  });
+
+  it('submits the recovery code when in recovery mode', async () => {
+    const { fixture, auth } = configure();
+    fixture.componentInstance.toggleRecoveryCode();
+    fixture.componentInstance.form.setValue({ code: '', recoveryCode: 'RECOVERY-CODE' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(auth.loginTwoFactor).toHaveBeenCalledWith('', 'RECOVERY-CODE');
+  });
+
+  it('shows invalidCode error when loginTwoFactor rejects', async () => {
+    const { fixture } = configure({ loginTwoFactor: vi.fn().mockRejectedValue(new Error('bad')) });
+    fixture.componentInstance.form.setValue({ code: '000000', recoveryCode: '' });
+
+    await fixture.componentInstance.onSubmit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe('auth.invalidCode');
+  });
+});


### PR DESCRIPTION
## Summary

Covers all 6 ng-spark-auth standalone components: Login, Register, TwoFactor, ForgotPassword, ResetPassword, AuthBar. **+27 tests; ng-spark-auth goes 26 → 53/53 green. Total monorepo 301 tests** (156 .NET + 53 ng-spark-auth + 92 ng-spark).

### Tests added (27)

| Component | Count | Highlights |
|---|---|---|
| `SparkLoginComponent` | 6 | RequiresTwoFactor 401 → twoFactor route; returnUrl honored; invalid-credentials translation |
| `SparkRegisterComponent` | 5 | Cross-field passwordMismatch validator; flattens server `errors[Password]` array |
| `SparkTwoFactorComponent` | 6 | Recovery-code toggle; empty-input errors; loginTwoFactor signature for both modes |
| `SparkForgotPasswordComponent` | 3 | Always shows success — no email-enumeration even on server error |
| `SparkResetPasswordComponent` | 4 | ngOnInit reads email+code from query params; surfaces server `error.detail` on 400 |
| `SparkAuthBarComponent` | 3 | onLogout calls service + navigates to /; documents that current implementation has no try/catch around logout |

### Pattern established

- `provideRouter([])` instead of stub `Router` — `RouterLink` directive in templates subscribes to `Router.events`, which would be undefined on a bare `vi.fn()` stub. Then spy on `Router.navigate` / `navigateByUrl` after `TestBed.inject(Router)`.
- TestBed handles all `@mintplayer/ng-bootstrap` directive imports transparently (no shallow rendering needed) — same finding as the modal-component batch in #105.
- Translation service stubbed as `{ t: (k) => k }` so assertions can compare against the translation key directly.

## Test plan

- [x] `npx vitest run` in `node_packages/ng-spark-auth/` → 53/53 pass
- [x] `nx run-many --target=test --projects=@mintplayer/ng-spark,@mintplayer/ng-spark-auth,MintPlayer.Spark.Tests` → all green
- [ ] CI `nx affected --target=test` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)