### PR TITLE
test: ng-spark — PoCreate, PoEdit, QueryList components (L3 part 1)

### DIFF
--- a/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
+++ b/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
@@ -1,26 +1,17 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkAuthBarComponent } from './spark-auth-bar.component';
 import { SparkAuthService } from '@mintplayer/ng-spark-auth/core';
 import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const routes: Routes = [
   { path: '', pathMatch: 'full', component: StubComponent },
   { path: 'somewhere', component: SparkAuthBarComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup() {
   const auth: any = {

--- a/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
+++ b/node_packages/ng-spark-auth/interceptors/src/spark-auth.interceptor.spec.ts
@@ -1,4 +1,3 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   HttpTestingController,
@@ -9,16 +8,13 @@ import {
   provideHttpClient,
   withInterceptors,
 } from '@angular/common/http';
-import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, beforeEach } from 'vitest';
 
 import { sparkAuthInterceptor } from './spark-auth.interceptor';
 import { SPARK_AUTH_CONFIG, defaultSparkAuthConfig } from '@mintplayer/ng-spark-auth/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const routes: Routes = [
   { path: '', pathMatch: 'full', component: StubComponent },
@@ -26,11 +22,6 @@ const routes: Routes = [
   { path: 'protected/page', component: StubComponent },
   { path: 'current/page', component: StubComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 describe('sparkAuthInterceptor', () => {
   let http: HttpClient;

--- a/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
+++ b/node_packages/ng-spark-auth/login/src/spark-login.component.spec.ts
@@ -1,10 +1,7 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Location } from '@angular/common';
-import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { HttpErrorResponse } from '@angular/common/http';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkLoginComponent } from './spark-login.component';
@@ -14,9 +11,7 @@ import {
   SPARK_AUTH_ROUTE_PATHS,
   defaultSparkAuthConfig,
 } from '@mintplayer/ng-spark-auth/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const routePaths = {
   login: '/login',
@@ -32,17 +27,6 @@ const routes: Routes = [
   { path: 'login/two-factor', component: StubComponent },
   { path: 'protected', component: StubComponent },
 ];
-
-/**
- * Components fire-and-forget router.navigate*(...) without awaiting the returned Promise,
- * so onSubmit resolves before the navigation completes. This helper subscribes BEFORE the
- * navigation is triggered and waits for the next NavigationEnd to fire — reliable across
- * route configs and zoneless mode.
- */
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { login: vi.fn().mockResolvedValue(undefined), ...authOverrides };
@@ -117,7 +101,7 @@ describe('SparkLoginComponent', () => {
     await component.onSubmit();
     await navigated;
 
-    expect(TestBed.inject(Location).path()).toBe('/protected');
+    expect(TestBed.inject(Router).url).toBe('/protected');
   });
 
   it('redirects to the two-factor route on 401 with RequiresTwoFactor detail', async () => {
@@ -130,7 +114,7 @@ describe('SparkLoginComponent', () => {
     await component.onSubmit();
     await navigated;
 
-    expect(TestBed.inject(Location).path()).toBe('/login/two-factor?returnUrl=%2Fprotected');
+    expect(TestBed.inject(Router).url).toBe('/login/two-factor?returnUrl=%2Fprotected');
   });
 
   it('shows the invalid-credentials error on a generic 401 (no navigation)', async () => {
@@ -143,6 +127,6 @@ describe('SparkLoginComponent', () => {
     await component.onSubmit();
 
     expect(component.errorMessage()).toBe('auth.invalidCredentials');
-    expect(TestBed.inject(Location).path()).toBe('/login');
+    expect(TestBed.inject(Router).url).toBe('/login');
   });
 });

--- a/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
+++ b/node_packages/ng-spark-auth/register/src/spark-register.component.spec.ts
@@ -1,17 +1,13 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { HttpErrorResponse } from '@angular/common/http';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkRegisterComponent } from './spark-register.component';
 import { SparkAuthService, SparkAuthTranslationService } from '@mintplayer/ng-spark-auth/core';
 import { SPARK_AUTH_ROUTE_PATHS } from '@mintplayer/ng-spark-auth/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const routePaths = {
   login: '/login', twoFactor: '/login/two-factor', register: '/register',
@@ -22,11 +18,6 @@ const routes: Routes = [
   { path: 'login', component: StubComponent },
   { path: 'register', component: SparkRegisterComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { register: vi.fn().mockResolvedValue(undefined), ...authOverrides };

--- a/node_packages/ng-spark-auth/src/test-utils.ts
+++ b/node_packages/ng-spark-auth/src/test-utils.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, firstValueFrom } from 'rxjs';
+
+/**
+ * Empty standalone component for use as a destination route in RouterTestingHarness setups.
+ * Avoids per-spec re-declaration when only navigation outcomes are asserted.
+ */
+@Component({ standalone: true, template: '' })
+export class StubComponent {}
+
+/**
+ * Resolves with the next NavigationEnd Router emits.
+ *
+ * Components in this codebase fire-and-forget `router.navigate*(...)` without awaiting
+ * the returned Promise, so a method that triggers navigation resolves before the URL
+ * actually changes. Subscribe to this BEFORE calling the trigger:
+ *
+ *   const navigated = nextNavigationEnd();
+ *   await component.onSubmit();
+ *   await navigated;
+ *   expect(TestBed.inject(Router).url).toBe(...);
+ *
+ * Reliable across zoneless mode where harness.fixture.whenStable() alone wasn't enough.
+ */
+export function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(
+    router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)),
+  );
+}

--- a/node_packages/ng-spark-auth/tsconfig.lib.json
+++ b/node_packages/ng-spark-auth/tsconfig.lib.json
@@ -31,6 +31,8 @@
   ],
   "exclude": [
     "**/*.spec.ts",
+    "src/test-setup.ts",
+    "src/test-utils.ts",
     "dist/**",
     "out-tsc/**",
     "node_modules/**"

--- a/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
+++ b/node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.spec.ts
@@ -1,8 +1,6 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, provideRouter, Router, Routes } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkTwoFactorComponent } from './spark-two-factor.component';
@@ -12,9 +10,7 @@ import {
   SPARK_AUTH_ROUTE_PATHS,
   defaultSparkAuthConfig,
 } from '@mintplayer/ng-spark-auth/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const routePaths = {
   login: '/login', twoFactor: '/login/two-factor', register: '/register',
@@ -25,11 +21,6 @@ const routes: Routes = [
   { path: 'login/two-factor', component: SparkTwoFactorComponent },
   { path: 'dashboard', component: StubComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup(authOverrides: Partial<SparkAuthService> = {}) {
   const auth: any = { loginTwoFactor: vi.fn().mockResolvedValue(undefined), ...authOverrides };

--- a/node_packages/ng-spark/po-create/src/spark-po-create.component.spec.ts
+++ b/node_packages/ng-spark/po-create/src/spark-po-create.component.spec.ts
@@ -1,17 +1,13 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter, Router, Routes, NavigationEnd } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { HttpErrorResponse } from '@angular/common/http';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkPoCreateComponent } from './spark-po-create.component';
 import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
 import { EntityType, ShowedOn } from '@mintplayer/ng-spark/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const personType: EntityType = {
   id: 't-person',
@@ -41,11 +37,6 @@ const routes: Routes = [
   { path: 'po/:type/new', component: SparkPoCreateComponent },
   { path: 'po/:type/:id', component: StubComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup(serviceOverrides: Partial<SparkService> = {}) {
   const service: any = {

--- a/node_packages/ng-spark/po-create/src/spark-po-create.component.spec.ts
+++ b/node_packages/ng-spark/po-create/src/spark-po-create.component.spec.ts
@@ -1,0 +1,150 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, Routes, NavigationEnd } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { filter, firstValueFrom } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkPoCreateComponent } from './spark-po-create.component';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { EntityType, ShowedOn } from '@mintplayer/ng-spark/models';
+
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
+const personType: EntityType = {
+  id: 't-person',
+  name: 'Person',
+  alias: 'person',
+  clrType: 'Test.Person',
+  attributes: [
+    {
+      id: 'a-first', name: 'FirstName', dataType: 'string',
+      isRequired: true, isVisible: true, isReadOnly: false,
+      order: 1, showedOn: ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-active', name: 'Active', dataType: 'boolean',
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 2, showedOn: ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-jobs', name: 'Jobs', dataType: 'AsDetail', isArray: true,
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 3, showedOn: ShowedOn.PersistentObject,
+    } as any,
+  ],
+} as any;
+
+const routes: Routes = [
+  { path: 'po/:type/new', component: SparkPoCreateComponent },
+  { path: 'po/:type/:id', component: StubComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getEntityTypes: vi.fn().mockResolvedValue([personType]),
+    create: vi.fn().mockResolvedValue({ id: 'people/new-1', name: 'Created' }),
+    ...serviceOverrides,
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      provideRouter(routes),
+      { provide: SparkService, useValue: service },
+      { provide: SparkLanguageService, useValue: { t: (k: string) => k } },
+    ],
+  });
+  const harness = await RouterTestingHarness.create();
+  return { harness, service };
+}
+
+describe('SparkPoCreateComponent', () => {
+  it('loads entity type from the route param and initializes form data per dataType', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/person/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.entityType()?.name).toBe('Person');
+    const data = c.formData();
+    expect(data['FirstName']).toBe('');
+    expect(data['Active']).toBe(false);
+    expect(data['Jobs']).toEqual([]);
+  });
+
+  it('resolves entity type by alias OR id', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/t-person/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.entityType()?.id).toBe('t-person');
+  });
+
+  it('onSave is a no-op when no entityType resolved', async () => {
+    const { harness, service } = await setup({ getEntityTypes: vi.fn().mockResolvedValue([]) });
+    const c = await harness.navigateByUrl('/po/unknown/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+
+    await c.onSave();
+
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('onSave creates the PO, emits saved, and navigates to the detail route', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+    c.formData.set({ ...c.formData(), FirstName: 'Alice', Active: true, Jobs: [] });
+
+    const saved = vi.fn();
+    c.saved.subscribe(saved);
+
+    const navigated = nextNavigationEnd();
+    await c.onSave();
+    await navigated;
+
+    expect(service.create).toHaveBeenCalledOnce();
+    const [type, payload] = (service.create as any).mock.calls[0];
+    expect(type).toBe('person');
+    expect(payload.objectTypeId).toBe('t-person');
+    expect(payload.attributes.find((a: any) => a.name === 'FirstName').value).toBe('Alice');
+
+    expect(saved).toHaveBeenCalledWith({ id: 'people/new-1', name: 'Created' });
+    expect(TestBed.inject(Router).url).toBe('/po/person/people%2Fnew-1');
+    expect(c.isSaving()).toBe(false);
+  });
+
+  it('onSave 400 error populates validationErrors from the server payload', async () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { errors: [{ attributeName: 'FirstName', errorMessage: { en: 'Required' }, ruleType: 'required' }] },
+    });
+    const { harness } = await setup({ create: vi.fn().mockRejectedValue(error) });
+    const c = await harness.navigateByUrl('/po/person/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+
+    await c.onSave();
+
+    expect(c.validationErrors()).toHaveLength(1);
+    expect(c.validationErrors()[0].attributeName).toBe('FirstName');
+    expect(c.isSaving()).toBe(false);
+  });
+
+  it('onSave non-400 error sets a single generic error', async () => {
+    const { harness } = await setup({ create: vi.fn().mockRejectedValue(new Error('boom')) });
+    const c = await harness.navigateByUrl('/po/person/new', SparkPoCreateComponent);
+    await harness.fixture.whenStable();
+
+    await c.onSave();
+
+    const errors = c.validationErrors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].attributeName).toBe('');
+    expect(c.generalErrors()).toEqual(errors);
+  });
+});

--- a/node_packages/ng-spark/po-edit/src/spark-po-edit.component.spec.ts
+++ b/node_packages/ng-spark/po-edit/src/spark-po-edit.component.spec.ts
@@ -1,18 +1,14 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter, Router, Routes, NavigationEnd } from '@angular/router';
+import { provideRouter, Router, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { HttpErrorResponse } from '@angular/common/http';
-import { filter, firstValueFrom } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SparkPoEditComponent } from './spark-po-edit.component';
 import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
 import { EntityType, PersistentObject, ShowedOn } from '@mintplayer/ng-spark/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
 
 const personType: EntityType = {
   id: 't-person',
@@ -47,11 +43,6 @@ const routes: Routes = [
   { path: 'po/:type/:id/edit', component: SparkPoEditComponent },
   { path: 'po/:type/:id', component: StubComponent },
 ];
-
-function nextNavigationEnd(): Promise<NavigationEnd> {
-  const router = TestBed.inject(Router);
-  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
-}
 
 async function setup(serviceOverrides: Partial<SparkService> = {}) {
   const service: any = {

--- a/node_packages/ng-spark/po-edit/src/spark-po-edit.component.spec.ts
+++ b/node_packages/ng-spark/po-edit/src/spark-po-edit.component.spec.ts
@@ -1,0 +1,167 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, Routes, NavigationEnd } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { HttpErrorResponse } from '@angular/common/http';
+import { filter, firstValueFrom } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkPoEditComponent } from './spark-po-edit.component';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { EntityType, PersistentObject, ShowedOn } from '@mintplayer/ng-spark/models';
+
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
+const personType: EntityType = {
+  id: 't-person',
+  name: 'Person',
+  alias: 'person',
+  clrType: 'Test.Person',
+  attributes: [
+    {
+      id: 'a-first', name: 'FirstName', dataType: 'string',
+      isRequired: true, isVisible: true, isReadOnly: false,
+      order: 1, showedOn: ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-last', name: 'LastName', dataType: 'string',
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 2, showedOn: ShowedOn.PersistentObject,
+    } as any,
+  ],
+} as any;
+
+const existingItem: PersistentObject = {
+  id: 'people/1',
+  name: 'Alice Smith',
+  objectTypeId: 't-person',
+  attributes: [
+    { id: 'a-first', name: 'FirstName', value: 'Alice' } as any,
+    { id: 'a-last', name: 'LastName', value: 'Smith' } as any,
+  ],
+} as any;
+
+const routes: Routes = [
+  { path: 'po/:type/:id/edit', component: SparkPoEditComponent },
+  { path: 'po/:type/:id', component: StubComponent },
+];
+
+function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)));
+}
+
+async function setup(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getEntityTypes: vi.fn().mockResolvedValue([personType]),
+    get: vi.fn().mockResolvedValue(existingItem),
+    update: vi.fn().mockResolvedValue({ id: 'people/1', name: 'Updated' }),
+    ...serviceOverrides,
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      provideRouter(routes),
+      { provide: SparkService, useValue: service },
+      { provide: SparkLanguageService, useValue: { t: (k: string) => k } },
+    ],
+  });
+  const harness = await RouterTestingHarness.create();
+  return { harness, service };
+}
+
+describe('SparkPoEditComponent', () => {
+  it('fetches entity type + existing item and prefills form data', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+
+    expect(service.getEntityTypes).toHaveBeenCalled();
+    expect(service.get).toHaveBeenCalledWith('person', 'people/1');
+    expect(c.entityType()?.name).toBe('Person');
+    expect(c.formData()).toEqual({ FirstName: 'Alice', LastName: 'Smith' });
+  });
+
+  it('records load failure as a general validation error', async () => {
+    const { harness } = await setup({
+      get: vi.fn().mockRejectedValue(new HttpErrorResponse({ status: 404, error: { error: 'Not found' } })),
+    });
+    const c = await harness.navigateByUrl('/po/person/people%2Fmissing/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+
+    const errors = c.validationErrors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].attributeName).toBe('');
+  });
+
+  it('onSave is a no-op when no item loaded', async () => {
+    const { harness, service } = await setup({
+      get: vi.fn().mockRejectedValue(new Error('no item')),
+    });
+    const c = await harness.navigateByUrl('/po/person/people%2F1/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+
+    await c.onSave();
+
+    expect(service.update).not.toHaveBeenCalled();
+  });
+
+  it('onSave updates with the new form values, emits saved, navigates to detail', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+    c.formData.set({ ...c.formData(), FirstName: 'Alicia' });
+
+    const saved = vi.fn();
+    c.saved.subscribe(saved);
+
+    const navigated = nextNavigationEnd();
+    await c.onSave();
+    await navigated;
+
+    expect(service.update).toHaveBeenCalledOnce();
+    const [, , payload] = (service.update as any).mock.calls[0];
+    const firstAttr = payload.attributes.find((a: any) => a.name === 'FirstName');
+    expect(firstAttr.value).toBe('Alicia');
+    expect(firstAttr.isValueChanged).toBe(true);
+    const lastAttr = payload.attributes.find((a: any) => a.name === 'LastName');
+    expect(lastAttr.isValueChanged).toBe(false);
+
+    expect(saved).toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/po/person/people%2F1');
+    expect(c.isSaving()).toBe(false);
+  });
+
+  it('onSave 400 error populates validationErrors from the server payload', async () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { errors: [{ attributeName: 'FirstName', errorMessage: { en: 'Required' }, ruleType: 'required' }] },
+    });
+    const { harness } = await setup({ update: vi.fn().mockRejectedValue(error) });
+    const c = await harness.navigateByUrl('/po/person/people%2F1/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+
+    await c.onSave();
+
+    expect(c.validationErrors()[0].attributeName).toBe('FirstName');
+    expect(c.isSaving()).toBe(false);
+  });
+
+  it('onCancel navigates back to detail', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1/edit', SparkPoEditComponent);
+    await harness.fixture.whenStable();
+
+    const cancelled = vi.fn();
+    c.cancelled.subscribe(cancelled);
+
+    const navigated = nextNavigationEnd();
+    c.onCancel();
+    await navigated;
+
+    expect(cancelled).toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/po/person/people%2F1');
+  });
+});

--- a/node_packages/ng-spark/query-list/src/spark-query-list.component.spec.ts
+++ b/node_packages/ng-spark/query-list/src/spark-query-list.component.spec.ts
@@ -1,4 +1,3 @@
-import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Routes } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
@@ -11,9 +10,7 @@ import { SparkQueryListComponent } from './spark-query-list.component';
 import { SparkService, SparkStreamingService } from '@mintplayer/ng-spark/services';
 import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
 import { EntityType, PersistentObject, ShowedOn, SparkQuery } from '@mintplayer/ng-spark/models';
-
-@Component({ standalone: true, template: '' })
-class StubComponent {}
+import { StubComponent } from '../../src/test-utils';
 
 const personType: EntityType = {
   id: 't-person',

--- a/node_packages/ng-spark/query-list/src/spark-query-list.component.spec.ts
+++ b/node_packages/ng-spark/query-list/src/spark-query-list.component.spec.ts
@@ -1,0 +1,202 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkQueryListComponent } from './spark-query-list.component';
+import { SparkService, SparkStreamingService } from '@mintplayer/ng-spark/services';
+import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
+import { EntityType, PersistentObject, ShowedOn, SparkQuery } from '@mintplayer/ng-spark/models';
+
+@Component({ standalone: true, template: '' })
+class StubComponent {}
+
+const personType: EntityType = {
+  id: 't-person',
+  name: 'Person',
+  alias: 'person',
+  clrType: 'Test.Person',
+  attributes: [
+    {
+      id: 'a-first', name: 'FirstName', dataType: 'string',
+      isVisible: true, isReadOnly: false, isRequired: false,
+      order: 1, showedOn: ShowedOn.Query | ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-internal', name: 'Internal', dataType: 'string',
+      isVisible: false, isReadOnly: false, isRequired: false,
+      order: 2, showedOn: ShowedOn.Query,
+    } as any,
+    {
+      id: 'a-detail-only', name: 'DetailOnly', dataType: 'string',
+      isVisible: true, isReadOnly: false, isRequired: false,
+      order: 3, showedOn: ShowedOn.PersistentObject,
+    } as any,
+  ],
+} as any;
+
+const allPeopleQuery: SparkQuery = {
+  id: 'q-all',
+  name: 'AllPeople',
+  source: 'Database.People',
+  alias: 'allpeople',
+  sortColumns: [],
+  renderMode: 'Standard',
+  isStreamingQuery: false,
+} as any;
+
+const routes: Routes = [
+  { path: 'query/:queryId', component: SparkQueryListComponent },
+  { path: 'po/:type', component: SparkQueryListComponent },
+  { path: 'po/:type/new', component: StubComponent },
+];
+
+const samplePage = {
+  data: [
+    { id: 'people/1', name: 'Alice', objectTypeId: 't-person', attributes: [] } as any,
+  ],
+  totalRecords: 1,
+};
+
+async function setup(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getEntityTypes: vi.fn().mockResolvedValue([personType]),
+    getQueries: vi.fn().mockResolvedValue([allPeopleQuery]),
+    getQuery: vi.fn().mockResolvedValue(allPeopleQuery),
+    getPermissions: vi.fn().mockResolvedValue({ canRead: true, canCreate: true, canUpdate: true, canDelete: true }),
+    executeQuery: vi.fn().mockResolvedValue(samplePage),
+    getLookupReference: vi.fn().mockResolvedValue({ values: [] }),
+    ...serviceOverrides,
+  };
+  const streaming: any = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      provideRouter(routes),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: SparkService, useValue: service },
+      { provide: SparkStreamingService, useValue: streaming },
+      { provide: SPARK_ATTRIBUTE_RENDERERS, useValue: [] },
+    ],
+  });
+  const harness = await RouterTestingHarness.create();
+  return { harness, service };
+}
+
+describe('SparkQueryListComponent', () => {
+  it('loads query by queryId route param and resolves matching entity type', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    expect(service.getQuery).toHaveBeenCalledWith('q-all');
+    expect(c.query()?.id).toBe('q-all');
+    expect(c.entityType()?.name).toBe('Person');
+  });
+
+  it('loads query by entity type alias and finds the matching query for it', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    expect(service.getEntityTypes).toHaveBeenCalled();
+    expect(service.getQueries).toHaveBeenCalled();
+    expect(c.entityType()?.name).toBe('Person');
+    expect(c.query()?.id).toBe('q-all');
+  });
+
+  it('hydrates canRead/canCreate from getPermissions', async () => {
+    const { harness } = await setup({
+      getPermissions: vi.fn().mockResolvedValue({ canRead: true, canCreate: false, canUpdate: false, canDelete: false }),
+    });
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.canRead()).toBe(true);
+    expect(c.canCreate()).toBe(false);
+  });
+
+  it('executes the query on initial load and stores the page in paginationData', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    expect(service.executeQuery).toHaveBeenCalledOnce();
+    const page = c.paginationData();
+    expect(page?.data).toHaveLength(1);
+    expect(page?.totalRecords).toBe(1);
+  });
+
+  it('visibleAttributes filters out non-visible and detail-only attributes', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    const visible = c.visibleAttributes();
+    expect(visible.map((a: any) => a.name)).toEqual(['FirstName']);
+  });
+
+  it('isVirtualScrolling reflects query renderMode', async () => {
+    const virtualQuery = { ...allPeopleQuery, id: 'q-virt', renderMode: 'VirtualScrolling' } as any;
+    const { harness } = await setup({
+      getQuery: vi.fn().mockResolvedValue(virtualQuery),
+    });
+    const c = await harness.navigateByUrl('/query/q-virt', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.isVirtualScrolling()).toBe(true);
+  });
+
+  it('onSearchChange refetches with the current searchTerm', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+    (service.executeQuery as any).mockClear();
+
+    c.searchTerm = 'alice';
+    c.onSearchChange();
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(service.executeQuery).toHaveBeenCalledOnce();
+    const opts = (service.executeQuery as any).mock.calls[0][1];
+    expect(opts.search).toBe('alice');
+  });
+
+  it('clearSearch resets searchTerm and triggers a reload', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+    c.searchTerm = 'alice';
+    (service.executeQuery as any).mockClear();
+
+    c.clearSearch();
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(c.searchTerm).toBe('');
+    expect(service.executeQuery).toHaveBeenCalledOnce();
+    const opts = (service.executeQuery as any).mock.calls[0][1];
+    expect(opts.search).toBeUndefined();
+  });
+
+  it('rowClicked output emits when a row is clicked', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/query/q-all', SparkQueryListComponent);
+    await harness.fixture.whenStable();
+
+    const handler = vi.fn();
+    c.rowClicked.subscribe(handler);
+
+    const item: PersistentObject = { id: 'people/1', name: 'A', objectTypeId: 't-person', attributes: [] } as any;
+    c.rowClicked.emit(item);
+
+    expect(handler).toHaveBeenCalledWith(item);
+  });
+});

--- a/node_packages/ng-spark/src/test-utils.ts
+++ b/node_packages/ng-spark/src/test-utils.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, firstValueFrom } from 'rxjs';
+
+/**
+ * Empty standalone component for use as a destination route in RouterTestingHarness setups.
+ * Avoids per-spec re-declaration when only navigation outcomes are asserted.
+ */
+@Component({ standalone: true, template: '' })
+export class StubComponent {}
+
+/**
+ * Resolves with the next NavigationEnd Router emits.
+ *
+ * Components in this codebase fire-and-forget `router.navigate*(...)` without awaiting
+ * the returned Promise, so a method that triggers navigation resolves before the URL
+ * actually changes. Subscribe to this BEFORE calling the trigger:
+ *
+ *   const navigated = nextNavigationEnd();
+ *   await component.onSave();
+ *   await navigated;
+ *   expect(TestBed.inject(Router).url).toBe(...);
+ *
+ * Reliable across zoneless mode where harness.fixture.whenStable() alone wasn't enough.
+ */
+export function nextNavigationEnd(): Promise<NavigationEnd> {
+  const router = TestBed.inject(Router);
+  return firstValueFrom(
+    router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)),
+  );
+}

--- a/node_packages/ng-spark/tsconfig.lib.json
+++ b/node_packages/ng-spark/tsconfig.lib.json
@@ -31,6 +31,8 @@
   ],
   "exclude": [
     "**/*.spec.ts",
+    "src/test-setup.ts",
+    "src/test-utils.ts",
     "dist/**",
     "out-tsc/**",
     "node_modules/**"


### PR DESCRIPTION
## Summary

L3 first batch — covers the three lighter ng-spark form/list components. **+21 tests; ng-spark goes 92 → 113/113 green. Total monorepo 322** (156 .NET + 53 ng-spark-auth + 113 ng-spark — was 301).

### Tests added (21)

| Component | Count | What |
|---|---|---|
| \`SparkPoCreateComponent\` | 6 | Route param → entity type + per-dataType form-data init; alias/id resolution; onSave success → emit + navigate; 400 → validationErrors; non-400 → generic error |
| \`SparkPoEditComponent\` | 6 | Loads type + existing item, prefills form; load failure recorded; onSave update with isValueChanged tracked per-attr; 400 errors; onCancel emits + navigates |
| \`SparkQueryListComponent\` | 9 | Load by queryId or by entity-type alias; permissions; executeQuery on init; visibleAttributes/isVirtualScrolling computed; onSearchChange/clearSearch refetch; rowClicked output |

### Patterns established / reaffirmed

- \`RouterTestingHarness\` everywhere navigation is tested (per the Angular routing-testing guide — same as PR #106).
- **\`provideNoopAnimations()\`** required for components using synthetic animations (\`SparkPoEditComponent\` has \`@fadeInOut\` on its error message).
- **\`provideHttpClient() + provideHttpClientTesting()\`** required when injecting tree-shakable services that auto-fetch on construction (\`SparkLanguageService\` hits \`/spark/culture\` and \`/spark/translations\`).
- Mock \`SparkService\` with plain \`vi.fn()\` — no need for \`HttpTestingController\` flush dance since the component never invokes \`HttpClient\` directly.

### Scoped out (deferred to follow-up batches)

- **\`SparkPoFormComponent\`** — the heart of CRUD; signals + effects + multi-way data flow. Deserves its own focused batch.
- **\`SparkPoDetailComponent\`** + \`SparkSubQueryComponent\` — sub-queries and custom-action invocation are non-trivial integration surface.
- \`SparkQueryListComponent\` virtual scrolling, streaming WebSocket, parent-context sub-queries — smoke-tested above; depth tests later.

## Test plan

- [x] \`npx vitest run\` in \`node_packages/ng-spark/\` → 113/113 pass
- [x] Three-project Nx sweep → 322 total green
- [ ] CI \`nx affected --target=test\` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)