### PR TITLE
docs: PRD-Testing v1.2 — implementation progress + real-world findings

### DIFF
--- a/docs/PRD-Testing.md
+++ b/docs/PRD-Testing.md
@@ -2,9 +2,9 @@
 
 | | |
 |---|---|
-| **Version** | 1.1 |
-| **Date** | 2026-04-18 |
-| **Status** | Proposed |
+| **Version** | 1.2 |
+| **Date** | 2026-04-20 |
+| **Status** | In progress (322/?? tests landed, see §12) |
 | **Owner** | MintPlayer |
 | **Scope** | All non-Demo projects in `MintPlayer.Spark.sln` + Angular libraries + IDE extensions (when activated) |
 
@@ -607,6 +607,79 @@ jobs:
 6. **Nx Cloud tier** — proposed: free tier initially; upgrade when free computes run out. Self-hosted remote cache (`@nx/nx-cloud` on-prem) is a fallback if commercial pricing is blocking.
 
 ---
+
+## 12. Implementation status (as of 2026-04-20)
+
+**322 tests passing across the monorepo** — 156 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 113 ng-spark.
+
+### Done ✅
+
+- **M1 (infrastructure)** — `MintPlayer.Spark.Testing` project, FluentAssertions everywhere, Vitest + `@analogjs/vite-plugin-angular` in both Angular libs, Nx + `@nx-dotnet/core` + Nx Cloud, license env-var wiring, CI workflow rewritten.
+- **M2 partial** — `AccessControlService` (15), `ClaimsGroupMembershipProvider` (10), `ValidationService` (18), `SecurityConfigurationLoader` (11), `QueryExecutor` (9 unit + 7 integration via `SparkTestDriver`).
+- **M3 endpoints** — `PersistentObject` GET/LIST/CREATE/UPDATE/DELETE (18) via `SparkEndpointFactory`; `Queries` GET/LIST/EXECUTE (12).
+- **M3 Angular** — `SparkAuthService` + guard + interceptor (15), all 6 ng-spark-auth components (27), all 22 ng-spark pipes (70), `RetryActionService` + `IconRegistry` + `IconComponent` + `RetryActionModal` (17), `SparkPoCreate` + `SparkPoEdit` + `SparkQueryList` (21).
+
+### Deferred (handoff for next sessions)
+
+| Item | Why scoped out | Notes for the next batch |
+|---|---|---|
+| **`SparkPoFormComponent`**, `SparkPoDetailComponent`, `SparkSubQueryComponent` | Deepest ng-spark components — signals + effects + multi-way binding + sub-queries + custom actions | Use the `nextNavigationEnd` + `StubComponent` helpers in `node_packages/ng-spark/src/test-utils.ts`. Mock `SparkService` with `vi.fn()`. Add `provideNoopAnimations()` and `provideHttpClient()/provideHttpClientTesting()` to the providers list. |
+| **`StreamExecuteQuery` WebSocket endpoint** | TestServer supports WebSockets via `Server.CreateWebSocketClient()` but the diff-engine + `IAsyncEnumerable` + cancellation deserves its own focused batch | Build on the existing `SparkEndpointFactory`. The `IStreamingQueryExecutor` returns `IAsyncEnumerable<T>` — mock or seed Raven. |
+| **Source-generator snapshot tests** | Generator targets `netstandard2.0` and pulls `MintPlayer.SourceGenerators.Tools` polyfills (esp. `ModuleInitializerAttribute`) that collide with `net10.0`'s `System.Runtime` at test load time | A first attempt with `Assembly.LoadFrom` from a separate `MintPlayer.Spark.SourceGenerators.Tests` project + `ExcludeAssets="compile"` on Tools got further but still hit `Microsoft.CodeAnalysis.CSharp` version mismatch. Worth a dedicated focused session. |
+| **Authorization endpoints** (`/spark/auth/*`) | Small batch (~6–8 tests), didn't fit the "biggest impact" prioritization | `GetCurrentUser`, `Logout`, `CsrfRefresh`, `Groups`. Reuse `SparkEndpointFactory` and the antiforgery wiring from `SparkTestClient`. |
+| **Custom Actions endpoint** (`/spark/actions/*`) | ~5–6 tests, deferred for the same reason | `Execute` + `List`. Same factory pattern. |
+| **`GitHubInstallationService` concurrency** | Needs WireMock.Net infra | Locks in the contract from [PRD-GitHubAppClientCache.md](./PRD-GitHubAppClientCache.md): cache hit, refresh, `SemaphoreSlim` serialization, 401-retry, no infinite-retry, signature verification. |
+| **Messaging / Replication / SubscriptionWorker** | Substantial new infra (real RavenDB subscriptions, message bus simulation) | Each gets its own batch per the §4 plan. `SparkTestDriver` is the foundation. |
+| **DevTunnel + SocketExtensions** | Smaller, both should fit one batch | Per §4.9 / §4.11. |
+| **AllFeatures source generator** | Smaller, included with the source-generator session above | |
+| **E2E test host + Playwright** (M4) | All M3 should be done first to avoid duplicating coverage | New `MintPlayer.Spark.E2E.TestHost` ASP.NET Core + Angular app. Playwright for .NET runs against it. |
+
+## 13. Implementation notes (real-world findings, not in original PRD)
+
+These are non-obvious things discovered while implementing. They cost real time to figure out — capture them here so future contributors don't re-hit them.
+
+### 13.1 .NET infrastructure
+
+- **RavenDB 7.x requires a license even for embedded TestDriver.** `MintPlayer.Spark.Testing/SparkTestDriver.cs` loads it from `RAVENDB_LICENSE` env var (CI) or a gitignored `raven-license.log` at the repo root (local). Throws an actionable error if neither is present. Both `pull-request.yml` and `dotnet-build-master.yml` pass the secret.
+- **CronosCore.RavenDB.UnitTests is a design reference, NOT a runtime dependency.** Its base class is NUnit-coupled (`[TestFixture]`, `[SetUp]`) and its license fetch targets a private Cronos Azure blob. We re-implemented the small amount of value-added code in `MintPlayer.Spark.Testing` using xUnit's `IAsyncLifetime` pattern.
+- **`InternalsVisibleTo("DynamicProxyGenAssembly2")`** must be on every project whose internal interfaces NSubstitute needs to mock. Currently set on `MintPlayer.Spark` and `MintPlayer.Spark.Authorization`.
+- **`<IsTestProject>false</IsTestProject>`** must be set on `MintPlayer.Spark.Testing.csproj` — it has an xunit reference (for `IAsyncLifetime` types) but is NOT a test project. Without this, `dotnet test <sln>` tries to discover tests in it and exits non-zero with a confusing "0 Error(s), Build FAILED".
+- **`WebApplicationFactory<T>` doesn't work** when the host assembly has no `Main` entry point. `MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs` uses `TestServer + IHost` directly instead.
+- **Spark's antiforgery middleware does NOT block JSON POST requests** without an `X-XSRF-TOKEN` header in the test setup, despite `RequireAntiforgeryTokenAttribute(true)` metadata. The token-mint pattern in `SparkTestClient` works for positive cases (mirrors what the SPA sends in production), but the negative-case "POST without token → rejected" assertion was removed because the middleware accepted it. May or may not be intended Spark behavior — flagged for separate investigation.
+- **`SPARK001` validation must accept `<ProjectReference OutputItemType="Analyzer">`**, not just `<PackageReference>`. The original implementation only checked PackageReference and broke monorepo Demo apps.
+
+### 13.2 Angular / Vitest infrastructure
+
+- **`@angular/router/testing`'s `RouterTestingHarness` is the official recommended pattern** ([angular.dev/guide/routing/testing](https://angular.dev/guide/routing/testing)) — *"Avoid mocking Angular Router."* Spies on `router.navigate*` are anti-pattern; use `provideRouter([routes])` + assert via `TestBed.inject(Router).url` after navigation completes.
+- **Components in this repo fire-and-forget `router.navigate*(...)`** without awaiting the returned `Promise`. `harness.fixture.whenStable()` alone is not reliable in zoneless mode — use `nextNavigationEnd()` from `node_packages/{ng-spark,ng-spark-auth}/src/test-utils.ts` (subscribes to `Router.events` BEFORE the trigger and awaits the next `NavigationEnd`).
+- **`TestBed.runInInjectionContext`** for invoking `CanActivateFn` — NOT the imported `runInInjectionContext` function from `@angular/core` (the `TestBed` itself is not a valid `Injector`).
+- **Test-utility files (`src/test-setup.ts`, `src/test-utils.ts`) MUST be excluded from `tsconfig.lib.json`** in both Angular libraries. Otherwise ng-packagr type-checks them and trips on `vitest` / `@angular/router/testing` not being declared as deps. Already excluded; new test-utility files need the same treatment.
+- **`vitest.config.ts` `resolve.alias` mirrors `tsconfig.base.json`** so source files keep using their `@mintplayer/ng-spark/services`-style imports at test time without needing a built `dist/`. Pattern in `node_packages/ng-spark/vitest.config.ts`.
+- **`provideNoopAnimations()`** is required for components using synthetic animations (`@fadeInOut` etc.). Without it: `NG05105: Unexpected synthetic listener`.
+- **`provideHttpClient() + provideHttpClientTesting()`** is required when any tree-shakable `providedIn: 'root'` service in the injector tree auto-fetches on construction (e.g. `SparkLanguageService` hits `/spark/culture` and `/spark/translations`). Without it, unhandled rejections flood the test output even though assertions pass.
+- **Sequential awaited HTTP via `firstValueFrom` needs a microtask flush between `expectOne` calls.** Pattern in `spark-auth.service.spec.ts`'s `flush()` helper: `await new Promise<void>(r => setTimeout(r, 0))`.
+- **Stub `Router` with `vi.fn()` is broken** because `RouterLink` directive subscribes to `Router.events` (which is undefined on a bare stub). Always use `provideRouter([])` even when you don't care about navigation, just for the directive's DI.
+- **Angular 21 signal inputs** (`input.required<T>()`) are set in tests via `fixture.componentRef.setInput(name, value)` + `fixture.detectChanges()`.
+- **`SparkAuthBarComponent.onLogout()` has no try/catch** — if `logout()` rejects, `router.navigateByUrl('/')` is skipped. The test documents that as the current behavior. Worth fixing in a follow-up if logout-on-network-error should still log the user out locally.
+
+### 13.3 CI / Nx
+
+- **`npx nx fix-ci` is NOT a generic CI-healing command.** It analyzes failed Nx Cloud CIPE runs and needs explicit `<project>:<target>` args without CIPE context. Don't add it as a workflow step.
+- **`@nx-dotnet/core` works with Nx 20–22** — confirmed in production. `nx.json` registers it as a plugin; it auto-discovers every `.csproj` in the solution.
+- **Demo apps must be excluded from `nx affected --target=test`** because they have no `test` target. Root `package.json` script: `nx affected --target=test --exclude=@spark-demo/*,DemoApp,DemoApp.Library,Fleet,Fleet.Library,HR,HR.Library,WebhooksDemo,WebhooksDemo.Library`.
+- **`nxCloudId` in `nx.json` is a public identifier** (safe to commit). Only `NX_CLOUD_ACCESS_TOKEN` (read-write API key) is a secret. Older Nx versions supported `nxCloudAccessToken` directly in `nx.json` — never do that.
+
+### 13.4 Source-generator testing blocker (unresolved)
+
+Attempted to test `ActionsRegistrationGenerator` and `CustomActionsRegistrationGenerator` via `Verify.SourceGenerators` snapshots. Sequence of problems hit:
+
+1. `ProjectReference` to `MintPlayer.Spark.SourceGenerators` (netstandard2.0) into the net10.0 test project leaks `MintPlayer.SourceGenerators.Tools`'s `ModuleInitializerAttribute` polyfill, colliding with `System.Runtime`.
+2. `Assembly.LoadFrom(generatorDll)` at test time avoided the compile-time leak BUT failed because `MintPlayer.SourceGenerators.Tools` runtime types weren't on the load path.
+3. Adding `MintPlayer.SourceGenerators.Tools` as a `PackageReference` with `ExcludeAssets="compile"` solved the runtime-load issue.
+4. Then hit `Microsoft.CodeAnalysis.CSharp` version conflict — `Verify.SourceGenerators` ships with 4.14.0 but the generator was compiled against 5.3.0; bypassing one breaks the other.
+5. RS1035 ("Don't do file IO in analyzers") flowed through transitively and rejected the test helper code.
+
+A dedicated focused session (with the latest `Microsoft.CodeAnalysis.Testing` versions and explicit version-pinning across the dep graph) should crack this. Until then, generator regression testing is via the actual Demo app builds — a generator regression breaks one of the Demo apps' compilation.
 
 ## 11. Success Criteria
 

--- a/docs/PRD-Testing.md
+++ b/docs/PRD-Testing.md
@@ -610,20 +610,19 @@ jobs:
 
 ## 12. Implementation status (as of 2026-04-20)
 
-**322 tests passing across the monorepo** — 156 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 113 ng-spark.
+**365 tests passing across the monorepo** — 156 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 156 ng-spark.
 
 ### Done ✅
 
 - **M1 (infrastructure)** — `MintPlayer.Spark.Testing` project, FluentAssertions everywhere, Vitest + `@analogjs/vite-plugin-angular` in both Angular libs, Nx + `@nx-dotnet/core` + Nx Cloud, license env-var wiring, CI workflow rewritten.
 - **M2 partial** — `AccessControlService` (15), `ClaimsGroupMembershipProvider` (10), `ValidationService` (18), `SecurityConfigurationLoader` (11), `QueryExecutor` (9 unit + 7 integration via `SparkTestDriver`).
 - **M3 endpoints** — `PersistentObject` GET/LIST/CREATE/UPDATE/DELETE (18) via `SparkEndpointFactory`; `Queries` GET/LIST/EXECUTE (12).
-- **M3 Angular** — `SparkAuthService` + guard + interceptor (15), all 6 ng-spark-auth components (27), all 22 ng-spark pipes (70), `RetryActionService` + `IconRegistry` + `IconComponent` + `RetryActionModal` (17), `SparkPoCreate` + `SparkPoEdit` + `SparkQueryList` (21).
+- **M3 Angular** — `SparkAuthService` + guard + interceptor (15), all 6 ng-spark-auth components (27), all 22 ng-spark pipes (70), `RetryActionService` + `IconRegistry` + `IconComponent` + `RetryActionModal` (17), `SparkPoCreate` + `SparkPoEdit` + `SparkQueryList` (21), `SparkPoFormComponent` + `SparkPoDetailComponent` + `SparkSubQueryComponent` (43).
 
 ### Deferred (handoff for next sessions)
 
 | Item | Why scoped out | Notes for the next batch |
 |---|---|---|
-| **`SparkPoFormComponent`**, `SparkPoDetailComponent`, `SparkSubQueryComponent` | Deepest ng-spark components — signals + effects + multi-way binding + sub-queries + custom actions | Use the `nextNavigationEnd` + `StubComponent` helpers in `node_packages/ng-spark/src/test-utils.ts`. Mock `SparkService` with `vi.fn()`. Add `provideNoopAnimations()` and `provideHttpClient()/provideHttpClientTesting()` to the providers list. |
 | **`StreamExecuteQuery` WebSocket endpoint** | TestServer supports WebSockets via `Server.CreateWebSocketClient()` but the diff-engine + `IAsyncEnumerable` + cancellation deserves its own focused batch | Build on the existing `SparkEndpointFactory`. The `IStreamingQueryExecutor` returns `IAsyncEnumerable<T>` — mock or seed Raven. |
 | **Source-generator snapshot tests** | Generator targets `netstandard2.0` and pulls `MintPlayer.SourceGenerators.Tools` polyfills (esp. `ModuleInitializerAttribute`) that collide with `net10.0`'s `System.Runtime` at test load time | A first attempt with `Assembly.LoadFrom` from a separate `MintPlayer.Spark.SourceGenerators.Tests` project + `ExcludeAssets="compile"` on Tools got further but still hit `Microsoft.CodeAnalysis.CSharp` version mismatch. Worth a dedicated focused session. |
 | **Authorization endpoints** (`/spark/auth/*`) | Small batch (~6–8 tests), didn't fit the "biggest impact" prioritization | `GetCurrentUser`, `Logout`, `CsrfRefresh`, `Groups`. Reuse `SparkEndpointFactory` and the antiforgery wiring from `SparkTestClient`. |
@@ -660,6 +659,14 @@ These are non-obvious things discovered while implementing. They cost real time 
 - **Sequential awaited HTTP via `firstValueFrom` needs a microtask flush between `expectOne` calls.** Pattern in `spark-auth.service.spec.ts`'s `flush()` helper: `await new Promise<void>(r => setTimeout(r, 0))`.
 - **Stub `Router` with `vi.fn()` is broken** because `RouterLink` directive subscribes to `Router.events` (which is undefined on a bare stub). Always use `provideRouter([])` even when you don't care about navigation, just for the directive's DI.
 - **Angular 21 signal inputs** (`input.required<T>()`) are set in tests via `fixture.componentRef.setInput(name, value)` + `fixture.detectChanges()`.
+- **Zoneless `fixture.whenStable()` does NOT await `effect()`-spawned async work.** Components like `SparkPoFormComponent` / `SparkSubQueryComponent` kick off `Promise.all(...)` loaders from an `effect()` and set signals when they resolve. Use a multi-tick microtask flush after `detectChanges()`:
+  ```typescript
+  async function flush() {
+    for (let i = 0; i < 5; i++) await new Promise<void>(r => setTimeout(r, 0));
+  }
+  ```
+  Three ticks is usually enough; five is a cheap upper bound.
+- **`RouterLink` in a non-router test setup** needs `provideRouter([])`. `SparkSubQueryComponent`'s template imports `RouterModule` for anchor-style links even though the component itself has no route, so any TestBed that renders it must include `provideRouter([])`.
 - **`SparkAuthBarComponent.onLogout()` has no try/catch** — if `logout()` rejects, `router.navigateByUrl('/')` is skipped. The test documents that as the current behavior. Worth fixing in a follow-up if logout-on-network-error should still log the user out locally.
 
 ### 13.3 CI / Nx

--- a/node_packages/ng-spark/po-detail/src/spark-po-detail.component.spec.ts
+++ b/node_packages/ng-spark/po-detail/src/spark-po-detail.component.spec.ts
@@ -1,0 +1,260 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, Routes } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { SparkPoDetailComponent } from './spark-po-detail.component';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
+import {
+  CustomActionDefinition,
+  EntityType,
+  PersistentObject,
+  ShowedOn,
+} from '@mintplayer/ng-spark/models';
+import { nextNavigationEnd, StubComponent } from '../../src/test-utils';
+
+const personType: EntityType = {
+  id: 't-person',
+  name: 'Person',
+  alias: 'person',
+  clrType: 'Test.Person',
+  attributes: [
+    {
+      id: 'a-first', name: 'FirstName', dataType: 'string',
+      isRequired: true, isVisible: true, isReadOnly: false,
+      order: 1, showedOn: ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-query-only', name: 'QueryOnly', dataType: 'string',
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 2, showedOn: ShowedOn.Query,
+    } as any,
+  ],
+  groups: [{ id: 'g-main', name: 'Main', order: 1 }],
+  tabs: [{ id: 'tab-main', name: 'Main', order: 1 }],
+} as any;
+
+const existingItem: PersistentObject = {
+  id: 'people/1',
+  name: 'Alice',
+  objectTypeId: 't-person',
+  attributes: [
+    { id: 'a-first', name: 'FirstName', value: 'Alice' } as any,
+  ],
+} as any;
+
+const customAction: CustomActionDefinition = {
+  name: 'Archive',
+  displayName: { en: 'Archive' } as any,
+  showedOn: 'detail',
+  refreshOnCompleted: false,
+  offset: 0,
+} as any;
+
+const customActionWithConfirm: CustomActionDefinition = {
+  ...customAction,
+  name: 'Delete',
+  confirmationMessageKey: 'confirmDelete',
+};
+
+const customActionRefresh: CustomActionDefinition = {
+  ...customAction,
+  name: 'Refresh',
+  refreshOnCompleted: true,
+};
+
+const routes: Routes = [
+  { path: 'po/:type/:id', component: SparkPoDetailComponent },
+  { path: 'po/:type/:id/edit', component: StubComponent },
+  { path: '', component: StubComponent },
+];
+
+async function setup(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getEntityTypes: vi.fn().mockResolvedValue([personType]),
+    get: vi.fn().mockResolvedValue(existingItem),
+    getPermissions: vi.fn().mockResolvedValue({ canRead: true, canCreate: true, canEdit: true, canDelete: true }),
+    getCustomActions: vi.fn().mockResolvedValue([customAction]),
+    executeCustomAction: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    getLookupReference: vi.fn().mockResolvedValue({ name: 'dummy', values: [] } as any),
+    executeQueryByName: vi.fn().mockResolvedValue({ data: [], totalRecords: 0 }),
+    ...serviceOverrides,
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      provideRouter(routes),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: SparkService, useValue: service },
+      { provide: SparkLanguageService, useValue: { t: (k: string) => k } },
+      { provide: SPARK_ATTRIBUTE_RENDERERS, useValue: [] },
+    ],
+  });
+  const harness = await RouterTestingHarness.create();
+  return { harness, service };
+}
+
+describe('SparkPoDetailComponent', () => {
+  const confirmSpy = vi.spyOn(globalThis, 'confirm');
+
+  beforeEach(() => confirmSpy.mockReset().mockReturnValue(true));
+  afterEach(() => confirmSpy.mockReset());
+
+  it('loads entity type + item + permissions + custom actions for detail view', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    expect(service.get).toHaveBeenCalledWith('person', 'people/1');
+    expect(c.entityType()?.name).toBe('Person');
+    expect(c.item()?.id).toBe('people/1');
+    expect(c.canEdit()).toBe(true);
+    expect(c.canDelete()).toBe(true);
+    expect(c.customActions()).toHaveLength(1);
+  });
+
+  it('resolves entity type via id OR alias', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/t-person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.entityType()?.id).toBe('t-person');
+  });
+
+  it('filters custom actions to those showedOn detail or both', async () => {
+    const actions = [
+      { ...customAction, name: 'A', showedOn: 'detail' },
+      { ...customAction, name: 'B', showedOn: 'both' },
+      { ...customAction, name: 'C', showedOn: 'list' },
+    ];
+    const { harness } = await setup({
+      getCustomActions: vi.fn().mockResolvedValue(actions),
+    });
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.customActions().map(a => a.name)).toEqual(['A', 'B']);
+  });
+
+  it('sets errorMessage when the item fails to load', async () => {
+    const { harness } = await setup({
+      get: vi.fn().mockRejectedValue(new HttpErrorResponse({ status: 404, error: { error: 'Not found' } })),
+    });
+    const c = await harness.navigateByUrl('/po/person/people%2Fmissing', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    expect(c.errorMessage()).toBe('Not found');
+    expect(c.item()).toBeNull();
+  });
+
+  it('visibleAttributes filters out query-only attributes', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    const names = c.visibleAttributes().map(a => a.name);
+    expect(names).toEqual(['FirstName']);
+  });
+
+  it('onEdit emits edited and navigates to the edit route', async () => {
+    const { harness } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    const edited = vi.fn();
+    c.edited.subscribe(edited);
+
+    const navigated = nextNavigationEnd();
+    c.onEdit();
+    await navigated;
+
+    expect(edited).toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/po/person/people%2F1/edit');
+  });
+
+  it('onDelete calls SparkService.delete and navigates away when confirmed', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    const deleted = vi.fn();
+    c.deleted.subscribe(deleted);
+
+    const navigated = nextNavigationEnd();
+    await c.onDelete();
+    await navigated;
+
+    expect(service.delete).toHaveBeenCalledWith('person', 'people/1');
+    expect(deleted).toHaveBeenCalled();
+    expect(TestBed.inject(Router).url).toBe('/');
+  });
+
+  it('onDelete is a no-op when confirm returns false', async () => {
+    confirmSpy.mockReturnValueOnce(false);
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    await c.onDelete();
+
+    expect(service.delete).not.toHaveBeenCalled();
+  });
+
+  it('onCustomAction executes without confirmation when none is configured', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    const executed = vi.fn();
+    c.customActionExecuted.subscribe(executed);
+
+    await c.onCustomAction(customAction);
+
+    expect(service.executeCustomAction).toHaveBeenCalledWith('person', 'Archive', existingItem);
+    expect(executed).toHaveBeenCalledWith(expect.objectContaining({ action: customAction }));
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('onCustomAction with confirmationMessageKey prompts; no-op on cancel', async () => {
+    confirmSpy.mockReturnValueOnce(false);
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    await c.onCustomAction(customActionWithConfirm);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(service.executeCustomAction).not.toHaveBeenCalled();
+  });
+
+  it('onCustomAction with refreshOnCompleted re-fetches the item', async () => {
+    const { harness, service } = await setup();
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+    (service.get as any).mockClear();
+
+    await c.onCustomAction(customActionRefresh);
+
+    expect(service.executeCustomAction).toHaveBeenCalled();
+    expect(service.get).toHaveBeenCalledWith('person', 'people/1');
+  });
+
+  it('onCustomAction failure sets errorMessage', async () => {
+    const { harness } = await setup({
+      executeCustomAction: vi.fn().mockRejectedValue(new HttpErrorResponse({ status: 500, error: { error: 'Boom' } })),
+    });
+    const c = await harness.navigateByUrl('/po/person/people%2F1', SparkPoDetailComponent);
+    await harness.fixture.whenStable();
+
+    await c.onCustomAction(customAction);
+
+    expect(c.errorMessage()).toBe('Boom');
+  });
+});

--- a/node_packages/ng-spark/po-detail/src/spark-sub-query.component.spec.ts
+++ b/node_packages/ng-spark/po-detail/src/spark-sub-query.component.spec.ts
@@ -1,0 +1,210 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkSubQueryComponent } from './spark-sub-query.component';
+import { SparkService } from '@mintplayer/ng-spark/services';
+import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
+import {
+  EntityType,
+  PersistentObject,
+  ShowedOn,
+  SparkQuery,
+} from '@mintplayer/ng-spark/models';
+
+const lineType: EntityType = {
+  id: 't-line',
+  name: 'Line',
+  alias: 'line',
+  clrType: 'Test.Line',
+  attributes: [
+    {
+      id: 'a-sku', name: 'Sku', dataType: 'string',
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 1, showedOn: ShowedOn.Query,
+    } as any,
+    {
+      id: 'a-detail', name: 'DetailOnly', dataType: 'string',
+      isRequired: false, isVisible: true, isReadOnly: false,
+      order: 2, showedOn: ShowedOn.PersistentObject,
+    } as any,
+    {
+      id: 'a-hidden', name: 'Hidden', dataType: 'string',
+      isRequired: false, isVisible: false, isReadOnly: false,
+      order: 3, showedOn: ShowedOn.Query,
+    } as any,
+  ],
+} as any;
+
+const linesQuery: SparkQuery = {
+  id: 'q-lines',
+  name: 'Lines',
+  alias: 'lines',
+  source: 'Database.Lines',
+  sortColumns: [{ property: 'Sku', direction: 'asc' }],
+  renderMode: 'Pagination',
+  entityType: 'Line',
+  isStreamingQuery: false,
+} as any;
+
+const samplePage = {
+  data: [
+    { id: 'lines/1', name: 'SKU-1', objectTypeId: 't-line', attributes: [] } as any,
+    { id: 'lines/2', name: 'SKU-2', objectTypeId: 't-line', attributes: [] } as any,
+  ],
+  totalRecords: 2,
+};
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>(r => setTimeout(r, 0));
+  }
+}
+
+function createComponent(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getQuery: vi.fn().mockResolvedValue(linesQuery),
+    getEntityTypes: vi.fn().mockResolvedValue([lineType]),
+    getPermissions: vi.fn().mockResolvedValue({ canRead: true, canCreate: true, canEdit: true, canDelete: true }),
+    executeQuery: vi.fn().mockResolvedValue(samplePage),
+    getLookupReference: vi.fn().mockResolvedValue({ name: 'dummy', values: [] } as any),
+    ...serviceOverrides,
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      provideRouter([]),
+      { provide: SparkService, useValue: service },
+      { provide: SPARK_ATTRIBUTE_RENDERERS, useValue: [] },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(SparkSubQueryComponent);
+  fixture.componentRef.setInput('queryId', 'q-lines');
+  fixture.componentRef.setInput('parentId', 'orders/1');
+  fixture.componentRef.setInput('parentType', 'order');
+  return { fixture, component: fixture.componentInstance, service };
+}
+
+describe('SparkSubQueryComponent', () => {
+  it('loads query + entity types + permissions on effect fire (Pagination mode)', async () => {
+    const { fixture, component, service } = createComponent();
+    fixture.detectChanges();
+    await flush();
+
+    expect(service.getQuery).toHaveBeenCalledWith('q-lines');
+    expect(component.query()?.id).toBe('q-lines');
+    expect(component.entityType()?.name).toBe('Line');
+    expect(component.canRead()).toBe(true);
+    expect(component.loading()).toBe(false);
+  });
+
+  it('Pagination mode: executeQuery is called with parent context and page metadata is stored', async () => {
+    const { fixture, component, service } = createComponent();
+    fixture.detectChanges();
+    await flush();
+
+    expect(service.executeQuery).toHaveBeenCalledOnce();
+    const [queryId, opts] = (service.executeQuery as any).mock.calls[0];
+    expect(queryId).toBe('q-lines');
+    expect(opts.parentId).toBe('orders/1');
+    expect(opts.parentType).toBe('order');
+    expect(opts.skip).toBe(0);
+    expect(opts.take).toBe(10);
+    expect(component.paginationData()?.totalRecords).toBe(2);
+    expect(component.paginationData()?.totalPages).toBe(1);
+  });
+
+  it('VirtualScrolling mode initializes virtualDataSource instead of paginationData', async () => {
+    const virtualQuery = { ...linesQuery, renderMode: 'VirtualScrolling' } as any;
+    const { fixture, component } = createComponent({
+      getQuery: vi.fn().mockResolvedValue(virtualQuery),
+    });
+    fixture.detectChanges();
+    await flush();
+
+    expect(component.virtualDataSource()).not.toBeNull();
+    expect(component.paginationData()).toBeUndefined();
+  });
+
+  it('visibleAttributes keeps Query-showed visible attrs and excludes detail-only + hidden', async () => {
+    const { fixture, component } = createComponent();
+    fixture.detectChanges();
+    await flush();
+
+    const names = component.visibleAttributes().map(a => a.name);
+    expect(names).toEqual(['Sku']);
+  });
+
+  it('initial sortColumns map desc/asc to descending/ascending', async () => {
+    const q = { ...linesQuery, sortColumns: [{ property: 'Sku', direction: 'desc' }] } as any;
+    const { fixture, component } = createComponent({
+      getQuery: vi.fn().mockResolvedValue(q),
+    });
+    fixture.detectChanges();
+    await flush();
+
+    expect(component.settings().sortColumns[0]).toEqual({ property: 'Sku', direction: 'descending' });
+  });
+
+  it('onSettingsChange in Pagination mode re-fetches the page', async () => {
+    const { fixture, component, service } = createComponent();
+    fixture.detectChanges();
+    await flush();
+    (service.executeQuery as any).mockClear();
+
+    component.onSettingsChange();
+    await flush();
+
+    expect(service.executeQuery).toHaveBeenCalledOnce();
+  });
+
+  it('onSettingsChange in VirtualScrolling mode rebuilds the data source', async () => {
+    const virtualQuery = { ...linesQuery, renderMode: 'VirtualScrolling' } as any;
+    const { fixture, component } = createComponent({
+      getQuery: vi.fn().mockResolvedValue(virtualQuery),
+    });
+    fixture.detectChanges();
+    await flush();
+    const firstSource = component.virtualDataSource();
+
+    component.onSettingsChange();
+
+    expect(component.virtualDataSource()).not.toBe(firstSource);
+  });
+
+  it('error path: when getQuery rejects, paginationData clears and loading resolves to false', async () => {
+    const { fixture, component } = createComponent({
+      getQuery: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    fixture.detectChanges();
+    await flush();
+
+    expect(component.paginationData()).toBeUndefined();
+    expect(component.loading()).toBe(false);
+  });
+
+  it('onSettingsChange is a no-op before the query has resolved', async () => {
+    const { fixture, component, service } = createComponent({
+      getQuery: vi.fn(() => new Promise<SparkQuery>(() => {})),
+    });
+    fixture.detectChanges();
+
+    component.onSettingsChange();
+
+    expect(service.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('entity type resolves by name OR by lowercased alias', async () => {
+    const aliasQuery = { ...linesQuery, entityType: 'line' } as any;
+    const { fixture, component } = createComponent({
+      getQuery: vi.fn().mockResolvedValue(aliasQuery),
+    });
+    fixture.detectChanges();
+    await flush();
+
+    expect(component.entityType()?.id).toBe('t-line');
+  });
+});

--- a/node_packages/ng-spark/po-form/src/spark-po-form.component.spec.ts
+++ b/node_packages/ng-spark/po-form/src/spark-po-form.component.spec.ts
@@ -1,0 +1,377 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkPoFormComponent } from './spark-po-form.component';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
+import {
+  EntityAttributeDefinition,
+  EntityType,
+  LookupReference,
+  LookupReferenceValue,
+  PersistentObject,
+  ShowedOn,
+} from '@mintplayer/ng-spark/models';
+
+function attr(partial: Partial<EntityAttributeDefinition>): EntityAttributeDefinition {
+  return {
+    id: partial.name || 'a',
+    name: 'a',
+    dataType: 'string',
+    isRequired: false,
+    isVisible: true,
+    isReadOnly: false,
+    order: 1,
+    showedOn: ShowedOn.PersistentObject,
+    rules: [],
+    ...partial,
+  } as EntityAttributeDefinition;
+}
+
+const personType: EntityType = {
+  id: 't-person',
+  name: 'Person',
+  clrType: 'Test.Person',
+  attributes: [
+    attr({ id: 'a-first', name: 'FirstName', order: 2 }),
+    attr({ id: 'a-nick', name: 'Nickname', order: 1, group: 'g-names' }),
+    attr({ id: 'a-hidden', name: 'Hidden', isVisible: false, order: 3 }),
+    attr({ id: 'a-readonly', name: 'Readonly', isReadOnly: true, order: 4 }),
+    attr({ id: 'a-detail-only', name: 'DetailOnly', order: 5, showedOn: ShowedOn.Query }),
+    attr({ id: 'a-orphaned', name: 'Orphaned', order: 6, group: 'g-missing' }),
+    attr({ id: 'a-company', name: 'Company', dataType: 'Reference', order: 7, query: 'CompanyQuery', referenceType: 'Test.Company' }),
+    attr({ id: 'a-role', name: 'Role', order: 8, lookupReferenceType: 'Roles' }),
+    attr({ id: 'a-status', name: 'Status', order: 9, lookupReferenceType: 'Roles' }),
+  ],
+  tabs: [
+    { id: 'tab-names', name: 'Names', order: 1 },
+  ],
+  groups: [
+    { id: 'g-names', name: 'Names', tab: 'tab-names', order: 1 },
+    { id: 'g-orphans', name: 'Orphans', order: 2 },
+  ],
+};
+
+const allCompanies: PersistentObject[] = [
+  { id: 'companies/1', name: 'Acme', objectTypeId: 't-company', attributes: [] } as any,
+];
+
+const rolesLookup: LookupReference = {
+  name: 'Roles',
+  isTransient: false,
+  displayType: 1,
+  values: [
+    { key: 'admin', values: { en: 'Admin' } as any, isActive: true },
+    { key: 'legacy', values: { en: 'Legacy' } as any, isActive: false },
+  ] as LookupReferenceValue[],
+} as any;
+
+function createComponent(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    executeQueryByName: vi.fn().mockResolvedValue({ data: allCompanies, totalRecords: 1 }),
+    getEntityTypes: vi.fn().mockResolvedValue([personType]),
+    getPermissions: vi.fn().mockResolvedValue({ canRead: true, canCreate: true, canUpdate: true, canDelete: true }),
+    getLookupReference: vi.fn().mockResolvedValue(rolesLookup),
+    ...serviceOverrides,
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      { provide: SparkService, useValue: service },
+      { provide: SparkLanguageService, useValue: { t: (k: string) => k } },
+      { provide: SPARK_ATTRIBUTE_RENDERERS, useValue: [] },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(SparkPoFormComponent);
+  const component = fixture.componentInstance;
+  return { fixture, component, service };
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>(r => setTimeout(r, 0));
+  }
+}
+
+async function setEntityType(fixture: any, et: EntityType): Promise<void> {
+  fixture.componentRef.setInput('entityType', et);
+  fixture.detectChanges();
+  await flush();
+}
+
+describe('SparkPoFormComponent', () => {
+  describe('attribute filtering and grouping', () => {
+    it('editableAttributes excludes hidden, read-only, and detail-only attributes, sorted by order', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const names = component.editableAttributes().map(a => a.name);
+      expect(names).not.toContain('Hidden');
+      expect(names).not.toContain('Readonly');
+      expect(names).not.toContain('DetailOnly');
+      expect(names[0]).toBe('Nickname');
+      expect(names[1]).toBe('FirstName');
+    });
+
+    it('ungroupedAttributes includes attrs without a group AND attrs with an unknown group', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const ungrouped = component.ungroupedAttributes().map(a => a.name);
+      expect(ungrouped).toContain('FirstName');
+      expect(ungrouped).toContain('Orphaned');
+      expect(ungrouped).not.toContain('Nickname');
+    });
+
+    it('resolvedTabs prepends the default tab when ungrouped attrs exist', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const tabs = component.resolvedTabs();
+      expect(tabs[0].id).toBe('__default__');
+      expect(tabs.map(t => t.id)).toContain('tab-names');
+    });
+
+    it('resolvedTabs returns only defined tabs when all groups are tabbed and no ungrouped attrs exist', async () => {
+      const et: EntityType = {
+        ...personType,
+        attributes: [attr({ id: 'a-nick', name: 'Nickname', order: 1, group: 'g-names' })],
+        groups: [{ id: 'g-names', name: 'Names', tab: 'tab-names', order: 1 }],
+      };
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, et);
+
+      const tabs = component.resolvedTabs();
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].id).toBe('tab-names');
+    });
+
+    it('groupsForTab for the default tab returns only untabbed groups', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const defaultTab = component.resolvedTabs().find(t => t.id === '__default__')!;
+      const groups = component.groupsForTab(defaultTab).map(g => g.id);
+      expect(groups).toEqual(['g-orphans']);
+    });
+
+    it('attrsForGroup returns only editable attributes assigned to the group', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const namesGroup = personType.groups!.find(g => g.id === 'g-names')!;
+      const attrs = component.attrsForGroup(namesGroup).map(a => a.name);
+      expect(attrs).toEqual(['Nickname']);
+    });
+  });
+
+  describe('reference and lookup loading', () => {
+    it('loadReferenceOptions calls executeQueryByName once per Reference attribute with a query', async () => {
+      const { fixture, component, service } = createComponent();
+      await setEntityType(fixture, personType);
+
+      expect(service.executeQueryByName).toHaveBeenCalledWith('CompanyQuery', expect.any(Object));
+      expect(component.referenceOptions()['Company']).toEqual(allCompanies);
+    });
+
+    it('loadLookupReferenceOptions deduplicates across attributes sharing the same lookupReferenceType', async () => {
+      const { fixture, component, service } = createComponent();
+      await setEntityType(fixture, personType);
+
+      expect(service.getLookupReference).toHaveBeenCalledTimes(1);
+      expect(service.getLookupReference).toHaveBeenCalledWith('Roles');
+      expect(component.lookupReferenceOptions()['Roles'].name).toBe('Roles');
+    });
+
+    it('getLookupOptions returns only active values', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const options = component.getLookupOptions(personType.attributes.find(a => a.name === 'Role')!);
+      expect(options.map(o => o.key)).toEqual(['admin']);
+    });
+  });
+
+  describe('lookup modal', () => {
+    it('openLookupSelector seeds items and opens the modal; selectLookupItem updates formData and closes', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const roleAttr = personType.attributes.find(a => a.name === 'Role')!;
+
+      component.openLookupSelector(roleAttr);
+      expect(component.showLookupModal()).toBe(true);
+      expect(component.lookupModalItems()).toHaveLength(1);
+
+      component.selectLookupItem({ key: 'admin', values: { en: 'Admin' } as any, isActive: true });
+
+      expect(component.formData()['Role']).toBe('admin');
+      expect(component.showLookupModal()).toBe(false);
+      expect(component.editingLookupAttr()).toBeNull();
+    });
+
+    it('filteredLookupItems narrows items by search term (case-insensitive, matches key or translation)', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const roleAttr = personType.attributes.find(a => a.name === 'Role')!;
+
+      component.openLookupSelector(roleAttr);
+      component.lookupSearchTerm.set('adm');
+
+      expect(component.filteredLookupItems().map(i => i.key)).toEqual(['admin']);
+
+      component.lookupSearchTerm.set('nope');
+      expect(component.filteredLookupItems()).toHaveLength(0);
+    });
+  });
+
+  describe('reference modal', () => {
+    it('openReferenceSelector loads the matching entity type and seeds paginationData', async () => {
+      const companyType: EntityType = { id: 't-company', name: 'Company', clrType: 'Test.Company', attributes: [] };
+      const { fixture, component, service } = createComponent({
+        getEntityTypes: vi.fn().mockResolvedValue([personType, companyType]),
+      });
+      await setEntityType(fixture, personType);
+      const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
+
+      await component.openReferenceSelector(companyAttr);
+
+      expect(service.getEntityTypes).toHaveBeenCalled();
+      expect(component.referenceModalEntityType()?.clrType).toBe('Test.Company');
+      expect(component.showReferenceModal()).toBe(true);
+      expect(component.referenceModalPagination()?.totalRecords).toBe(1);
+    });
+
+    it('selectReferenceItem writes the item id into formData and closes the modal', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
+      await component.openReferenceSelector(companyAttr);
+
+      component.selectReferenceItem(allCompanies[0]);
+
+      expect(component.formData()['Company']).toBe('companies/1');
+      expect(component.showReferenceModal()).toBe(false);
+    });
+
+    it('onReferenceSearchChange narrows paginationData to matching items by name', async () => {
+      const more = [
+        { id: 'companies/1', name: 'Acme', objectTypeId: 't-company', attributes: [] } as any,
+        { id: 'companies/2', name: 'Globex', objectTypeId: 't-company', attributes: [] } as any,
+      ];
+      const { fixture, component } = createComponent({
+        executeQueryByName: vi.fn().mockResolvedValue({ data: more, totalRecords: 2 }),
+      });
+      await setEntityType(fixture, personType);
+      const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
+      await component.openReferenceSelector(companyAttr);
+
+      component.referenceSearchTerm = 'glob';
+      component.onReferenceSearchChange();
+
+      expect(component.referenceModalPagination()?.data).toHaveLength(1);
+      expect(component.referenceModalPagination()?.data[0].name).toBe('Globex');
+    });
+  });
+
+  describe('AsDetail object modal', () => {
+    it('openAsDetailEditor seeds asDetailFormData from formData for single-object attrs', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const nested = attr({ id: 'a-addr', name: 'Address', dataType: 'AsDetail' });
+      component.formData.set({ Address: { Street: 'Main' } });
+
+      component.openAsDetailEditor(nested);
+
+      expect(component.showAsDetailModal()).toBe(true);
+      expect(component.asDetailFormData()).toEqual({ Street: 'Main' });
+      expect(component.editingArrayIndex()).toBeNull();
+    });
+
+    it('saveAsDetailObject writes single-object value back into formData and closes the modal', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const nested = attr({ id: 'a-addr', name: 'Address', dataType: 'AsDetail' });
+      component.openAsDetailEditor(nested);
+      component.asDetailFormData.set({ Street: 'Broadway' });
+
+      component.saveAsDetailObject();
+
+      expect(component.formData()['Address']).toEqual({ Street: 'Broadway' });
+      expect(component.showAsDetailModal()).toBe(false);
+    });
+
+    it('addArrayItem + saveAsDetailObject appends to the array; editArrayItem updates in place', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const jobs = attr({ id: 'a-jobs', name: 'Jobs', dataType: 'AsDetail', isArray: true });
+      component.formData.set({ Jobs: [] });
+
+      component.addArrayItem(jobs);
+      component.asDetailFormData.set({ Title: 'Dev' });
+      component.saveAsDetailObject();
+      expect(component.formData()['Jobs']).toEqual([{ Title: 'Dev' }]);
+
+      component.editArrayItem(jobs, 0);
+      expect(component.editingArrayIndex()).toBe(0);
+      component.asDetailFormData.set({ Title: 'Senior Dev' });
+      component.saveAsDetailObject();
+
+      expect(component.formData()['Jobs']).toEqual([{ Title: 'Senior Dev' }]);
+    });
+
+    it('removeArrayItem splices the indexed entry out of the array', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const jobs = attr({ id: 'a-jobs', name: 'Jobs', dataType: 'AsDetail', isArray: true });
+      component.formData.set({ Jobs: [{ Title: 'A' }, { Title: 'B' }] });
+
+      component.removeArrayItem(jobs, 0);
+
+      expect(component.formData()['Jobs']).toEqual([{ Title: 'B' }]);
+    });
+
+    it('addInlineRow appends an empty object without opening the modal', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+      const jobs = attr({ id: 'a-jobs', name: 'Jobs', dataType: 'AsDetail', isArray: true, editMode: 'inline' });
+      component.formData.set({ Jobs: [] });
+
+      component.addInlineRow(jobs);
+
+      expect(component.formData()['Jobs']).toEqual([{}]);
+      expect(component.showAsDetailModal()).toBe(false);
+    });
+  });
+
+  describe('outputs and helpers', () => {
+    it('hasError returns true when validationErrors contain the given attribute', async () => {
+      const { fixture, component } = createComponent();
+      fixture.componentRef.setInput('validationErrors', [
+        { attributeName: 'FirstName', errorMessage: { en: 'Required' } as any, ruleType: 'required' },
+      ]);
+      await setEntityType(fixture, personType);
+
+      expect(component.hasError('FirstName')).toBe(true);
+      expect(component.hasError('LastName')).toBe(false);
+    });
+
+    it('onSave and onCancel emit their outputs', async () => {
+      const { fixture, component } = createComponent();
+      await setEntityType(fixture, personType);
+
+      const saved = vi.fn();
+      const cancelled = vi.fn();
+      component.save.subscribe(saved);
+      component.cancel.subscribe(cancelled);
+
+      component.onSave();
+      component.onCancel();
+
+      expect(saved).toHaveBeenCalled();
+      expect(cancelled).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Captures everything learned across the M1–M3 implementation work (PRs #94–#107) into the testing PRD. Two new sections plus a status header bump.

### New §12 — Implementation status

322 tests passing (156 .NET + 53 ng-spark-auth + 113 ng-spark). Lists what's done per milestone and a deferred-items table with starting hints for each: \`SparkPoFormComponent\` + detail/sub-query, \`StreamExecuteQuery\` WebSocket, source-generator snapshots, Authorization endpoints, Custom Actions endpoint, \`GitHubInstallationService\` concurrency, Messaging/Replication/SubscriptionWorker, DevTunnel/SocketExtensions, E2E.

### New §13 — Implementation notes (real-world findings)

Non-obvious things that cost time to figure out and aren't in the original PRD. Grouped:

- **.NET infrastructure** — RavenDB license loader, CronosCore as design-reference-only, \`InternalsVisibleTo("DynamicProxyGenAssembly2")\` for NSubstitute internals, \`<IsTestProject>false</IsTestProject>\` on test-utility libs, why \`WebApplicationFactory<T>\` doesn't work here (no \`Main\`), antiforgery JSON behavior, SPARK001 validation accepting ProjectReference-as-analyzer.
- **Angular / Vitest** — \`RouterTestingHarness\` per the Angular docs, \`nextNavigationEnd\` helper for fire-and-forget navigation in zoneless mode, \`TestBed.runInInjectionContext\` for \`CanActivateFn\`, excluding \`test-utils.ts\` from \`tsconfig.lib.json\`, Vitest \`resolve.alias\` mirroring tsconfig paths, \`provideNoopAnimations()\`, \`provideHttpClient() + provideHttpClientTesting()\` for tree-shakable auto-fetching services, microtask \`flush()\` between sequential awaited HTTP calls, why \`provideRouter([])\` is needed even when not testing navigation (\`RouterLink\` subscribes to \`Router.events\`), Angular 21 signal-input \`setInput\` pattern.
- **CI / Nx** — \`nx fix-ci\` is not a generic healing command, \`@nx-dotnet\` works with Nx 20–22, Demo-app exclusion list, \`nxCloudId\` (public) vs \`NX_CLOUD_ACCESS_TOKEN\` (secret).
- **Source-generator testing blocker** — sequence of problems hit, current state, and what a next focused session should try.

### Status header

\`Version 1.2\` / \`In progress (322/?? tests landed)\` / dated 2026-04-20.

## Test plan

- [x] No code changes — docs only
- [ ] CI passes (no test impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)