### PR TITLE
test: Authorization endpoints (H)

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/Authorization/CsrfRefreshTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Authorization/CsrfRefreshTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using MintPlayer.Spark.Authorization.Endpoints;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Authorization;
+
+public class CsrfRefreshTests
+{
+    [Fact]
+    public async Task Returns_an_OK_IResult()
+    {
+        var endpoint = new CsrfRefresh();
+        var context = new DefaultHttpContext();
+
+        var result = await endpoint.HandleAsync(context);
+
+        // Results.Ok() without a body is Microsoft.AspNetCore.Http.HttpResults.Ok
+        // whose ExecuteAsync writes status 200 and an empty body. This endpoint's
+        // job is to round-trip an authenticated request so the antiforgery
+        // middleware emits a fresh XSRF-TOKEN cookie — the handler itself is a no-op.
+        result.Should().BeOfType<Ok>();
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Authorization/GetCurrentUserTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Authorization/GetCurrentUserTests.cs
@@ -1,0 +1,105 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MintPlayer.Spark.Authorization.Endpoints;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Authorization;
+
+public class GetCurrentUserTests
+{
+    [Fact]
+    public async Task Returns_isAuthenticated_false_when_identity_is_missing()
+    {
+        var endpoint = new GetCurrentUser();
+        var context = new DefaultHttpContext();
+        // Bare ClaimsPrincipal — no identity — IsAuthenticated == false
+        context.User = new ClaimsPrincipal();
+
+        var result = await endpoint.HandleAsync(context);
+        var body = await ExecuteResultAsync(result, context);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("isAuthenticated").GetBoolean().Should().BeFalse();
+        doc.RootElement.TryGetProperty("userName", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Returns_isAuthenticated_false_when_identity_is_not_authenticated()
+    {
+        var endpoint = new GetCurrentUser();
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity()), // empty identity, not authenticated
+        };
+
+        var result = await endpoint.HandleAsync(context);
+        var body = await ExecuteResultAsync(result, context);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("isAuthenticated").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Returns_userName_email_and_roles_when_authenticated()
+    {
+        var endpoint = new GetCurrentUser();
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.Name, "alice"),
+                    new Claim(ClaimTypes.Email, "alice@example.com"),
+                    new Claim(ClaimTypes.Role, "Admin"),
+                    new Claim(ClaimTypes.Role, "Editor"),
+                ],
+                authenticationType: "TestScheme"
+            )),
+        };
+
+        var result = await endpoint.HandleAsync(context);
+        var body = await ExecuteResultAsync(result, context);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("isAuthenticated").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("userName").GetString().Should().Be("alice");
+        doc.RootElement.GetProperty("email").GetString().Should().Be("alice@example.com");
+        doc.RootElement.GetProperty("roles").EnumerateArray()
+            .Select(r => r.GetString()).Should().BeEquivalentTo(["Admin", "Editor"]);
+    }
+
+    [Fact]
+    public async Task Returns_empty_roles_array_when_user_has_no_role_claims()
+    {
+        var endpoint = new GetCurrentUser();
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "bob")],
+                authenticationType: "TestScheme"
+            )),
+        };
+
+        var result = await endpoint.HandleAsync(context);
+        var body = await ExecuteResultAsync(result, context);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("isAuthenticated").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("userName").GetString().Should().Be("bob");
+        doc.RootElement.GetProperty("email").ValueKind.Should().Be(JsonValueKind.Null);
+        doc.RootElement.GetProperty("roles").GetArrayLength().Should().Be(0);
+    }
+
+    private static async Task<string> ExecuteResultAsync(IResult result, HttpContext context)
+    {
+        var stream = new MemoryStream();
+        context.Response.Body = stream;
+        context.RequestServices = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+        await result.ExecuteAsync(context);
+        stream.Position = 0;
+        return await new StreamReader(stream).ReadToEndAsync();
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Authorization/LogoutTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Authorization/LogoutTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MintPlayer.AspNetCore.Endpoints;
+using MintPlayer.Spark.Authorization.Endpoints;
+using NSubstitute;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Authorization;
+
+public class LogoutTests
+{
+    [Fact]
+    public async Task Calls_SignOutAsync_with_the_IdentityConstants_ApplicationScheme()
+    {
+        var authService = Substitute.For<IAuthenticationService>();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton(authService)
+            .BuildServiceProvider();
+
+        var context = new DefaultHttpContext { RequestServices = services };
+
+        var endpoint = new Logout();
+        var result = await endpoint.HandleAsync(context);
+
+        await authService.Received(1).SignOutAsync(
+            context,
+            IdentityConstants.ApplicationScheme,
+            properties: null);
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Configure_marks_the_endpoint_with_RequireAntiforgeryTokenAttribute()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddRouting();
+        var app = builder.Build();
+
+        var routeBuilder = app.MapPost("/test-logout", () => Results.Ok());
+        InvokeConfigure<Logout>(routeBuilder);
+
+        // Start the app so endpoint conventions materialize into the data source.
+        await app.StartAsync();
+        try
+        {
+            var endpoints = app.Services
+                .GetRequiredService<IEnumerable<EndpointDataSource>>()
+                .SelectMany(ds => ds.Endpoints);
+
+            var hasAntiforgeryMetadata = endpoints.Any(
+                e => e.Metadata.GetMetadata<RequireAntiforgeryTokenAttribute>() is not null);
+            hasAntiforgeryMetadata.Should().BeTrue();
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    private static void InvokeConfigure<TEndpoint>(RouteHandlerBuilder builder)
+        where TEndpoint : IEndpointBase
+        => TEndpoint.Configure(builder);
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Authorization/SparkAuthGroupTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Authorization/SparkAuthGroupTests.cs
@@ -1,0 +1,29 @@
+using MintPlayer.AspNetCore.Endpoints;
+using MintPlayer.Spark.Authorization.Endpoints;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Authorization;
+
+public class SparkAuthGroupTests
+{
+    [Fact]
+    public void Prefix_is_spark_auth()
+    {
+        SparkAuthGroup.Prefix.Should().Be("/spark/auth");
+    }
+
+    [Fact]
+    public void All_auth_endpoints_are_members_of_SparkAuthGroup()
+    {
+        typeof(GetCurrentUser).Should().BeAssignableTo<IMemberOf<SparkAuthGroup>>();
+        typeof(Logout).Should().BeAssignableTo<IMemberOf<SparkAuthGroup>>();
+        typeof(CsrfRefresh).Should().BeAssignableTo<IMemberOf<SparkAuthGroup>>();
+    }
+
+    [Fact]
+    public void Endpoint_paths_match_the_documented_routes()
+    {
+        GetCurrentUser.Path.Should().Be("/me");
+        Logout.Path.Should().Be("/logout");
+        CsrfRefresh.Path.Should().Be("/csrf-refresh");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 10 tests for the four auth endpoint building blocks: `GetCurrentUser`, `Logout`, `CsrfRefresh`, and the `SparkAuthGroup` endpoint prefix contract.
- Endpoints are small wrappers; tested at the handler level via `DefaultHttpContext` instead of booting the full Spark + Identity stack.
- Notable: `Logout.Configure` metadata verification requires booting a minimal `WebApplication` and calling `app.StartAsync()` — metadata conventions only materialize after pipeline start.

## Test plan
- [x] \`dotnet test MintPlayer.Spark.Tests\` — 166/166 passing (156 prior + 10 new)
- [x] All 10 new tests pass locally in <400 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)