### PR TITLE
test: StreamExecuteQuery + StreamingDiffEngine (M)

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/Queries/StreamExecuteQueryTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Queries/StreamExecuteQueryTests.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Endpoints.Queries;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Streaming;
+using NSubstitute;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Queries;
+
+public class StreamExecuteQueryTests : IAsyncLifetime
+{
+    private static readonly Guid PersonTypeId = Guid.NewGuid();
+
+    private readonly IQueryLoader _queryLoader = Substitute.For<IQueryLoader>();
+    private readonly IStreamingQueryExecutor _executor = Substitute.For<IStreamingQueryExecutor>();
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddLogging();
+                    services.AddRouting();
+                    services.AddSingleton(_queryLoader);
+                    services.AddSingleton(_executor);
+                })
+                .Configure(app =>
+                {
+                    app.UseWebSockets();
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/stream/{id}", async httpContext =>
+                        {
+                            var endpoint = new StreamExecuteQuery(_queryLoader, _executor);
+                            var result = await endpoint.HandleAsync(httpContext);
+                            await result.ExecuteAsync(httpContext);
+                        });
+                    });
+                }))
+            .Build();
+        await _host.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task Returns_400_when_the_request_is_not_a_WebSocket_upgrade()
+    {
+        var client = _host.GetTestClient();
+
+        var response = await client.GetAsync("/stream/q-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("WebSocket connection required");
+    }
+
+    [Fact]
+    public async Task Returns_404_when_the_query_id_does_not_resolve()
+    {
+        _queryLoader.ResolveQuery("missing").Returns((SparkQuery?)null);
+
+        var wsClient = _host.GetTestServer().CreateWebSocketClient();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => wsClient.ConnectAsync(
+            new Uri(_host.GetTestServer().BaseAddress, "/stream/missing"), CancellationToken.None));
+
+        // TestServer surfaces a pre-upgrade HTTP rejection as "Incomplete handshake, status code: NNN"
+        ex.Message.Should().Contain("404");
+    }
+
+    [Fact]
+    public async Task Returns_400_when_the_query_is_not_flagged_as_streaming()
+    {
+        var nonStreaming = new SparkQuery { Id = Guid.NewGuid(), Name = "AllPeople", Source = "Database.People", IsStreamingQuery = false };
+        _queryLoader.ResolveQuery("all-people").Returns(nonStreaming);
+
+        var wsClient = _host.GetTestServer().CreateWebSocketClient();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => wsClient.ConnectAsync(
+            new Uri(_host.GetTestServer().BaseAddress, "/stream/all-people"), CancellationToken.None));
+
+        ex.Message.Should().Contain("400");
+    }
+
+    [Fact]
+    public async Task Streams_a_snapshot_followed_by_a_patch_over_the_WebSocket()
+    {
+        var query = new SparkQuery { Id = Guid.NewGuid(), Name = "LivePeople", Source = "Database.People", IsStreamingQuery = true };
+        _queryLoader.ResolveQuery("live-people").Returns(query);
+        _executor.ExecuteStreamingQueryAsync(query, Arg.Any<CancellationToken>()).Returns(Produce(
+            [Po("people/1", ("FirstName", "Alice"))],
+            [Po("people/1", ("FirstName", "Alicia"))]
+        ));
+
+        var socket = await ConnectAsync("/stream/live-people");
+
+        var first = await ReceiveJsonAsync(socket);
+        first.RootElement.GetProperty("type").GetString().Should().Be("snapshot");
+        first.RootElement.GetProperty("data").GetArrayLength().Should().Be(1);
+
+        var second = await ReceiveJsonAsync(socket);
+        second.RootElement.GetProperty("type").GetString().Should().Be("patch");
+        var updated = second.RootElement.GetProperty("updated");
+        updated.GetArrayLength().Should().Be(1);
+        updated[0].GetProperty("attributes").GetProperty("FirstName").GetString().Should().Be("Alicia");
+
+        await ExpectCloseAsync(socket, WebSocketCloseStatus.NormalClosure);
+    }
+
+    [Fact]
+    public async Task Skips_identical_snapshots_and_only_sends_the_initial_one()
+    {
+        var query = new SparkQuery { Id = Guid.NewGuid(), Name = "SteadyPeople", Source = "Database.People", IsStreamingQuery = true };
+        _queryLoader.ResolveQuery("steady").Returns(query);
+        _executor.ExecuteStreamingQueryAsync(query, Arg.Any<CancellationToken>()).Returns(Produce(
+            [Po("people/1", ("FirstName", "Alice"))],
+            [Po("people/1", ("FirstName", "Alice"))]
+        ));
+
+        var socket = await ConnectAsync("/stream/steady");
+
+        var first = await ReceiveJsonAsync(socket);
+        first.RootElement.GetProperty("type").GetString().Should().Be("snapshot");
+
+        await ExpectCloseAsync(socket, WebSocketCloseStatus.NormalClosure);
+    }
+
+    [Fact]
+    public async Task SparkAccessDeniedException_is_delivered_as_an_error_message_then_closes_with_InternalServerError()
+    {
+        var query = new SparkQuery { Id = Guid.NewGuid(), Name = "Guarded", Source = "Database.People", IsStreamingQuery = true };
+        _queryLoader.ResolveQuery("guarded").Returns(query);
+        _executor.ExecuteStreamingQueryAsync(query, Arg.Any<CancellationToken>())
+            .Returns(Throwing(new SparkAccessDeniedException("nope")));
+
+        var socket = await ConnectAsync("/stream/guarded");
+
+        var message = await ReceiveJsonAsync(socket);
+        message.RootElement.GetProperty("type").GetString().Should().Be("error");
+        message.RootElement.GetProperty("message").GetString().Should().Be("Access denied");
+
+        await ExpectCloseAsync(socket, WebSocketCloseStatus.InternalServerError);
+    }
+
+    [Fact]
+    public async Task Generic_exception_is_surfaced_as_an_error_message_with_the_exception_text()
+    {
+        var query = new SparkQuery { Id = Guid.NewGuid(), Name = "Crashy", Source = "Database.People", IsStreamingQuery = true };
+        _queryLoader.ResolveQuery("crashy").Returns(query);
+        _executor.ExecuteStreamingQueryAsync(query, Arg.Any<CancellationToken>())
+            .Returns(Throwing(new InvalidOperationException("boom")));
+
+        var socket = await ConnectAsync("/stream/crashy");
+
+        var message = await ReceiveJsonAsync(socket);
+        message.RootElement.GetProperty("type").GetString().Should().Be("error");
+        message.RootElement.GetProperty("message").GetString().Should().Be("boom");
+
+        await ExpectCloseAsync(socket, WebSocketCloseStatus.InternalServerError);
+    }
+
+    private async Task<WebSocket> ConnectAsync(string path)
+    {
+        var wsClient = _host.GetTestServer().CreateWebSocketClient();
+        return await wsClient.ConnectAsync(
+            new Uri(_host.GetTestServer().BaseAddress, path),
+            CancellationToken.None);
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket socket)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[4096];
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket.ReceiveAsync(buffer, CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+                throw new InvalidOperationException($"Socket closed before a message arrived: {result.CloseStatus} {result.CloseStatusDescription}");
+            ms.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+
+        ms.Position = 0;
+        return JsonDocument.Parse(ms);
+    }
+
+    private static async Task ExpectCloseAsync(WebSocket socket, WebSocketCloseStatus expected)
+    {
+        var buffer = new byte[1024];
+        var result = await socket.ReceiveAsync(buffer, CancellationToken.None);
+        result.MessageType.Should().Be(WebSocketMessageType.Close);
+        socket.CloseStatus.Should().Be(expected);
+    }
+
+    private static global::MintPlayer.Spark.Abstractions.PersistentObject Po(string id, params (string Name, object? Value)[] attrs) => new()
+    {
+        Id = id,
+        Name = id,
+        ObjectTypeId = PersonTypeId,
+        Attributes = attrs.Select(a => new global::MintPlayer.Spark.Abstractions.PersistentObjectAttribute { Name = a.Name, Value = a.Value }).ToArray(),
+    };
+
+    private static async IAsyncEnumerable<global::MintPlayer.Spark.Abstractions.PersistentObject[]> Produce(params global::MintPlayer.Spark.Abstractions.PersistentObject[][] batches)
+    {
+        foreach (var batch in batches)
+        {
+            yield return batch;
+            await Task.Yield();
+        }
+    }
+
+#pragma warning disable CS1998 // no awaits — the iterator is expected to throw synchronously on MoveNext
+    private static async IAsyncEnumerable<global::MintPlayer.Spark.Abstractions.PersistentObject[]> Throwing(Exception ex)
+    {
+        throw ex;
+        yield break;
+    }
+#pragma warning restore CS1998
+}

--- a/MintPlayer.Spark.Tests/Streaming/StreamingDiffEngineTests.cs
+++ b/MintPlayer.Spark.Tests/Streaming/StreamingDiffEngineTests.cs
@@ -1,0 +1,151 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Streaming;
+
+namespace MintPlayer.Spark.Tests.Streaming;
+
+public class StreamingDiffEngineTests
+{
+    private static readonly Guid PersonTypeId = Guid.NewGuid();
+
+    private static PersistentObject Po(string id, params (string Name, object? Value)[] attrs) => new()
+    {
+        Id = id,
+        Name = id,
+        ObjectTypeId = PersonTypeId,
+        Attributes = attrs.Select(a => new PersistentObjectAttribute { Name = a.Name, Value = a.Value }).ToArray(),
+    };
+
+    [Fact]
+    public void First_call_returns_a_SnapshotMessage_carrying_all_items()
+    {
+        var engine = new StreamingDiffEngine();
+        var items = new[] { Po("people/1", ("FirstName", "Alice")), Po("people/2", ("FirstName", "Bob")) };
+
+        var message = engine.ComputeMessage(items);
+
+        var snapshot = message.Should().BeOfType<SnapshotMessage>().Subject;
+        snapshot.Data.Should().HaveCount(2);
+        snapshot.Type.Should().Be("snapshot");
+    }
+
+    [Fact]
+    public void Returns_null_when_a_second_call_has_no_changes()
+    {
+        var engine = new StreamingDiffEngine();
+        var items = new[] { Po("people/1", ("FirstName", "Alice")) };
+
+        engine.ComputeMessage(items);
+        var secondMessage = engine.ComputeMessage(items);
+
+        secondMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void Changed_attribute_value_produces_a_PatchMessage_with_only_the_changed_attribute()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("FirstName", "Alice"), ("LastName", "Smith"))]);
+
+        var patch = engine.ComputeMessage([Po("people/1", ("FirstName", "Alicia"), ("LastName", "Smith"))]);
+
+        var patchMessage = patch.Should().BeOfType<PatchMessage>().Subject;
+        patchMessage.Type.Should().Be("patch");
+        patchMessage.Updated.Should().HaveCount(1);
+        var item = patchMessage.Updated[0];
+        item.Id.Should().Be("people/1");
+        item.Attributes.Should().ContainKey("FirstName").WhoseValue.Should().Be("Alicia");
+        item.Attributes.Should().NotContainKey("LastName");
+    }
+
+    [Fact]
+    public void New_item_on_second_call_is_patched_with_all_of_its_attribute_values()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("FirstName", "Alice"))]);
+
+        var patch = engine.ComputeMessage([
+            Po("people/1", ("FirstName", "Alice")),
+            Po("people/2", ("FirstName", "Bob"), ("LastName", "Jones")),
+        ]);
+
+        var patchMessage = patch.Should().BeOfType<PatchMessage>().Subject;
+        patchMessage.Updated.Should().HaveCount(1);
+        var newItem = patchMessage.Updated[0];
+        newItem.Id.Should().Be("people/2");
+        newItem.Attributes.Should().ContainKey("FirstName").WhoseValue.Should().Be("Bob");
+        newItem.Attributes.Should().ContainKey("LastName").WhoseValue.Should().Be("Jones");
+    }
+
+    [Fact]
+    public void New_attribute_appearing_on_an_existing_item_is_included_in_the_patch()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("FirstName", "Alice"))]);
+
+        var patch = engine.ComputeMessage([
+            Po("people/1", ("FirstName", "Alice"), ("LastName", "Smith")),
+        ]);
+
+        var patchMessage = patch.Should().BeOfType<PatchMessage>().Subject;
+        var item = patchMessage.Updated.Single();
+        item.Attributes.Should().ContainKey("LastName").WhoseValue.Should().Be("Smith");
+    }
+
+    [Fact]
+    public void Items_with_null_ids_are_ignored_by_the_diff_state()
+    {
+        var engine = new StreamingDiffEngine();
+        var nullIdItem = new PersistentObject
+        {
+            Id = null,
+            Name = "anon",
+            ObjectTypeId = PersonTypeId,
+            Attributes = [new PersistentObjectAttribute { Name = "X", Value = "Y" }],
+        };
+
+        var first = engine.ComputeMessage([nullIdItem]);
+        first.Should().BeOfType<SnapshotMessage>()
+            .Which.Data.Should().ContainSingle().Which.Id.Should().BeNull();
+
+        // Second call with only a keyed item — should be treated as a brand-new item patch.
+        var second = engine.ComputeMessage([Po("people/1", ("FirstName", "Alice"))]);
+        var patch = second.Should().BeOfType<PatchMessage>().Subject;
+        patch.Updated.Should().ContainSingle().Which.Id.Should().Be("people/1");
+    }
+
+    [Fact]
+    public void Null_and_null_compare_equal_no_patch_emitted_when_both_sides_are_null()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("Nickname", null))]);
+
+        var secondMessage = engine.ComputeMessage([Po("people/1", ("Nickname", null))]);
+
+        secondMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void Null_to_value_counts_as_a_change_and_emits_a_patch()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("Nickname", null))]);
+
+        var secondMessage = engine.ComputeMessage([Po("people/1", ("Nickname", "Ally"))]);
+
+        var patch = secondMessage.Should().BeOfType<PatchMessage>().Subject;
+        patch.Updated.Single().Attributes["Nickname"].Should().Be("Ally");
+    }
+
+    [Fact]
+    public void State_advances_every_call_patches_are_computed_against_the_previous_call_not_the_snapshot()
+    {
+        var engine = new StreamingDiffEngine();
+        engine.ComputeMessage([Po("people/1", ("FirstName", "Alice"))]);
+        engine.ComputeMessage([Po("people/1", ("FirstName", "Alicia"))]);
+
+        // Third call matches the second — no change relative to the second call
+        var thirdMessage = engine.ComputeMessage([Po("people/1", ("FirstName", "Alicia"))]);
+
+        thirdMessage.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- 9 unit tests for \`StreamingDiffEngine\`: snapshot/patch/null/new-item/new-attribute/null-id/null-equality/state-advance.
- 7 integration tests for \`StreamExecuteQuery\` via \`TestServer.CreateWebSocketClient()\`: non-WS rejection, unknown/non-streaming query paths, full snapshot+patch flow, identical-batch skip, access-denied + generic exception error-frame-then-close.

## Test plan
- [x] \`dotnet test MintPlayer.Spark.Tests\` — 198/198 passing (182 prior + 16 new)
- [x] WebSocket flow verified end-to-end via TestServer (no external infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)