### PR TITLE
test: GitHubInstallationService (J)

### DIFF
--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\MintPlayer.Spark\MintPlayer.Spark.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Authorization\MintPlayer.Spark.Authorization.csproj" />
+    <ProjectReference Include="..\MintPlayer.Spark.Webhooks.GitHub\MintPlayer.Spark.Webhooks.GitHub.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.AllFeatures\MintPlayer.Spark.AllFeatures.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Testing\MintPlayer.Spark.Testing.csproj" />
   </ItemGroup>

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceTests.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Webhooks.GitHub.Configuration;
+using MintPlayer.Spark.Webhooks.GitHub.Services;
+using Octokit;
+
+namespace MintPlayer.Spark.Tests.Webhooks.GitHub;
+
+public class GitHubInstallationServiceTests
+{
+    private const long InstallationId = 12345L;
+
+    private static GitHubInstallationService NewService(GitHubWebhooksOptions? options = null)
+    {
+        var opts = Options.Create(options ?? new GitHubWebhooksOptions());
+        // Source generator writes the [Options] field via the public ctor
+        return new GitHubInstallationService(opts);
+    }
+
+    private static ConcurrentDictionary<long, AccessToken> GetTokenCache(GitHubInstallationService service)
+    {
+        var field = typeof(GitHubInstallationService)
+            .GetField("_installationTokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (ConcurrentDictionary<long, AccessToken>)field.GetValue(service)!;
+    }
+
+    private static void SeedToken(GitHubInstallationService service, long id, DateTimeOffset expiresAt)
+    {
+        GetTokenCache(service)[id] = new AccessToken("seeded-" + id, expiresAt);
+    }
+
+    [Fact]
+    public async Task Fast_path_returns_the_cached_token_when_it_has_more_than_60s_remaining()
+    {
+        using var service = NewService();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(10);
+        SeedToken(service, InstallationId, expiry);
+
+        var token = await service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None);
+
+        token.Token.Should().Be("seeded-12345");
+        token.ExpiresAt.Should().Be(expiry);
+    }
+
+    [Fact]
+    public async Task Token_expiring_within_60s_is_treated_as_stale_and_triggers_a_refresh()
+    {
+        using var service = NewService(); // no ClientId / no private key — refresh must throw
+        SeedToken(service, InstallationId, DateTimeOffset.UtcNow.AddSeconds(30));
+
+        // Because PEM/ClientId are unconfigured, CreateAppClientAsync throws inside the refresh path.
+        // The exception is the signal that the stale check decided to refresh.
+        var act = async () => await service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*PrivateKeyPem*");
+    }
+
+    [Fact]
+    public async Task Token_expiring_just_past_the_60s_window_is_still_considered_fresh()
+    {
+        using var service = NewService();
+        var expiry = DateTimeOffset.UtcNow.AddSeconds(75);
+        SeedToken(service, InstallationId, expiry);
+
+        var token = await service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None);
+
+        token.ExpiresAt.Should().Be(expiry);
+    }
+
+    [Fact]
+    public void InvalidateInstallation_removes_the_cached_entry()
+    {
+        using var service = NewService();
+        SeedToken(service, InstallationId, DateTimeOffset.UtcNow.AddHours(1));
+        GetTokenCache(service).ContainsKey(InstallationId).Should().BeTrue();
+
+        service.InvalidateInstallation(InstallationId);
+
+        GetTokenCache(service).ContainsKey(InstallationId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task One_thousand_concurrent_fast_path_calls_all_return_the_same_cached_AccessToken()
+    {
+        using var service = NewService();
+        SeedToken(service, InstallationId, DateTimeOffset.UtcNow.AddHours(1));
+        var original = GetTokenCache(service)[InstallationId];
+
+        var tasks = Enumerable.Range(0, 1000).Select(_ =>
+            service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None)).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        results.Should().OnlyContain(t => ReferenceEquals(t, original));
+    }
+
+    [Fact]
+    public async Task CreateAppClientAsync_throws_when_ClientId_is_not_configured()
+    {
+        using var service = NewService(new GitHubWebhooksOptions
+        {
+            PrivateKeyPem = GenerateRsaPrivateKeyPem(),
+            // ClientId is null
+        });
+
+        var act = async () => await service.CreateAppClientAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*ClientId*");
+    }
+
+    [Fact]
+    public async Task CreateAppClientAsync_throws_when_neither_PrivateKeyPem_nor_PrivateKeyPath_is_set()
+    {
+        using var service = NewService(new GitHubWebhooksOptions
+        {
+            ClientId = "Iv23liFAKEAPPID",
+        });
+
+        var act = async () => await service.CreateAppClientAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*PrivateKeyPem*");
+    }
+
+    [Fact]
+    public async Task CreateAppClientAsync_produces_a_GitHubClient_with_Bearer_credentials_and_a_three_part_JWT()
+    {
+        using var service = NewService(new GitHubWebhooksOptions
+        {
+            ClientId = "Iv23liFAKEAPPID",
+            PrivateKeyPem = GenerateRsaPrivateKeyPem(),
+        });
+
+        var client = await service.CreateAppClientAsync();
+
+        client.Connection.Credentials.AuthenticationType.Should().Be(AuthenticationType.Bearer);
+        var jwt = client.Connection.Credentials.Password;
+        jwt.Split('.').Should().HaveCount(3, "JWT format is header.payload.signature");
+    }
+
+    [Fact]
+    public async Task CreateInstallationClientAsync_caches_the_client_per_installationId()
+    {
+        using var service = NewService();
+
+        var a = await service.CreateInstallationClientAsync(InstallationId);
+        var b = await service.CreateInstallationClientAsync(InstallationId);
+        var c = await service.CreateInstallationClientAsync(InstallationId + 1);
+
+        a.Should().BeSameAs(b, "same id → cached");
+        a.Should().NotBeSameAs(c, "different id → different client");
+    }
+
+    private static string GenerateRsaPrivateKeyPem()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var base64 = Convert.ToBase64String(pkcs8, Base64FormattingOptions.InsertLineBreaks);
+        return $"-----BEGIN PRIVATE KEY-----\n{base64}\n-----END PRIVATE KEY-----";
+    }
+}

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/TokenRefreshingDecoratorsTests.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/TokenRefreshingDecoratorsTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Webhooks.GitHub.Configuration;
+using MintPlayer.Spark.Webhooks.GitHub.Services;
+using MintPlayer.Spark.Webhooks.GitHub.Services.Internal;
+using NSubstitute;
+using Octokit;
+using Octokit.Internal;
+
+namespace MintPlayer.Spark.Tests.Webhooks.GitHub;
+
+public class TokenRefreshingDecoratorsTests
+{
+    private const long InstallationId = 42L;
+
+    private static GitHubInstallationService NewService()
+        => new(Options.Create(new GitHubWebhooksOptions()));
+
+    private static ConcurrentDictionary<long, AccessToken> GetCache(GitHubInstallationService service)
+    {
+        var field = typeof(GitHubInstallationService)
+            .GetField("_installationTokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (ConcurrentDictionary<long, AccessToken>)field.GetValue(service)!;
+    }
+
+    private static void Seed(GitHubInstallationService service, long id, string token, DateTimeOffset expiresAt)
+        => GetCache(service)[id] = new AccessToken(token, expiresAt);
+
+    // ---- DynamicInstallationCredentialStore --------------------------------
+
+    [Fact]
+    public async Task DynamicInstallationCredentialStore_returns_the_currently_cached_token_as_Octokit_Credentials()
+    {
+        using var service = NewService();
+        Seed(service, InstallationId, "cached-abc", DateTimeOffset.UtcNow.AddHours(1));
+        var store = new DynamicInstallationCredentialStore(InstallationId, service);
+
+        var credentials = await store.GetCredentials();
+
+        credentials.Password.Should().Be("cached-abc");
+    }
+
+    [Fact]
+    public async Task DynamicInstallationGraphQLCredentialStore_returns_the_currently_cached_token_string()
+    {
+        using var service = NewService();
+        Seed(service, InstallationId, "graphql-token", DateTimeOffset.UtcNow.AddHours(1));
+        var store = new DynamicInstallationGraphQLCredentialStore(InstallationId, service);
+
+        var token = await store.GetCredentials(CancellationToken.None);
+
+        token.Should().Be("graphql-token");
+    }
+
+    // ---- TokenRefreshingHttpClient -----------------------------------------
+
+    [Fact]
+    public async Task TokenRefreshingHttpClient_passes_200_responses_through_without_invalidating_the_cache()
+    {
+        using var service = NewService();
+        Seed(service, InstallationId, "good-token", DateTimeOffset.UtcNow.AddHours(1));
+        var inner = new StubOctokitHttpClient(HttpStatusCode.OK);
+
+        var client = new TokenRefreshingHttpClient(inner, InstallationId, service);
+        var response = await client.Send(new StubOctokitRequest(), CancellationToken.None, _ => _);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        GetCache(service).ContainsKey(InstallationId).Should().BeTrue();
+        inner.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TokenRefreshingHttpClient_on_401_invalidates_the_cache_before_attempting_a_refresh()
+    {
+        // Service has no configured PEM/ClientId — the refresh attempt will throw.
+        // That's fine: we only care that InvalidateInstallation ran first.
+        using var service = NewService();
+        Seed(service, InstallationId, "stale", DateTimeOffset.UtcNow.AddHours(1));
+        var inner = new StubOctokitHttpClient(HttpStatusCode.Unauthorized);
+
+        var client = new TokenRefreshingHttpClient(inner, InstallationId, service);
+        var act = async () => await client.Send(new StubOctokitRequest(), CancellationToken.None, _ => _);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*PrivateKeyPem*");
+        GetCache(service).ContainsKey(InstallationId).Should()
+            .BeFalse("the 401 handler invalidates the cache *before* asking for a fresh token");
+    }
+
+    private sealed class StubOctokitHttpClient(HttpStatusCode statusCode) : IHttpClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<IResponse> Send(IRequest request, CancellationToken cancellationToken, Func<object, object> preprocessResponseBody)
+        {
+            CallCount++;
+            return Task.FromResult<IResponse>(new StubOctokitResponse(statusCode));
+        }
+
+        public void SetRequestTimeout(TimeSpan timeout) { }
+        public void Dispose() { }
+    }
+
+    private sealed class StubOctokitResponse(HttpStatusCode statusCode) : IResponse
+    {
+        public object? Body => null;
+        public IReadOnlyDictionary<string, string> Headers { get; } = new Dictionary<string, string>();
+        public ApiInfo ApiInfo => null!;
+        public HttpStatusCode StatusCode { get; } = statusCode;
+        public string ContentType => "application/json";
+    }
+
+    private sealed class StubOctokitRequest : IRequest
+    {
+        public object? Body { get; set; }
+        public Dictionary<string, string> Headers { get; } = new();
+        public HttpMethod Method { get; set; } = HttpMethod.Get;
+        public Dictionary<string, string> Parameters { get; } = new();
+        public Uri BaseAddress { get; set; } = new("https://api.github.com");
+        public Uri Endpoint { get; set; } = new("/ping", UriKind.Relative);
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+        public string ContentType { get; set; } = "application/json";
+    }
+
+    // ---- TokenRefreshingHandler (GraphQL/.NET HttpClient side) -------------
+
+    [Fact]
+    public async Task TokenRefreshingHandler_passes_200_responses_through_without_invalidating_the_cache()
+    {
+        using var service = NewService();
+        Seed(service, InstallationId, "good-token", DateTimeOffset.UtcNow.AddHours(1));
+
+        var inner = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new TokenRefreshingHandler(InstallationId, service) { InnerHandler = inner };
+        using var client = new HttpClient(handler);
+
+        var response = await client.GetAsync("https://api.github.com/ping");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        GetCache(service).ContainsKey(InstallationId).Should().BeTrue();
+        inner.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TokenRefreshingHandler_on_401_invalidates_the_cache_before_attempting_a_refresh()
+    {
+        using var service = NewService();
+        Seed(service, InstallationId, "stale", DateTimeOffset.UtcNow.AddHours(1));
+
+        var inner = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        var handler = new TokenRefreshingHandler(InstallationId, service) { InnerHandler = inner };
+        using var client = new HttpClient(handler);
+
+        var act = async () => await client.GetAsync("https://api.github.com/ping");
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*PrivateKeyPem*");
+        GetCache(service).ContainsKey(InstallationId).Should().BeFalse();
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(respond(request, cancellationToken));
+        }
+    }
+}

--- a/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
+++ b/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
@@ -20,6 +20,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="MintPlayer.Spark.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
 		<ProjectReference Include="..\MintPlayer.Spark.Messaging.Abstractions\MintPlayer.Spark.Messaging.Abstractions.csproj" />
 		<ProjectReference Include="..\MintPlayer.Dotnet.SocketExtensions\MintPlayer.Dotnet.SocketExtensions.csproj" />


### PR DESCRIPTION
## Summary
- 15 tests locking in the caching contract from \`docs/PRD-GitHubAppClientCache.md\` v2.
- **Cache behavior**: fast-path, 60s-expiry boundary, \`InvalidateInstallation\`, concurrency (1000 parallel fast-path calls all get the same \`AccessToken\`).
- **JWT / App client**: configuration validation + real RSA key produces a 3-part JWT with \`AuthenticationType.Bearer\`.
- **Decorators** (REST + GraphQL): 200 pass-through, 401 invalidates cache *before* refresh attempt. Both the Octokit-side \`TokenRefreshingHttpClient\` and the .NET \`HttpClient\`-side \`TokenRefreshingHandler\` are covered.

## Infra
- Added \`InternalsVisibleTo\` from \`MintPlayer.Spark.Webhooks.GitHub\` → \`MintPlayer.Spark.Tests\`.
- Added ProjectReference from test project to the Webhooks.GitHub project.
- Cache state asserted via reflection on \`_installationTokens\` — goal is a regression shield for the caching contract, not to mint real tokens. WireMock.Net-backed refresh tests remain a deferred item.

## Test plan
- [x] \`dotnet test MintPlayer.Spark.Tests\` — 213/213 passing (198 prior + 15 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)