### PR TITLE
feat: IGitHubClientFactory + WireMock-backed token refresh tests

### DIFF
--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Verify.Xunit" Version="28.6.1" />
+    <PackageReference Include="WireMock.Net" Version="1.8.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceTests.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceTests.cs
@@ -15,8 +15,7 @@ public class GitHubInstallationServiceTests
     private static GitHubInstallationService NewService(GitHubWebhooksOptions? options = null)
     {
         var opts = Options.Create(options ?? new GitHubWebhooksOptions());
-        // Source generator writes the [Options] field via the public ctor
-        return new GitHubInstallationService(opts);
+        return new GitHubInstallationService(new GitHubClientFactory(), opts);
     }
 
     private static ConcurrentDictionary<long, AccessToken> GetTokenCache(GitHubInstallationService service)

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceWireMockTests.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/GitHubInstallationServiceWireMockTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Tests.Webhooks.GitHub._Infrastructure;
+using MintPlayer.Spark.Webhooks.GitHub.Configuration;
+using MintPlayer.Spark.Webhooks.GitHub.Services;
+using Octokit;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace MintPlayer.Spark.Tests.Webhooks.GitHub;
+
+/// <summary>
+/// End-to-end tests for installation token refresh + 401 retry, using a local WireMock
+/// server to stand in for api.github.com. Covers the concurrency and retry contract from
+/// docs/PRD-GitHubAppClientCache.md that the reflection-based tests in
+/// GitHubInstallationServiceTests cannot reach.
+/// </summary>
+public class GitHubInstallationServiceWireMockTests : IAsyncLifetime
+{
+    private const long InstallationId = 42L;
+
+    private WireMockServer _server = null!;
+    private GitHubInstallationService _service = null!;
+
+    public Task InitializeAsync()
+    {
+        _server = WireMockServer.Start();
+        var factory = new WireMockGitHubClientFactory(new Uri(_server.Url!));
+        var opts = Options.Create(new GitHubWebhooksOptions
+        {
+            ClientId = "Iv23liFAKEAPPID",
+            PrivateKeyPem = GenerateRsaPrivateKeyPem(),
+        });
+        _service = new GitHubInstallationService(factory, opts);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _service.Dispose();
+        _server.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private static ConcurrentDictionary<long, AccessToken> GetTokenCache(GitHubInstallationService service)
+    {
+        var field = typeof(GitHubInstallationService)
+            .GetField("_installationTokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (ConcurrentDictionary<long, AccessToken>)field.GetValue(service)!;
+    }
+
+    private static void StubAccessTokenResponse(WireMockServer server, string token, DateTimeOffset expiresAt)
+    {
+        server
+            .Given(Request.Create()
+                .WithPath($"/api/v3/app/installations/{InstallationId}/access_tokens")
+                .UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(201)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(
+                    "{\"token\":\"" + token +
+                    "\",\"expires_at\":\"" + expiresAt.ToString("O") +
+                    "\",\"permissions\":{}}"));
+    }
+
+    [Fact]
+    public async Task Concurrent_refresh_200_callers_result_in_exactly_one_access_token_mint()
+    {
+        StubAccessTokenResponse(_server, "ghs_fresh", DateTimeOffset.UtcNow.AddHours(1));
+
+        var tasks = Enumerable.Range(0, 200).Select(_ =>
+            _service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None)).ToArray();
+        var tokens = await Task.WhenAll(tasks);
+
+        tokens.Should().OnlyContain(t => t.Token == "ghs_fresh");
+        var mintCalls = _server.FindLogEntries(
+            Request.Create().WithPath($"/api/v3/app/installations/{InstallationId}/access_tokens").UsingPost());
+        mintCalls.Count.Should().Be(1, "the SemaphoreSlim gate serializes refresh and the re-check inside the gate skips the second mint");
+    }
+
+    [Fact]
+    public async Task Stale_token_triggers_one_new_mint_and_the_cache_updates_to_the_fresh_token()
+    {
+        // Seed an about-to-expire token — the service must treat it as stale and mint fresh.
+        GetTokenCache(_service)[InstallationId] = new AccessToken("stale", DateTimeOffset.UtcNow.AddSeconds(10));
+        StubAccessTokenResponse(_server, "ghs_refreshed", DateTimeOffset.UtcNow.AddHours(1));
+
+        var token = await _service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None);
+
+        token.Token.Should().Be("ghs_refreshed");
+        GetTokenCache(_service)[InstallationId].Token.Should().Be("ghs_refreshed");
+        var mintCalls = _server.FindLogEntries(
+            Request.Create().WithPath($"/api/v3/app/installations/{InstallationId}/access_tokens").UsingPost());
+        mintCalls.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Fast_path_hit_does_not_mint_a_fresh_token()
+    {
+        GetTokenCache(_service)[InstallationId] = new AccessToken("ghs_cached", DateTimeOffset.UtcNow.AddHours(1));
+
+        var token = await _service.GetOrCreateInstallationTokenAsync(InstallationId, CancellationToken.None);
+
+        token.Token.Should().Be("ghs_cached");
+        var mintCalls = _server.FindLogEntries(
+            Request.Create().WithPath($"/api/v3/app/installations/{InstallationId}/access_tokens").UsingPost());
+        mintCalls.Count.Should().Be(0, "fast-path cache hit never goes through the refresh gate");
+    }
+
+
+    [Fact]
+    public async Task Installation_REST_call_that_returns_401_triggers_a_token_refresh_and_a_single_retry()
+    {
+        GetTokenCache(_service)[InstallationId] = new AccessToken("stale-token", DateTimeOffset.UtcNow.AddHours(1));
+        StubAccessTokenResponse(_server, "fresh-token", DateTimeOffset.UtcNow.AddHours(1));
+
+        // Scenario: first GET → 401. Second GET (after token refresh) → 200.
+        _server
+            .Given(Request.Create().WithPath("/repos/octocat/hello-world").UsingGet())
+            .InScenario("repo-get-retry").WhenStateIs(null).WillSetStateTo("after-401")
+            .RespondWith(Response.Create().WithStatusCode(401));
+        _server
+            .Given(Request.Create().WithPath("/repos/octocat/hello-world").UsingGet())
+            .InScenario("repo-get-retry").WhenStateIs("after-401")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"id\":1,\"name\":\"hello-world\",\"full_name\":\"octocat/hello-world\"}"));
+
+        var client = await _service.CreateInstallationClientAsync(InstallationId);
+        var repo = await client.Repository.Get("octocat", "hello-world");
+
+        repo.Name.Should().Be("hello-world");
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/repos/octocat/hello-world").UsingGet());
+        requests.Count.Should().Be(2, "the handler retries exactly once after the 401");
+        var mintCalls = _server.FindLogEntries(
+            Request.Create().WithPath($"/api/v3/app/installations/{InstallationId}/access_tokens").UsingPost());
+        mintCalls.Count.Should().Be(1, "the 401 forces exactly one fresh-token mint");
+    }
+
+    [Fact]
+    public async Task Persistent_401_after_refresh_does_not_retry_a_second_time()
+    {
+        GetTokenCache(_service)[InstallationId] = new AccessToken("stale", DateTimeOffset.UtcNow.AddHours(1));
+        StubAccessTokenResponse(_server, "still-broken", DateTimeOffset.UtcNow.AddHours(1));
+
+        // Every REST call returns 401 — both the original AND the retry with the fresh token.
+        _server
+            .Given(Request.Create().WithPath("/repos/octocat/hello-world").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(401));
+
+        var client = await _service.CreateInstallationClientAsync(InstallationId);
+        var act = async () => await client.Repository.Get("octocat", "hello-world");
+
+        await act.Should().ThrowAsync<AuthorizationException>();
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/repos/octocat/hello-world").UsingGet());
+        requests.Count.Should().Be(2, "exactly one retry — no infinite loop even when the refresh did not resolve the 401");
+    }
+
+    private static string GenerateRsaPrivateKeyPem()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var base64 = Convert.ToBase64String(pkcs8, Base64FormattingOptions.InsertLineBreaks);
+        return $"-----BEGIN PRIVATE KEY-----\n{base64}\n-----END PRIVATE KEY-----";
+    }
+}

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/TokenRefreshingDecoratorsTests.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/TokenRefreshingDecoratorsTests.cs
@@ -16,7 +16,7 @@ public class TokenRefreshingDecoratorsTests
     private const long InstallationId = 42L;
 
     private static GitHubInstallationService NewService()
-        => new(Options.Create(new GitHubWebhooksOptions()));
+        => new(new GitHubClientFactory(), Options.Create(new GitHubWebhooksOptions()));
 
     private static ConcurrentDictionary<long, AccessToken> GetCache(GitHubInstallationService service)
     {

--- a/MintPlayer.Spark.Tests/Webhooks/GitHub/_Infrastructure/WireMockGitHubClientFactory.cs
+++ b/MintPlayer.Spark.Tests/Webhooks/GitHub/_Infrastructure/WireMockGitHubClientFactory.cs
@@ -1,0 +1,41 @@
+using MintPlayer.Spark.Webhooks.GitHub.Services;
+using Octokit;
+using Octokit.Internal;
+using GraphQLConnection = Octokit.GraphQL.Connection;
+using GraphQLCredentialStore = Octokit.GraphQL.ICredentialStore;
+using GraphQLProductHeaderValue = Octokit.GraphQL.ProductHeaderValue;
+
+namespace MintPlayer.Spark.Tests.Webhooks.GitHub._Infrastructure;
+
+/// <summary>
+/// Test-only factory that points Octokit at a locally running WireMock server.
+/// Enables end-to-end token refresh + 401 retry tests without hitting api.github.com.
+/// </summary>
+internal sealed class WireMockGitHubClientFactory(Uri restBaseAddress) : IGitHubClientFactory
+{
+    private static readonly ProductHeaderValue ProductHeader = new("SparkWebhooks", "test");
+    private static readonly GraphQLProductHeaderValue GraphQLProductHeader = new("SparkWebhooks", "test");
+
+    public IGitHubClient CreateAppClient(string jwt) =>
+        new GitHubClient(ProductHeader, restBaseAddress)
+        {
+            Credentials = new Credentials(jwt, AuthenticationType.Bearer),
+        };
+
+    public IGitHubClient CreateInstallationClient(IHttpClient refreshingHttpClient, ICredentialStore credentialStore)
+    {
+        var connection = new Connection(
+            ProductHeader,
+            restBaseAddress,
+            credentialStore,
+            refreshingHttpClient,
+            new SimpleJsonSerializer());
+        return new GitHubClient(connection);
+    }
+
+    public GraphQLConnection CreateAppGraphQLConnection(string appToken) =>
+        new(GraphQLProductHeader, appToken);
+
+    public GraphQLConnection CreateInstallationGraphQLConnection(GraphQLCredentialStore credentialStore, HttpClient httpClient) =>
+        new(GraphQLProductHeader, credentialStore, httpClient);
+}

--- a/MintPlayer.Spark.Webhooks.GitHub/Services/GitHubClientFactory.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Services/GitHubClientFactory.cs
@@ -1,0 +1,44 @@
+using MintPlayer.SourceGenerators.Attributes;
+using Octokit;
+using Octokit.Internal;
+using GraphQLConnection = Octokit.GraphQL.Connection;
+using GraphQLCredentialStore = Octokit.GraphQL.ICredentialStore;
+using GraphQLProductHeaderValue = Octokit.GraphQL.ProductHeaderValue;
+
+namespace MintPlayer.Spark.Webhooks.GitHub.Services;
+
+/// <summary>
+/// Default <see cref="IGitHubClientFactory"/> targeting api.github.com.
+/// Tests inject an alternative factory pointing at a local WireMock server.
+/// </summary>
+[Register(typeof(IGitHubClientFactory), ServiceLifetime.Singleton)]
+internal sealed class GitHubClientFactory : IGitHubClientFactory
+{
+    private static readonly ProductHeaderValue ProductHeader = new("SparkWebhooks", "1.0");
+    private static readonly GraphQLProductHeaderValue GraphQLProductHeader = new("SparkWebhooks", "1.0");
+
+    public IGitHubClient CreateAppClient(string jwt) =>
+        new GitHubClient(ProductHeader)
+        {
+            Credentials = new Credentials(jwt, AuthenticationType.Bearer),
+        };
+
+    public IGitHubClient CreateInstallationClient(IHttpClient refreshingHttpClient, ICredentialStore credentialStore)
+    {
+        var connection = new Connection(
+            ProductHeader,
+            GitHubClient.GitHubApiUrl,
+            credentialStore,
+            refreshingHttpClient,
+            new SimpleJsonSerializer());
+        return new GitHubClient(connection);
+    }
+
+    public GraphQLConnection CreateAppGraphQLConnection(string appToken) =>
+        new(GraphQLProductHeader, appToken);
+
+    public GraphQLConnection CreateInstallationGraphQLConnection(
+        GraphQLCredentialStore credentialStore,
+        HttpClient httpClient) =>
+        new(GraphQLProductHeader, credentialStore, httpClient);
+}

--- a/MintPlayer.Spark.Webhooks.GitHub/Services/GitHubInstallationService.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Services/GitHubInstallationService.cs
@@ -9,17 +9,14 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using GraphQLConnection = Octokit.GraphQL.Connection;
-using GraphQLProductHeaderValue = Octokit.GraphQL.ProductHeaderValue;
 
 namespace MintPlayer.Spark.Webhooks.GitHub.Services;
 
 [Register(typeof(IGitHubInstallationService), ServiceLifetime.Singleton)]
 internal partial class GitHubInstallationService : IGitHubInstallationService, IDisposable
 {
-    private static readonly ProductHeaderValue ProductHeader = new("SparkWebhooks", "1.0");
-    private static readonly GraphQLProductHeaderValue GraphQLProductHeader = new("SparkWebhooks", "1.0");
-
     [Options] private readonly IOptions<GitHubWebhooksOptions> _options;
+    [Inject] private readonly IGitHubClientFactory _clientFactory;
 
     private readonly ConcurrentDictionary<long, AccessToken> _installationTokens = new();
     private readonly ConcurrentDictionary<long, IGitHubClient> _installationClients = new();
@@ -75,11 +72,7 @@ internal partial class GitHubInstallationService : IGitHubInstallationService, I
         var opts = _options.Value;
         var privateKey = await ResolvePrivateKeyAsync(opts);
         var jwt = CreateJwt(opts.ClientId!, privateKey);
-
-        return new GitHubClient(ProductHeader)
-        {
-            Credentials = new Credentials(jwt, AuthenticationType.Bearer),
-        };
+        return _clientFactory.CreateAppClient(jwt);
     }
 
     public Task<IGitHubClient> CreateInstallationClientAsync(long installationId)
@@ -88,13 +81,8 @@ internal partial class GitHubInstallationService : IGitHubInstallationService, I
     private IGitHubClient BuildInstallationClient(long installationId)
     {
         var refreshing = new TokenRefreshingHttpClient(_sharedRestHttpClient, installationId, this);
-        var connection = new Connection(
-            ProductHeader,
-            GitHubClient.GitHubApiUrl,
-            new DynamicInstallationCredentialStore(installationId, this),
-            refreshing,
-            new SimpleJsonSerializer());
-        return new GitHubClient(connection);
+        var credentialStore = new DynamicInstallationCredentialStore(installationId, this);
+        return _clientFactory.CreateInstallationClient(refreshing, credentialStore);
     }
 
     public async Task<GraphQLConnection> CreateGraphQLConnectionAsync(long installationId, EClientType clientType)
@@ -105,7 +93,7 @@ internal partial class GitHubInstallationService : IGitHubInstallationService, I
                 // App-mode GraphQL is rare and never cached — mint a fresh JWT-bearing connection per call.
                 var appClient = await CreateAppClientAsync();
                 var appToken = appClient.Connection.Credentials.Password;
-                return new GraphQLConnection(GraphQLProductHeader, appToken);
+                return _clientFactory.CreateAppGraphQLConnection(appToken);
             case EClientType.Installation:
                 return _installationGraphQLConnections.GetOrAdd(installationId, BuildInstallationGraphQLConnection);
             default:
@@ -119,8 +107,7 @@ internal partial class GitHubInstallationService : IGitHubInstallationService, I
         var httpClient = new HttpClient(handler);
         lock (_ownedDisposables) { _ownedDisposables.Add(httpClient); }
 
-        return new GraphQLConnection(
-            GraphQLProductHeader,
+        return _clientFactory.CreateInstallationGraphQLConnection(
             new DynamicInstallationGraphQLCredentialStore(installationId, this),
             httpClient);
     }

--- a/MintPlayer.Spark.Webhooks.GitHub/Services/IGitHubClientFactory.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Services/IGitHubClientFactory.cs
@@ -1,0 +1,35 @@
+using Octokit;
+using Octokit.Internal;
+using GraphQLConnection = Octokit.GraphQL.Connection;
+using GraphQLCredentialStore = Octokit.GraphQL.ICredentialStore;
+
+namespace MintPlayer.Spark.Webhooks.GitHub.Services;
+
+/// <summary>
+/// Seam for constructing Octokit clients / connections. Introduced so tests can redirect
+/// all GitHub API traffic to a WireMock server; the production implementation targets
+/// api.github.com.
+/// </summary>
+public interface IGitHubClientFactory
+{
+    /// <summary>Creates a JWT-bearing App client.</summary>
+    IGitHubClient CreateAppClient(string jwt);
+
+    /// <summary>
+    /// Creates an installation client whose REST pipeline uses the given
+    /// <paramref name="refreshingHttpClient"/> (decorates Octokit's default with
+    /// a 401-retry + token-refresh layer) and <paramref name="credentialStore"/>
+    /// (returns the currently cached installation token on each request).
+    /// </summary>
+    IGitHubClient CreateInstallationClient(IHttpClient refreshingHttpClient, ICredentialStore credentialStore);
+
+    /// <summary>Creates a JWT-bearing App GraphQL connection.</summary>
+    GraphQLConnection CreateAppGraphQLConnection(string appToken);
+
+    /// <summary>
+    /// Creates an installation GraphQL connection whose HTTP pipeline uses the given
+    /// <paramref name="httpClient"/> (token-refreshing <see cref="HttpClient"/>) and
+    /// <paramref name="credentialStore"/>.
+    /// </summary>
+    GraphQLConnection CreateInstallationGraphQLConnection(GraphQLCredentialStore credentialStore, HttpClient httpClient);
+}


### PR DESCRIPTION
## Summary
Extract \`IGitHubClientFactory\` as a seam so tests can redirect Octokit traffic to a WireMock server — enables the end-to-end tests the reflection-based PR #112 couldn't reach.

**Production change:**
- New \`IGitHubClientFactory\` interface + default \`GitHubClientFactory\` impl targeting api.github.com.
- \`GitHubInstallationService\` takes the factory via \`[Inject]\`; replaces \`new GitHubClient(...)\` / \`new Connection(...)\` calls with factory methods.
- Public API surface unchanged.

**New WireMock-backed tests (5):**
- Concurrent refresh: 200 parallel callers → exactly 1 POST /access_tokens (SemaphoreSlim contract).
- Stale token triggers exactly 1 mint; cache updates to fresh.
- Fast-path cache hit doesn't POST.
- Installation REST 401 → token refresh + exactly 1 retry with the fresh token.
- Persistent 401 → AuthorizationException, no second retry (no infinite loop).

**Octokit quirk documented in the tests:** custom base URL on \`GitHubClient\` prepends \`/api/v3\`; direct \`Connection(…)\` construction does not. Stubs account for both.

## Test plan
- [x] \`dotnet test MintPlayer.Spark.Tests\` — 218/218 passing (213 prior + 5 new).
- [x] Existing 15 reflection-based J tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)