### PR TITLE
fix: antiforgery gap + logout robustness + Token casing

### DIFF
--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/AntiforgerySecurityTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/AntiforgerySecurityTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http.Json;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+/// <summary>
+/// Verifies that Spark's antiforgery middleware rejects mutating requests without
+/// an X-XSRF-TOKEN header. See PRD-Testing.md §13.1.
+/// </summary>
+public class AntiforgerySecurityTests : MintPlayer.Spark.Testing.SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("55555555-dddd-dddd-dddd-555555555555");
+
+    private SparkEndpointFactory _factory = null!;
+    private HttpClient _bareClient = null!; // no antiforgery cookie/header
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _bareClient = _factory.CreateClient();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _bareClient.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task POST_without_antiforgery_token_is_rejected_with_400()
+    {
+        var response = await _bareClient.PostAsJsonAsync(
+            $"/spark/po/{PersonTypeId}",
+            new
+            {
+                persistentObject = new
+                {
+                    name = "Person",
+                    objectTypeId = PersonTypeId,
+                    attributes = new[]
+                    {
+                        new { name = "FirstName", value = (object)"Alice" },
+                        new { name = "LastName", value = (object)"Smith" },
+                    }
+                }
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/MintPlayer.Spark.Webhooks.GitHub/Services/Internal/TokenRefreshingHttpClient.cs
+++ b/MintPlayer.Spark.Webhooks.GitHub/Services/Internal/TokenRefreshingHttpClient.cs
@@ -29,7 +29,10 @@ internal sealed class TokenRefreshingHttpClient : IHttpClient
 
         _service.InvalidateInstallation(_installationId);
         var fresh = await _service.GetOrCreateInstallationTokenAsync(_installationId, cancellationToken);
-        request.Headers["Authorization"] = $"token {fresh.Token}";
+        // Align with Octokit's Credentials serialization ("Token xxx" with capital T) so
+        // WireMock scenarios / logs / packet captures see a single consistent header shape
+        // across the initial call and the retry.
+        request.Headers["Authorization"] = $"Token {fresh.Token}";
         return await _inner.Send(request, cancellationToken, preprocessResponseBody);
     }
 

--- a/MintPlayer.Spark/SparkMiddleware.cs
+++ b/MintPlayer.Spark/SparkMiddleware.cs
@@ -137,8 +137,46 @@ public static class SparkExtensions
             app.UseAuthentication();
         }
 
-        // Always add authorization and antiforgery
         app.UseAuthorization();
+
+        // Antiforgery validation for mutating requests that carry IAntiforgeryMetadata.
+        //
+        // Runs BEFORE the built-in UseAntiforgery() so this middleware can call
+        // IAntiforgery.ValidateRequestAsync before FormFeature's "unvalidated" guard
+        // gets set. After successful validation we set IAntiforgeryValidationFeature to
+        // "validated" so (a) the built-in middleware and FormFeature treat the request
+        // as already checked and (b) EndpointMiddleware doesn't throw
+        // "contains anti-forgery metadata, but a middleware was not found".
+        //
+        // The built-in UseAntiforgery() was narrowed in 8.0.1 to validate ONLY form-content
+        // bodies — Spark's JSON API is not protected by it alone. This middleware closes
+        // that gap for any mutating HTTP method (POST/PUT/PATCH/DELETE) whose endpoint has
+        // IAntiforgeryMetadata.RequiresValidation = true.
+        app.Use(async (context, next) =>
+        {
+            var endpoint = context.GetEndpoint();
+            var metadata = endpoint?.Metadata.GetMetadata<IAntiforgeryMetadata>();
+            if (metadata is { RequiresValidation: true } && IsMutatingMethod(context.Request.Method))
+            {
+                var antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
+                try
+                {
+                    await antiforgery.ValidateRequestAsync(context);
+                    context.Features.Set<IAntiforgeryValidationFeature>(new SparkAntiforgeryValidationFeature(isValid: true));
+                }
+                catch (AntiforgeryValidationException ex)
+                {
+                    context.Features.Set<IAntiforgeryValidationFeature>(new SparkAntiforgeryValidationFeature(isValid: false, error: ex));
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return;
+                }
+            }
+            await next(context);
+        });
+
+        // Keep the built-in middleware registered — EndpointMiddleware uses its presence as a
+        // "antiforgery was wired" probe when the endpoint has IAntiforgeryMetadata. For
+        // non-form mutating requests that pass Spark's validation above, it's a no-op.
         app.UseAntiforgery();
 
         app.UseWebSockets();
@@ -342,6 +380,24 @@ public static class SparkExtensions
             current = current.BaseType;
         }
         return false;
+    }
+
+    private static bool IsMutatingMethod(string method) =>
+        HttpMethods.IsPost(method)
+        || HttpMethods.IsPut(method)
+        || HttpMethods.IsPatch(method)
+        || HttpMethods.IsDelete(method);
+
+    /// <summary>
+    /// Spark's implementation of <see cref="IAntiforgeryValidationFeature"/> used to record
+    /// the outcome of <see cref="IAntiforgery.ValidateRequestAsync"/>. The concrete class
+    /// in <c>Microsoft.AspNetCore.Antiforgery</c> is internal, so we provide our own.
+    /// </summary>
+    private sealed class SparkAntiforgeryValidationFeature(bool isValid, AntiforgeryValidationException? error = null)
+        : IAntiforgeryValidationFeature
+    {
+        public bool IsValid { get; } = isValid;
+        public Exception? Error { get; } = error;
     }
 }
 

--- a/docs/PRD-Testing.md
+++ b/docs/PRD-Testing.md
@@ -2,9 +2,9 @@
 
 | | |
 |---|---|
-| **Version** | 1.2 |
+| **Version** | 1.3 |
 | **Date** | 2026-04-20 |
-| **Status** | In progress (322/?? tests landed, see §12) |
+| **Status** | In progress (454 tests landed, see §12) |
 | **Owner** | MintPlayer |
 | **Scope** | All non-Demo projects in `MintPlayer.Spark.sln` + Angular libraries + IDE extensions (when activated) |
 
@@ -610,26 +610,23 @@ jobs:
 
 ## 12. Implementation status (as of 2026-04-20)
 
-**365 tests passing across the monorepo** — 156 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 156 ng-spark.
+**454 tests passing across the monorepo** — 245 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 156 ng-spark.
 
 ### Done ✅
 
 - **M1 (infrastructure)** — `MintPlayer.Spark.Testing` project, FluentAssertions everywhere, Vitest + `@analogjs/vite-plugin-angular` in both Angular libs, Nx + `@nx-dotnet/core` + Nx Cloud, license env-var wiring, CI workflow rewritten.
 - **M2 partial** — `AccessControlService` (15), `ClaimsGroupMembershipProvider` (10), `ValidationService` (18), `SecurityConfigurationLoader` (11), `QueryExecutor` (9 unit + 7 integration via `SparkTestDriver`).
-- **M3 endpoints** — `PersistentObject` GET/LIST/CREATE/UPDATE/DELETE (18) via `SparkEndpointFactory`; `Queries` GET/LIST/EXECUTE (12).
+- **M3 endpoints** — `PersistentObject` GET/LIST/CREATE/UPDATE/DELETE (18) via `SparkEndpointFactory`; `Queries` GET/LIST/EXECUTE (12); `Authorization` — `GetCurrentUser` + `Logout` + `CsrfRefresh` + `SparkAuthGroup` (10); `Custom Actions` — `ListCustomActions` + `ExecuteCustomAction` (16); `StreamExecuteQuery` WebSocket (7) + `StreamingDiffEngine` (9).
+- **M3 services** — `GitHubInstallationService` cache + JWT + decorators via reflection (15); WireMock.Net-backed end-to-end token refresh + 401-retry (5, behind a new `IGitHubClientFactory` seam); `RetryNumerator` (6); `MessageBus` (5) + `MessageCheckpoint` (3); `EtlScriptCollector` (5) + `SyncActionInterceptor` (8).
 - **M3 Angular** — `SparkAuthService` + guard + interceptor (15), all 6 ng-spark-auth components (27), all 22 ng-spark pipes (70), `RetryActionService` + `IconRegistry` + `IconComponent` + `RetryActionModal` (17), `SparkPoCreate` + `SparkPoEdit` + `SparkQueryList` (21), `SparkPoFormComponent` + `SparkPoDetailComponent` + `SparkSubQueryComponent` (43).
 
 ### Deferred (handoff for next sessions)
 
 | Item | Why scoped out | Notes for the next batch |
 |---|---|---|
-| **`StreamExecuteQuery` WebSocket endpoint** | TestServer supports WebSockets via `Server.CreateWebSocketClient()` but the diff-engine + `IAsyncEnumerable` + cancellation deserves its own focused batch | Build on the existing `SparkEndpointFactory`. The `IStreamingQueryExecutor` returns `IAsyncEnumerable<T>` — mock or seed Raven. |
-| **Source-generator snapshot tests** | Generator targets `netstandard2.0` and pulls `MintPlayer.SourceGenerators.Tools` polyfills (esp. `ModuleInitializerAttribute`) that collide with `net10.0`'s `System.Runtime` at test load time | A first attempt with `Assembly.LoadFrom` from a separate `MintPlayer.Spark.SourceGenerators.Tests` project + `ExcludeAssets="compile"` on Tools got further but still hit `Microsoft.CodeAnalysis.CSharp` version mismatch. Worth a dedicated focused session. |
-| **Authorization endpoints** (`/spark/auth/*`) | Small batch (~6–8 tests), didn't fit the "biggest impact" prioritization | `GetCurrentUser`, `Logout`, `CsrfRefresh`, `Groups`. Reuse `SparkEndpointFactory` and the antiforgery wiring from `SparkTestClient`. |
-| **Custom Actions endpoint** (`/spark/actions/*`) | ~5–6 tests, deferred for the same reason | `Execute` + `List`. Same factory pattern. |
-| **`GitHubInstallationService` concurrency** | Needs WireMock.Net infra | Locks in the contract from [PRD-GitHubAppClientCache.md](./PRD-GitHubAppClientCache.md): cache hit, refresh, `SemaphoreSlim` serialization, 401-retry, no infinite-retry, signature verification. |
-| **Messaging / Replication / SubscriptionWorker** | Substantial new infra (real RavenDB subscriptions, message bus simulation) | Each gets its own batch per the §4 plan. `SparkTestDriver` is the foundation. |
-| **DevTunnel + SocketExtensions** | Smaller, both should fit one batch | Per §4.9 / §4.11. |
+| **Subscription-worker end-to-end flows** | `MessageSubscriptionWorker` + `SyncActionSubscriptionWorker` happy path, retry, dead-letter, non-retryable exception routing — require a real running RavenDB subscription | Seed `SparkMessage` / `SparkSyncAction` docs via `SparkTestDriver.Store`, start the worker, poll for terminal status with `WaitFor(...)`. `MaxDocsPerBatch = 1` keeps assertions deterministic. `RollupMessageStatus` + handler-level retry/backoff are the high-value paths. |
+| **Source-generator snapshot tests** | Generator targets `netstandard2.0` and pulls `MintPlayer.SourceGenerators.Tools` polyfills (esp. `ModuleInitializerAttribute`) that collide with `net10.0`'s `System.Runtime` at test load time | A first attempt with `Assembly.LoadFrom` from a separate `MintPlayer.Spark.SourceGenerators.Tests` project + `ExcludeAssets="compile"` on Tools got further but still hit `Microsoft.CodeAnalysis.CSharp` version mismatch. Worth a dedicated focused session with pinned `Microsoft.CodeAnalysis.Testing` versions across the dep graph. |
+| **DevTunnel + SocketExtensions** | Smaller, both should fit one batch | `MintPlayer.Spark.Webhooks.GitHub.DevTunnel` helpers + `MintPlayer.Dotnet.SocketExtensions` utilities. Unit-testable, no external infra. |
 | **AllFeatures source generator** | Smaller, included with the source-generator session above | |
 | **E2E test host + Playwright** (M4) | All M3 should be done first to avoid duplicating coverage | New `MintPlayer.Spark.E2E.TestHost` ASP.NET Core + Angular app. Playwright for .NET runs against it. |
 
@@ -644,8 +641,15 @@ These are non-obvious things discovered while implementing. They cost real time 
 - **`InternalsVisibleTo("DynamicProxyGenAssembly2")`** must be on every project whose internal interfaces NSubstitute needs to mock. Currently set on `MintPlayer.Spark` and `MintPlayer.Spark.Authorization`.
 - **`<IsTestProject>false</IsTestProject>`** must be set on `MintPlayer.Spark.Testing.csproj` — it has an xunit reference (for `IAsyncLifetime` types) but is NOT a test project. Without this, `dotnet test <sln>` tries to discover tests in it and exits non-zero with a confusing "0 Error(s), Build FAILED".
 - **`WebApplicationFactory<T>` doesn't work** when the host assembly has no `Main` entry point. `MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs` uses `TestServer + IHost` directly instead.
-- **Spark's antiforgery middleware does NOT block JSON POST requests** without an `X-XSRF-TOKEN` header in the test setup, despite `RequireAntiforgeryTokenAttribute(true)` metadata. The token-mint pattern in `SparkTestClient` works for positive cases (mirrors what the SPA sends in production), but the negative-case "POST without token → rejected" assertion was removed because the middleware accepted it. May or may not be intended Spark behavior — flagged for separate investigation.
+- **Built-in `app.UseAntiforgery()` only validates form-content bodies** (ASP.NET Core 8.0.1 breaking change). Spark's JSON API was therefore unprotected — `RequireAntiforgeryTokenAttribute(true)` metadata was effectively dead code. **Fixed** by adding a supplemental middleware in `UseSpark()` that runs BEFORE `UseAntiforgery()`, calls `IAntiforgery.ValidateRequestAsync` on any mutating method whose endpoint has `IAntiforgeryMetadata.RequiresValidation=true`, and sets a custom `IAntiforgeryValidationFeature` so (a) `FormFeature`'s "unvalidated" guard doesn't trip on later form reads and (b) `EndpointMiddleware` doesn't throw "contains anti-forgery metadata but no middleware was found". Covered by `AntiforgerySecurityTests`.
 - **`SPARK001` validation must accept `<ProjectReference OutputItemType="Analyzer">`**, not just `<PackageReference>`. The original implementation only checked PackageReference and broke monorepo Demo apps.
+- **Endpoint-level `IEndpointBase.Configure` metadata** (e.g., `RequireAntiforgeryTokenAttribute` on `Logout` / `ExecuteCustomAction`) is applied via a *convention*, not directly on the builder. The metadata only materializes into the `EndpointDataSource` after `app.StartAsync()`. Test shape: boot a `WebApplication`, `MapPost` a dummy endpoint, invoke the static `Configure` through a generic helper (`static void InvokeConfigure<TEndpoint>(RouteHandlerBuilder) where TEndpoint : IEndpointBase => TEndpoint.Configure(b)`), `StartAsync`, then enumerate `IEnumerable<EndpointDataSource>`.
+- **Octokit base-URL quirk:** `new GitHubClient(header, uri)` treats a custom base URL as GitHub Enterprise and prepends `/api/v3/` to every request; `new Connection(header, uri, credentialStore, httpClient, serializer)` does NOT. WireMock stubs need to account for both shapes — the App client (token minting) hits `/api/v3/app/installations/.../access_tokens` but the installation REST client hits `/repos/...` directly.
+- **NSubstitute can't record the "last call"** for methods whose parameter list includes a `Func<object, object>` (e.g., Octokit's `IHttpClient.Send(IRequest, CancellationToken, Func<object, object>)`). `Returns(...)` after such a call fails with `CouldNotSetReturnDueToNoLastCallException`. Workaround: use plain stub classes (`internal sealed class StubOctokitHttpClient : IHttpClient`) instead of `Substitute.For<IHttpClient>()`. This affected the `TokenRefreshingHttpClient` tests.
+- **`DateTime.Parse("2026-04-20T10:00:00Z")` drops the `Z` and returns a `Local`-kind `DateTime`.** Subtracting `DateTime.UtcNow` (UTC kind) then double-counts the machine's UTC offset, inflating "delay" assertions by hours. Parse with `DateTimeStyles.RoundtripKind` to preserve UTC kind. This hit the `RetryNumerator` linear-backoff test.
+- **WireMock.Net end-to-end flows use *scenarios* for sequenced responses.** For a 401 → refresh → retry test, use `.InScenario("retry").WhenStateIs(null).WillSetStateTo("after-401")` for the first call and `.WhenStateIs("after-401")` for the retry. State machine over header-matching is more robust — the stub keeps working across refactors.
+- **`TestServer.CreateWebSocketClient()` pre-upgrade failures** surface as `InvalidOperationException: Incomplete handshake, status code: NNN`, NOT as `WebSocketException`. When the endpoint returns `404`/`400` before calling `AcceptWebSocketAsync` (e.g., `StreamExecuteQuery`'s "unknown query" or "non-streaming query" paths), assert on the exception message's status-code substring rather than the exception type.
+- **`Microsoft.NET.Sdk.Web` implicitly stages `App_Data/**` as `Content` with `CopyToPublishDirectory=PreserveNewest`.** That propagates through `ProjectReference` chains. For libraries whose `App_Data/translations.json` only needs to be an `AdditionalFiles` input for the source generator (and NOT copied to the consuming app's publish output), add `<Content Remove="App_Data\translations.json" />`. Without it, apps that reference multiple Spark libraries hit `NETSDK1152` at publish time.
 
 ### 13.2 Angular / Vitest infrastructure
 
@@ -667,7 +671,7 @@ These are non-obvious things discovered while implementing. They cost real time 
   ```
   Three ticks is usually enough; five is a cheap upper bound.
 - **`RouterLink` in a non-router test setup** needs `provideRouter([])`. `SparkSubQueryComponent`'s template imports `RouterModule` for anchor-style links even though the component itself has no route, so any TestBed that renders it must include `provideRouter([])`.
-- **`SparkAuthBarComponent.onLogout()` has no try/catch** — if `logout()` rejects, `router.navigateByUrl('/')` is skipped. The test documents that as the current behavior. Worth fixing in a follow-up if logout-on-network-error should still log the user out locally.
+- **`SparkAuthBarComponent.onLogout()` now wraps the service call in `try { ... } finally { router.navigateByUrl('/') }`** so navigation runs even when `authService.logout()` rejects (network error, already expired session). The local session state is cleared by `SparkAuthService` regardless, and the user is returned to the anonymous area. The spec asserts this behavior on both success and rejection paths.
 
 ### 13.3 CI / Nx
 

--- a/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
+++ b/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.spec.ts
@@ -50,12 +50,15 @@ describe('SparkAuthBarComponent', () => {
     expect(TestBed.inject(Router).url).toBe('/');
   });
 
-  it('does not navigate when logout rejects (current implementation has no try/catch)', async () => {
+  it('still navigates back to root when authService.logout rejects', async () => {
     const { harness } = await setup();
     const c = await harness.navigateByUrl('/somewhere', SparkAuthBarComponent);
     c.authService.logout = vi.fn().mockRejectedValue(new Error('network'));
 
-    await expect(c.onLogout()).rejects.toThrow();
-    expect(TestBed.inject(Router).url).toBe('/somewhere');
+    const navigated = nextNavigationEnd();
+    await expect(c.onLogout()).rejects.toThrow('network');
+    await navigated;
+
+    expect(TestBed.inject(Router).url).toBe('/');
   });
 });

--- a/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.ts
+++ b/node_packages/ng-spark-auth/auth-bar/src/spark-auth-bar.component.ts
@@ -17,8 +17,14 @@ export class SparkAuthBarComponent {
   private readonly router = inject(Router);
 
   async onLogout(): Promise<void> {
-    await this.authService.logout();
-    this.router.navigateByUrl('/');
+    try {
+      await this.authService.logout();
+    } finally {
+      // Always navigate away from the authenticated area, even if the server-side
+      // logout call fails (network error, session already expired, etc.). The local
+      // session state has been cleared by SparkAuthService regardless.
+      this.router.navigateByUrl('/');
+    }
   }
 }
 


### PR DESCRIPTION
Three production fixes surfaced by the recent testing work (PRD-Testing §13), plus the PRD update that documents them.

## 1. Antiforgery gap (**security**)
Spark's mutating endpoints (\`Create\` / \`Update\` / \`Delete\` / \`Logout\` / \`ExecuteCustomAction\`) all carry \`RequireAntiforgeryTokenAttribute(true)\` metadata, but ASP.NET Core 8.0.1 narrowed \`UseAntiforgery()\` to validate only \`application/x-www-form-urlencoded\` and \`multipart/form-data\` bodies. Spark's API is JSON-only, so CSRF checks were silently skipped.

Fix: supplemental middleware in \`UseSpark()\` that runs **before** the built-in \`UseAntiforgery()\`, validates any mutating HTTP method whose endpoint has \`IAntiforgeryMetadata.RequiresValidation=true\`, and sets a Spark-provided \`IAntiforgeryValidationFeature\` so \`FormFeature\` and \`EndpointMiddleware\` treat the request as already checked. Covered by the new \`AntiforgerySecurityTests\`.

## 2. \`Token\` / \`token\` casing in \`TokenRefreshingHttpClient\`
On 401 the retry rewrite used lowercase \`token\`, while Octokit's \`Credentials\` serializer produces capital-T \`Token\`. Both work, but the mismatch was a footgun for WireMock header matchers. Aligning on capital T.

## 3. \`SparkAuthBarComponent.onLogout()\` swallowed navigation on error
\`await authService.logout()\` was unguarded — if it rejected (network error, session already expired), \`router.navigateByUrl('/')\` was skipped and the user stayed in the authenticated UI. \`try { await logout() } finally { navigate('/') }\` — spec updated to cover both paths.

## PRD update
\`docs/PRD-Testing.md\` → v1.3: totals updated (454 tests landed), done/deferred lists re-triaged, new §13 notes from recent batches (TestServer WebSocket exception shape, Octokit \`/api/v3\` prefix, NSubstitute \`Func<object,object>\` quirk, \`DateTime.Parse\` drops Kind, WireMock scenarios, \`App_Data/**\` NETSDK1152).

## Test plan
- [x] \`dotnet test\` — 246/246 passing (245 prior + 1 new negative antiforgery test)
- [x] \`ng-spark-auth\` — 53/53 (includes the updated \`onLogout\` rejection spec)
- [x] \`ng-spark\` — 156/156 (no changes here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)