### PR TITLE
test: SocketExtensions + DevTunnel extensions

### DIFF
--- a/MintPlayer.Spark.Tests/DevTunnel/GitHubWebhooksDevTunnelExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/DevTunnel/GitHubWebhooksDevTunnelExtensionsTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Webhooks.GitHub.Configuration;
+using MintPlayer.Spark.Webhooks.GitHub.DevTunnel.Configuration;
+using MintPlayer.Spark.Webhooks.GitHub.DevTunnel.Extensions;
+using MintPlayer.Spark.Webhooks.GitHub.DevTunnel.Services;
+
+namespace MintPlayer.Spark.Tests.DevTunnel;
+
+/// <summary>
+/// These extensions defer service registration: they call
+/// <c>options.RegisterService(s => ...)</c>, and the registrations only execute
+/// when <c>GitHubWebhooksOptions.ApplyRegistrations(services)</c> runs (during
+/// <c>AddSparkGitHubWebhooks</c> composition). Tests drive the option + invoke
+/// <c>ApplyRegistrations</c> directly.
+/// </summary>
+public class GitHubWebhooksDevTunnelExtensionsTests
+{
+    [Fact]
+    public void AddSmeeDevTunnel_registers_the_smee_background_service_and_binds_the_channel_url()
+    {
+        var options = new GitHubWebhooksOptions();
+
+        options.AddSmeeDevTunnel("https://smee.io/abc");
+
+        var services = Register(options);
+        var opts = services.GetRequiredService<IOptions<SmeeOptions>>().Value;
+        opts.ChannelUrl.Should().Be("https://smee.io/abc");
+
+        services.GetServices<IHostedService>().Should().ContainSingle(h => h is SmeeBackgroundService);
+    }
+
+    [Fact]
+    public void AddWebSocketDevTunnel_registers_the_websocket_client_service_and_binds_both_options()
+    {
+        var options = new GitHubWebhooksOptions();
+
+        options.AddWebSocketDevTunnel(
+            productionWebSocketUrl: "wss://prod.example.com/spark/github/dev-ws",
+            githubToken: "ghp_fake_token_123");
+
+        var services = Register(options);
+        var opts = services.GetRequiredService<IOptions<WebSocketDevTunnelOptions>>().Value;
+        opts.ProductionWebSocketUrl.Should().Be("wss://prod.example.com/spark/github/dev-ws");
+        opts.GitHubToken.Should().Be("ghp_fake_token_123");
+
+        services.GetServices<IHostedService>().Should().ContainSingle(h => h is WebSocketDevClientService);
+    }
+
+    [Fact]
+    public void Extension_methods_return_the_same_options_instance_for_fluent_chaining()
+    {
+        var options = new GitHubWebhooksOptions();
+
+        var r1 = options.AddSmeeDevTunnel("https://smee.io/abc");
+        var r2 = options.AddWebSocketDevTunnel("wss://x", "t");
+
+        r1.Should().BeSameAs(options);
+        r2.Should().BeSameAs(options);
+    }
+
+    [Fact]
+    public void Calling_both_extensions_on_the_same_options_registers_both_hosted_services()
+    {
+        var options = new GitHubWebhooksOptions();
+        options.AddSmeeDevTunnel("https://smee.io/abc");
+        options.AddWebSocketDevTunnel("wss://x", "t");
+
+        var services = Register(options);
+
+        var hosted = services.GetServices<IHostedService>().ToList();
+        hosted.Should().ContainSingle(h => h is SmeeBackgroundService);
+        hosted.Should().ContainSingle(h => h is WebSocketDevClientService);
+    }
+
+    /// <summary>
+    /// Builds the service provider the way GitHubWebhooksOptions.ApplyRegistrations would
+    /// during Spark composition. ApplyRegistrations is internal so it's invoked via reflection.
+    /// </summary>
+    private static ServiceProvider Register(GitHubWebhooksOptions options)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        // Dependencies the hosted services will need at activation time.
+        services.AddSingleton<Octokit.Webhooks.WebhookEventProcessor>(_ => new StubProcessor());
+
+        var apply = typeof(GitHubWebhooksOptions).GetMethod(
+            "ApplyRegistrations",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        apply.Invoke(options, [services]);
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StubProcessor : Octokit.Webhooks.WebhookEventProcessor
+    {
+    }
+}

--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -34,6 +34,8 @@
     <ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Authorization\MintPlayer.Spark.Authorization.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Webhooks.GitHub\MintPlayer.Spark.Webhooks.GitHub.csproj" />
+    <ProjectReference Include="..\MintPlayer.Spark.Webhooks.GitHub.DevTunnel\MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj" />
+    <ProjectReference Include="..\MintPlayer.Dotnet.SocketExtensions\MintPlayer.Dotnet.SocketExtensions.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Messaging\MintPlayer.Spark.Messaging.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Replication\MintPlayer.Spark.Replication.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.SubscriptionWorker\MintPlayer.Spark.SubscriptionWorker.csproj" />

--- a/MintPlayer.Spark.Tests/SocketExtensions/SocketExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/SocketExtensions/SocketExtensionsTests.cs
@@ -1,0 +1,180 @@
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+
+namespace MintPlayer.Spark.Tests.SocketExtensions;
+
+/// <summary>
+/// Exercises <see cref="System.Net.WebSockets.SocketExtensions"/> against a real
+/// connected WebSocket pair served by TestServer. Each test spins up a fresh host
+/// whose server-side handler decides what to send/receive; the client-side is a
+/// <see cref="ClientWebSocket"/> obtained via <see cref="TestServer.CreateWebSocketClient"/>.
+/// </summary>
+public class SocketExtensionsTests : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private Func<WebSocket, Task> _serverHandler = _ => Task.CompletedTask;
+
+    public async Task InitializeAsync()
+    {
+        _host = new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseWebSockets();
+                    app.Use(async (context, next) =>
+                    {
+                        if (context.WebSockets.IsWebSocketRequest)
+                        {
+                            using var ws = await context.WebSockets.AcceptWebSocketAsync();
+                            await _serverHandler(ws);
+                            return;
+                        }
+                        await next();
+                    });
+                }))
+            .Build();
+        await _host.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task<WebSocket> ConnectAsync()
+    {
+        var wsClient = _host.GetTestServer().CreateWebSocketClient();
+        return await wsClient.ConnectAsync(
+            new Uri(_host.GetTestServer().BaseAddress, "/"),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WriteMessage_then_ReadMessage_round_trips_a_short_string()
+    {
+        string? receivedOnServer = null;
+        _serverHandler = async ws =>
+        {
+            receivedOnServer = await ws.ReadMessage();
+            await ws.WriteMessage("echo:" + receivedOnServer);
+        };
+
+        var client = await ConnectAsync();
+        await client.WriteMessage("hello");
+        var echoed = await client.ReadMessage();
+
+        receivedOnServer.Should().Be("hello");
+        echoed.Should().Be("echo:hello");
+    }
+
+    [Fact]
+    public async Task ReadMessage_reassembles_a_body_that_spans_multiple_receive_frames()
+    {
+        // Internal buffer is 512 bytes — send something much bigger so the loop runs.
+        var payload = new string('a', 2048);
+        _serverHandler = async ws =>
+        {
+            var incoming = await ws.ReadMessage();
+            await ws.WriteMessage(incoming);
+        };
+
+        var client = await ConnectAsync();
+        await client.WriteMessage(payload);
+        var echoed = await client.ReadMessage();
+
+        echoed.Should().Be(payload);
+        echoed.Length.Should().Be(2048);
+    }
+
+    [Fact]
+    public async Task WriteMessage_splits_long_payloads_into_frames_marking_only_the_last_as_EndOfMessage()
+    {
+        // Record the frames the server receives from the helper's SendAsync.
+        var frames = new List<(int Count, bool EndOfMessage)>();
+        var done = new TaskCompletionSource();
+        _serverHandler = async ws =>
+        {
+            var buffer = new byte[256];
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+                frames.Add((result.Count, result.EndOfMessage));
+            } while (!result.EndOfMessage);
+            done.TrySetResult();
+            // Echo anything back so the client can close cleanly.
+            await ws.WriteMessage("ack");
+        };
+
+        var client = await ConnectAsync();
+        await client.WriteMessage(new string('x', 1300));
+        await done.Task;
+        _ = await client.ReadMessage();
+
+        frames.Sum(f => f.Count).Should().Be(1300);
+        frames.SkipLast(1).Should().OnlyContain(f => !f.EndOfMessage);
+        frames.Last().EndOfMessage.Should().BeTrue();
+        frames.Count.Should().BeGreaterThan(1, "1300 bytes cannot fit in a single non-final frame");
+    }
+
+    [Fact]
+    public async Task ReadMessage_throws_WebSocketException_when_the_peer_sends_a_Close_frame()
+    {
+        _serverHandler = async ws =>
+        {
+            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+        };
+
+        var client = await ConnectAsync();
+        var act = async () => await client.ReadMessage();
+
+        await act.Should().ThrowAsync<WebSocketException>()
+            .WithMessage("*closed*");
+    }
+
+    [Fact]
+    public async Task WriteObject_and_ReadObject_round_trip_a_POCO_via_JSON()
+    {
+        Envelope? receivedOnServer = null;
+        _serverHandler = async ws =>
+        {
+            receivedOnServer = await ws.ReadObject<Envelope>();
+            await ws.WriteObject(new Envelope { Type = "ack", Value = receivedOnServer?.Value ?? 0 });
+        };
+
+        var client = await ConnectAsync();
+        await client.WriteObject(new Envelope { Type = "ping", Value = 42 });
+        var reply = await client.ReadObject<Envelope>();
+
+        receivedOnServer!.Type.Should().Be("ping");
+        receivedOnServer.Value.Should().Be(42);
+        reply!.Type.Should().Be("ack");
+        reply.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task ReadObject_returns_null_when_the_peer_sent_the_JSON_literal_null()
+    {
+        _serverHandler = async ws =>
+        {
+            await ws.WriteMessage("null");
+        };
+
+        var client = await ConnectAsync();
+        var reply = await client.ReadObject<Envelope>();
+
+        reply.Should().BeNull();
+    }
+
+    private sealed class Envelope
+    {
+        public string Type { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}

--- a/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
+++ b/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
@@ -20,6 +20,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="MintPlayer.Spark.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\MintPlayer.Spark.Webhooks.GitHub\MintPlayer.Spark.Webhooks.GitHub.csproj" />
 		<ProjectReference Include="..\MintPlayer.Dotnet.SocketExtensions\MintPlayer.Dotnet.SocketExtensions.csproj" />
 	</ItemGroup>

--- a/docs/PRD-Testing.md
+++ b/docs/PRD-Testing.md
@@ -610,14 +610,14 @@ jobs:
 
 ## 12. Implementation status (as of 2026-04-20)
 
-**454 tests passing across the monorepo** — 245 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 156 ng-spark.
+**464 tests passing across the monorepo** — 256 .NET (`MintPlayer.Spark.Tests`) + 53 ng-spark-auth + 156 ng-spark.
 
 ### Done ✅
 
 - **M1 (infrastructure)** — `MintPlayer.Spark.Testing` project, FluentAssertions everywhere, Vitest + `@analogjs/vite-plugin-angular` in both Angular libs, Nx + `@nx-dotnet/core` + Nx Cloud, license env-var wiring, CI workflow rewritten.
 - **M2 partial** — `AccessControlService` (15), `ClaimsGroupMembershipProvider` (10), `ValidationService` (18), `SecurityConfigurationLoader` (11), `QueryExecutor` (9 unit + 7 integration via `SparkTestDriver`).
 - **M3 endpoints** — `PersistentObject` GET/LIST/CREATE/UPDATE/DELETE (18) via `SparkEndpointFactory`; `Queries` GET/LIST/EXECUTE (12); `Authorization` — `GetCurrentUser` + `Logout` + `CsrfRefresh` + `SparkAuthGroup` (10); `Custom Actions` — `ListCustomActions` + `ExecuteCustomAction` (16); `StreamExecuteQuery` WebSocket (7) + `StreamingDiffEngine` (9).
-- **M3 services** — `GitHubInstallationService` cache + JWT + decorators via reflection (15); WireMock.Net-backed end-to-end token refresh + 401-retry (5, behind a new `IGitHubClientFactory` seam); `RetryNumerator` (6); `MessageBus` (5) + `MessageCheckpoint` (3); `EtlScriptCollector` (5) + `SyncActionInterceptor` (8).
+- **M3 services** — `GitHubInstallationService` cache + JWT + decorators via reflection (15); WireMock.Net-backed end-to-end token refresh + 401-retry (5, behind a new `IGitHubClientFactory` seam); `RetryNumerator` (6); `MessageBus` (5) + `MessageCheckpoint` (3); `EtlScriptCollector` (5) + `SyncActionInterceptor` (8); `SocketExtensions` (6, via TestServer WebSocket pair); `GitHubWebhooksDevTunnelExtensions` (4, `AddSmeeDevTunnel` + `AddWebSocketDevTunnel` composition).
 - **M3 Angular** — `SparkAuthService` + guard + interceptor (15), all 6 ng-spark-auth components (27), all 22 ng-spark pipes (70), `RetryActionService` + `IconRegistry` + `IconComponent` + `RetryActionModal` (17), `SparkPoCreate` + `SparkPoEdit` + `SparkQueryList` (21), `SparkPoFormComponent` + `SparkPoDetailComponent` + `SparkSubQueryComponent` (43).
 
 ### Deferred (handoff for next sessions)
@@ -626,7 +626,6 @@ jobs:
 |---|---|---|
 | **Subscription-worker end-to-end flows** | `MessageSubscriptionWorker` + `SyncActionSubscriptionWorker` happy path, retry, dead-letter, non-retryable exception routing — require a real running RavenDB subscription | Seed `SparkMessage` / `SparkSyncAction` docs via `SparkTestDriver.Store`, start the worker, poll for terminal status with `WaitFor(...)`. `MaxDocsPerBatch = 1` keeps assertions deterministic. `RollupMessageStatus` + handler-level retry/backoff are the high-value paths. |
 | **Source-generator snapshot tests** | Generator targets `netstandard2.0` and pulls `MintPlayer.SourceGenerators.Tools` polyfills (esp. `ModuleInitializerAttribute`) that collide with `net10.0`'s `System.Runtime` at test load time | A first attempt with `Assembly.LoadFrom` from a separate `MintPlayer.Spark.SourceGenerators.Tests` project + `ExcludeAssets="compile"` on Tools got further but still hit `Microsoft.CodeAnalysis.CSharp` version mismatch. Worth a dedicated focused session with pinned `Microsoft.CodeAnalysis.Testing` versions across the dep graph. |
-| **DevTunnel + SocketExtensions** | Smaller, both should fit one batch | `MintPlayer.Spark.Webhooks.GitHub.DevTunnel` helpers + `MintPlayer.Dotnet.SocketExtensions` utilities. Unit-testable, no external infra. |
 | **AllFeatures source generator** | Smaller, included with the source-generator session above | |
 | **E2E test host + Playwright** (M4) | All M3 should be done first to avoid duplicating coverage | New `MintPlayer.Spark.E2E.TestHost` ASP.NET Core + Angular app. Playwright for .NET runs against it. |
 


### PR DESCRIPTION
Closes the two smallest deferred items from PRD §12.

## SocketExtensions (6)
Tests the \`ReadMessage\` / \`WriteMessage\` / \`ReadObject\` / \`WriteObject\` helpers against a real connected WebSocket pair served by TestServer:
- Short-string round-trip
- Multi-receive-frame reassembly (2048-byte body vs the helper's 512-byte internal buffer)
- Long-payload splitting across multiple send frames, \`EndOfMessage=true\` only on the last (synchronized via TaskCompletionSource so assertions run after the server drains the loop)
- Close-frame throws \`WebSocketException\`
- POCO JSON round-trip
- Literal \`null\` JSON returns \`null\`

## DevTunnel extensions (4)
Covers \`AddSmeeDevTunnel\` and \`AddWebSocketDevTunnel\`:
- Each registers its hosted service and binds the right options
- Both return the same \`GitHubWebhooksOptions\` for fluent chaining
- Calling both on the same options registers both services

\`GitHubWebhooksOptions.ApplyRegistrations\` is internal, so the test composes it via reflection — mirrors what \`AddSparkGitHubWebhooks\` does at framework compose time.

## Infra
- \`InternalsVisibleTo → MintPlayer.Spark.Tests\` on \`MintPlayer.Spark.Webhooks.GitHub.DevTunnel\`
- Test-project \`ProjectReferences\` to both DevTunnel and SocketExtensions

## Test plan
- [x] \`dotnet test\` — 256/256 passing (246 prior + 10 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)