### PR TITLE
fix(nx): disable Nx cache for E2E test target

### DIFF
--- a/MintPlayer.Spark.E2E.Tests/project.json
+++ b/MintPlayer.Spark.E2E.Tests/project.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "name": "MintPlayer.Spark.E2E.Tests",
+  "targets": {
+    "test": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

On PR #118 the CI run reported 4/4 E2E tests passing in 1 second — but the log showed `Remote Cache Hit` and no Playwright install / Fleet boot output. Nx Cloud was replaying the pass from a local Windows run. **Playwright had never actually run on the Linux CI runner.**

This is correct for unit and integration tests (deterministic from source + package refs) but **wrong for E2E** — those tests interact with live subprocesses and platform-specific browser binaries, so a pass on one machine doesn't prove anything about another.

## Change

Adds `MintPlayer.Spark.E2E.Tests/project.json` with `test.cache: false`. Confirmed via `nx show project`:
- `MintPlayer.Spark.Tests` → `test.cache = true` (unchanged — still cacheable)
- `MintPlayer.Spark.E2E.Tests` → `test.cache = false` (new)

Re-ran `nx run MintPlayer.Spark.E2E.Tests:test` twice locally: build tasks hit cache, `test` target re-executes each time (8s, 4 passed).

## Test plan
- [x] `nx show project MintPlayer.Spark.E2E.Tests` → `test.cache = False`
- [x] `nx show project MintPlayer.Spark.Tests` → `test.cache = True`
- [x] Local `nx run MintPlayer.Spark.E2E.Tests:test` executes fresh (no cache replay)
- [ ] Next CI run should show Playwright install + Fleet boot output (cache miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)