### PR TITLE
ci: cache Playwright Chromium between runs

### DIFF
--- a/.github/workflows/dotnet-build-master.yml
+++ b/.github/workflows/dotnet-build-master.yml
@@ -55,6 +55,21 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
+    - name: Resolve Playwright version
+      id: playwright
+      run: |
+        version=$(grep -oE 'Microsoft\.Playwright"[[:space:]]*Version="[^"]+"' MintPlayer.Spark.E2E.Tests/MintPlayer.Spark.E2E.Tests.csproj \
+          | grep -oE 'Version="[^"]+"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
     - name: Test
       run: dotnet test --no-restore --verbosity normal
       env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,6 +48,22 @@ jobs:
       env:
         NUGET_AUTH_TOKEN: ${{ github.token }}
 
+    - name: Resolve Playwright version
+      id: playwright
+      run: |
+        version=$(grep -oE 'Microsoft\.Playwright"[[:space:]]*Version="[^"]+"' MintPlayer.Spark.E2E.Tests/MintPlayer.Spark.E2E.Tests.csproj \
+          | grep -oE 'Version="[^"]+"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "Playwright version: ${version}"
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
     - name: Run affected tests (.NET + Angular via Nx)
       run: npx nx affected --target=test --exclude=@spark-demo/*,DemoApp,DemoApp.Library,Fleet,Fleet.Library,HR,HR.Library,WebhooksDemo,WebhooksDemo.Library
       env:


### PR DESCRIPTION
## Summary

The E2E fixture runs `playwright install chromium --with-deps` on every test session. On a fresh CI runner that downloads ~150MB of Chromium every time, adding ~30–60s to each PR's feedback loop.

Adds an `actions/cache@v4` step that restores `~/.cache/ms-playwright` keyed on `runner.os` + the `Microsoft.Playwright` NuGet version (extracted from the E2E csproj by a small shell step). Cache invalidates cleanly when the package upgrades; partial `restore-keys` keep us warm across minor version shifts.

Applied to both workflows that exercise the E2E suite:
- `pull-request.yml` (via `nx affected`)
- `dotnet-build-master.yml` (via `dotnet test`)

The fixture's in-process `Microsoft.Playwright.Program.Main(["install", ...])` call stays — it's idempotent when browsers are already cached, and keeps local dev + first-ever CI run on a clean runner working.

## Test plan
- [ ] First CI run will have a cache miss + populate (~same duration as before)
- [ ] Subsequent runs should hit the cache (look for `Cache restored successfully` in the log + faster E2E boot)
- [ ] Upgrading `Microsoft.Playwright` later should auto-invalidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)