### PR TITLE
Security audit: PRD + 28 e2e tests pinning secure behaviour

### DIFF
--- a/.github/workflows/webhooks-demo-deploy.yml
+++ b/.github/workflows/webhooks-demo-deploy.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/Demo/Fleet/Fleet.Library/Entities/Car.cs
+++ b/Demo/Fleet/Fleet.Library/Entities/Car.cs
@@ -18,4 +18,12 @@ public class Car
 
     [LookupReference(typeof(LookupReferences.CarBrand))]
     public string? Brand { get; set; }
+
+    /// <summary>
+    /// User id of the account that created the record. Set on create by CarActions; used
+    /// by the row-level auth hook to restrict non-admin callers to their own cars.
+    /// Demo field: wouldn't necessarily live on the entity in a production app (could be
+    /// a metadata field), but keeping it on the entity is the simplest illustration.
+    /// </summary>
+    public string? CreatedBy { get; set; }
 }

--- a/Demo/Fleet/Fleet/Actions/CarActions.cs
+++ b/Demo/Fleet/Fleet/Actions/CarActions.cs
@@ -1,6 +1,8 @@
+using System.Security.Claims;
 using Fleet.Entities;
 using Fleet.Indexes;
 using Fleet.LookupReferences;
+using Microsoft.AspNetCore.Http;
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Actions;
@@ -12,9 +14,34 @@ namespace Fleet.Actions;
 public partial class CarActions : DefaultPersistentObjectActions<Car>
 {
     [Inject] private readonly IManager manager;
+    [Inject] private readonly IHttpContextAccessor httpContextAccessor;
+
+    private const string AdminRole = "Administrators";
+
+    private ClaimsPrincipal? CurrentUser => httpContextAccessor.HttpContext?.User;
+    private string? CurrentUserId => CurrentUser?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    private bool CurrentUserIsAdmin => CurrentUser?.IsInRole(AdminRole) == true;
+
+    /// <summary>
+    /// Row-level auth (H-2): administrators see/edit/delete everything; other authenticated
+    /// users only act on cars they created. An unauthenticated caller (which would already be
+    /// blocked by entity-type authz in Fleet's security.json) falls through to deny.
+    /// </summary>
+    public override Task<bool> IsAllowedAsync(string action, Car entity)
+    {
+        if (CurrentUserIsAdmin) return Task.FromResult(true);
+        var userId = CurrentUserId;
+        if (string.IsNullOrEmpty(userId)) return Task.FromResult(false);
+        return Task.FromResult(string.Equals(entity.CreatedBy, userId, StringComparison.Ordinal));
+    }
 
     public override async Task OnBeforeSaveAsync(PersistentObject obj, Car entity)
     {
+        // Stamp the creator id on first save. Preserve it on subsequent updates so the
+        // row-level auth check stays consistent even if the owner changes password/email.
+        if (string.IsNullOrEmpty(entity.CreatedBy))
+            entity.CreatedBy = CurrentUserId;
+
         var statusAttr = obj.Attributes.FirstOrDefault(a => a.Name == nameof(Car.Status));
         if (statusAttr?.IsValueChanged == true && entity.Status == CarStatus.Stolen)
         {

--- a/Demo/Fleet/Fleet/App_Data/Model/Car.json
+++ b/Demo/Fleet/Fleet/App_Data/Model/Car.json
@@ -203,6 +203,24 @@
         "lookupReferenceType": "CarBrand",
         "showedOn": "Query, PersistentObject",
         "rules": []
+      },
+      {
+        "id": "b8a4d2f1-1c3e-4a7b-9d5e-6c8f2a4b3d1e",
+        "name": "CreatedBy",
+        "label": {
+          "en": "Created By",
+          "fr": "Créé par",
+          "nl": "Aangemaakt door"
+        },
+        "dataType": "string",
+        "isRequired": false,
+        "isVisible": false,
+        "isReadOnly": true,
+        "order": 100,
+        "isArray": false,
+        "inQueryType": false,
+        "showedOn": "PersistentObject",
+        "rules": []
       }
     ]
   },

--- a/Demo/Fleet/Fleet/Program.cs
+++ b/Demo/Fleet/Fleet/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddSparkFull(builder.Configuration, options =>
         opt.SparkModulesDatabase = section["SparkModulesDatabase"] ?? "SparkModules";
         opt.AssembliesToScan = [typeof(Fleet.Replicated.Person).Assembly];
     };
+    options.RateLimiter = _ => { };
 });
 
 builder.Services.ConfigureApplicationCookie(options =>

--- a/MintPlayer.Spark.Abstractions/PersistentObject.cs
+++ b/MintPlayer.Spark.Abstractions/PersistentObject.cs
@@ -7,6 +7,14 @@ public sealed class PersistentObject
     public required Guid ObjectTypeId { get; set; }
     public string? Breadcrumb { get; set; }
     public PersistentObjectAttribute[] Attributes { get; set; } = [];
+
+    /// <summary>
+    /// Optimistic-concurrency token. Populated by the server on read (RavenDB's change
+    /// vector for the underlying entity). Clients should echo the value back on update —
+    /// if the server's current change vector differs, the update is rejected with HTTP 409.
+    /// Null on create and when the caller doesn't opt in.
+    /// </summary>
+    public string? Etag { get; set; }
 }
 
 public sealed class PersistentObjectAttribute

--- a/MintPlayer.Spark.AllFeatures.SourceGenerators/Generators/SparkFullGenerator.Producer.cs
+++ b/MintPlayer.Spark.AllFeatures.SourceGenerators/Generators/SparkFullGenerator.Producer.cs
@@ -102,6 +102,13 @@ public class SparkFullProducer : Producer
                         writer.WriteLine("global::MintPlayer.Spark.Replication.SparkBuilderReplicationExtensions.AddReplication(spark, options.Replication);");
                     }
                 }
+
+                // Rate limiter is opt-in per security audit finding L-3 — framework stays
+                // out of rate-limiting policy; apps enable it via options.RateLimiter.
+                using (writer.OpenBlock("if (options.RateLimiter != null)"))
+                {
+                    writer.WriteLine("global::MintPlayer.Spark.Extensions.SparkBuilderRateLimiterExtensions.AddRateLimiter(spark, options.RateLimiter);");
+                }
             }
             writer.WriteLine(");");
             writer.WriteLine("return services;");

--- a/MintPlayer.Spark.AllFeatures/SparkFullOptions.cs
+++ b/MintPlayer.Spark.AllFeatures/SparkFullOptions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using MintPlayer.Spark.Authorization.Configuration;
+using MintPlayer.Spark.Extensions;
 using MintPlayer.Spark.Messaging;
 using MintPlayer.Spark.Replication.Abstractions.Configuration;
 
@@ -35,4 +36,11 @@ public class SparkFullOptions
     /// When null, replication is not enabled.
     /// </summary>
     public Action<SparkReplicationOptions>? Replication { get; set; }
+
+    /// <summary>
+    /// Configures the Spark rate limiter (partitioned by client IP, scoped to <c>/spark/</c>).
+    /// When null, the limiter is not wired — demo/production apps opt in.
+    /// Set to <c>_ =&gt; { }</c> to enable with default limits (150 requests / 10 s).
+    /// </summary>
+    public Action<SparkRateLimiterOptions>? RateLimiter { get; set; }
 }

--- a/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
+++ b/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MintPlayer.Spark.Client/SparkClient.cs
+++ b/MintPlayer.Spark.Client/SparkClient.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+
+namespace MintPlayer.Spark.Client;
+
+/// <summary>
+/// Typed .NET client for a Spark backend. Handles CSRF round-tripping (warmup GET +
+/// <c>X-XSRF-TOKEN</c> header on mutating requests), serialization, and status-to-exception
+/// translation so callers can work in terms of <see cref="PersistentObject"/> and
+/// <see cref="QueryResult"/> instead of hand-building JSON bodies and URL strings.
+///
+/// Two construction modes:
+/// <list type="bullet">
+///   <item><description><c>new SparkClient(baseUrl)</c> — real HTTP use; owns an internal <see cref="HttpClient"/>.</description></item>
+///   <item><description><c>new SparkClient(httpClient)</c> — wrap an existing client (e.g. one returned
+///     by <c>SparkEndpointFactory.CreateClient()</c> for <c>TestServer</c>-backed tests).</description></item>
+/// </list>
+/// </summary>
+public class SparkClient : IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsClient;
+    private string? _cookieHeader;
+    private string? _xsrfToken;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public SparkClient(string baseUrl)
+        : this(new HttpClient { BaseAddress = new Uri(baseUrl) }, ownsClient: true)
+    {
+    }
+
+    public SparkClient(HttpClient httpClient, bool ownsClient = false)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _ownsClient = ownsClient;
+    }
+
+    // --------------------------------------------------------------------------------
+    // PersistentObject endpoints
+    // --------------------------------------------------------------------------------
+
+    /// <summary>Returns the PersistentObject with its <see cref="PersistentObject.Etag"/> populated, or null on 404.</summary>
+    public async Task<PersistentObject?> GetPersistentObjectAsync(Guid objectTypeId, string id, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"/spark/po/{objectTypeId}/{Uri.EscapeDataString(id)}", cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+        await ThrowIfNotSuccessAsync(response, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<PersistentObject>(JsonOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a new PersistentObject. The instance's <see cref="PersistentObject.Id"/> must be
+    /// null on input; the server assigns it and returns the populated object.
+    /// </summary>
+    public Task<PersistentObject> CreatePersistentObjectAsync(PersistentObject obj, CancellationToken cancellationToken = default)
+    {
+        if (obj is null) throw new ArgumentNullException(nameof(obj));
+        var target = $"/spark/po/{obj.Name}";
+        return SendPersistentObjectAsync(HttpMethod.Post, target, obj, cancellationToken);
+    }
+
+    /// <summary>
+    /// Updates an existing PersistentObject. The instance's <see cref="PersistentObject.Id"/> is
+    /// required; <see cref="PersistentObject.Etag"/> is echoed back to the server for the
+    /// optimistic-concurrency check — a stale etag surfaces as <see cref="SparkClientException"/>
+    /// with <c>StatusCode = HttpStatusCode.Conflict</c>.
+    /// </summary>
+    public Task<PersistentObject> UpdatePersistentObjectAsync(PersistentObject obj, CancellationToken cancellationToken = default)
+    {
+        if (obj is null) throw new ArgumentNullException(nameof(obj));
+        if (string.IsNullOrEmpty(obj.Id))
+            throw new ArgumentException("PersistentObject must have an Id for update.", nameof(obj));
+        var target = $"/spark/po/{obj.ObjectTypeId}/{Uri.EscapeDataString(obj.Id)}";
+        return SendPersistentObjectAsync(HttpMethod.Put, target, obj, cancellationToken);
+    }
+
+    public async Task DeletePersistentObjectAsync(Guid objectTypeId, string id, CancellationToken cancellationToken = default)
+    {
+        await EnsureAntiforgeryAsync(cancellationToken);
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/spark/po/{objectTypeId}/{Uri.EscapeDataString(id)}");
+        AttachAntiforgery(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        await ThrowIfNotSuccessAsync(response, cancellationToken);
+    }
+
+    // --------------------------------------------------------------------------------
+    // Query endpoints
+    // --------------------------------------------------------------------------------
+
+    public async Task<QueryResult> ExecuteQueryAsync(
+        Guid queryId,
+        int skip = 0,
+        int take = 50,
+        string? search = null,
+        string? parentId = null,
+        string? parentType = null,
+        CancellationToken cancellationToken = default)
+    {
+        var url = BuildQueryUrl(queryId.ToString(), skip, take, search, parentId, parentType);
+        return await ExecuteQueryAsyncCore(url, cancellationToken);
+    }
+
+    /// <summary>Executes a query by its alias (e.g. <c>"allpeople"</c>) instead of by Guid.</summary>
+    public async Task<QueryResult> ExecuteQueryAsync(
+        string queryAlias,
+        int skip = 0,
+        int take = 50,
+        string? search = null,
+        string? parentId = null,
+        string? parentType = null,
+        CancellationToken cancellationToken = default)
+    {
+        var url = BuildQueryUrl(Uri.EscapeDataString(queryAlias), skip, take, search, parentId, parentType);
+        return await ExecuteQueryAsyncCore(url, cancellationToken);
+    }
+
+    private async Task<QueryResult> ExecuteQueryAsyncCore(string url, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+        await ThrowIfNotSuccessAsync(response, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<QueryResult>(JsonOptions, cancellationToken)
+            ?? throw new SparkClientException(response.StatusCode, responseBody: null, "Empty query response body.");
+    }
+
+    private static string BuildQueryUrl(string idSegment, int skip, int take, string? search, string? parentId, string? parentType)
+    {
+        var qs = new List<string> { $"skip={skip}", $"take={take}" };
+        if (!string.IsNullOrEmpty(search)) qs.Add($"search={Uri.EscapeDataString(search)}");
+        if (!string.IsNullOrEmpty(parentId)) qs.Add($"parentId={Uri.EscapeDataString(parentId)}");
+        if (!string.IsNullOrEmpty(parentType)) qs.Add($"parentType={Uri.EscapeDataString(parentType)}");
+        return $"/spark/queries/{idSegment}/execute?{string.Join('&', qs)}";
+    }
+
+    // --------------------------------------------------------------------------------
+    // CSRF / internals
+    // --------------------------------------------------------------------------------
+
+    private async Task<PersistentObject> SendPersistentObjectAsync(HttpMethod method, string url, PersistentObject obj, CancellationToken cancellationToken)
+    {
+        await EnsureAntiforgeryAsync(cancellationToken);
+        var request = new HttpRequestMessage(method, url)
+        {
+            Content = JsonContent.Create(new { persistentObject = obj }, options: JsonOptions),
+        };
+        AttachAntiforgery(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        await ThrowIfNotSuccessAsync(response, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<PersistentObject>(JsonOptions, cancellationToken)
+            ?? throw new SparkClientException(response.StatusCode, responseBody: null, "Empty response body.");
+    }
+
+    /// <summary>
+    /// Lazily primes <see cref="_cookieHeader"/> and <see cref="_xsrfToken"/> by hitting the
+    /// framework's antiforgery warmup endpoint. Only called before the first mutating request —
+    /// reads don't need CSRF.
+    /// </summary>
+    private async Task EnsureAntiforgeryAsync(CancellationToken cancellationToken)
+    {
+        if (_xsrfToken is not null) return;
+
+        var response = await _httpClient.GetAsync("/spark/po/__warmup__", cancellationToken);
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+            throw new SparkClientException(response.StatusCode, responseBody: null,
+                "Warmup did not return any Set-Cookie headers — is this endpoint a Spark backend?");
+
+        string? antiforgeryCookie = null;
+        string? xsrfToken = null;
+        foreach (var raw in setCookies)
+        {
+            var nameValue = raw.Split(';', 2)[0];
+            var eq = nameValue.IndexOf('=');
+            if (eq < 0) continue;
+            var name = nameValue[..eq];
+            var value = nameValue[(eq + 1)..];
+
+            if (name.StartsWith(".AspNetCore.Antiforgery", StringComparison.Ordinal))
+                antiforgeryCookie = nameValue;
+            else if (name == "XSRF-TOKEN")
+                xsrfToken = Uri.UnescapeDataString(value);
+        }
+
+        if (antiforgeryCookie is null || xsrfToken is null)
+            throw new SparkClientException(response.StatusCode, responseBody: null,
+                $"Warmup did not yield both antiforgery cookies. Got: '{string.Join(" | ", setCookies)}'");
+
+        _cookieHeader = antiforgeryCookie + "; XSRF-TOKEN=" + Uri.EscapeDataString(xsrfToken);
+        _xsrfToken = xsrfToken;
+    }
+
+    private void AttachAntiforgery(HttpRequestMessage request)
+    {
+        if (_cookieHeader is null || _xsrfToken is null)
+            throw new InvalidOperationException("Antiforgery tokens not initialized — call EnsureAntiforgeryAsync first.");
+        request.Headers.Add("Cookie", _cookieHeader);
+        request.Headers.Add("X-XSRF-TOKEN", _xsrfToken);
+    }
+
+    private static async Task ThrowIfNotSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode) return;
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        throw new SparkClientException(
+            response.StatusCode,
+            body,
+            $"Spark request failed with {(int)response.StatusCode} {response.StatusCode}: {Truncate(body, 500)}");
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max] + "…";
+
+    public void Dispose()
+    {
+        if (_ownsClient) _httpClient.Dispose();
+    }
+}

--- a/MintPlayer.Spark.Client/SparkClientException.cs
+++ b/MintPlayer.Spark.Client/SparkClientException.cs
@@ -1,0 +1,22 @@
+using System.Net;
+
+namespace MintPlayer.Spark.Client;
+
+/// <summary>
+/// Thrown by <see cref="SparkClient"/> when the server returns a non-success HTTP status code.
+/// Tests and call sites can inspect <see cref="StatusCode"/> (e.g. <c>HttpStatusCode.Conflict</c>
+/// for optimistic-concurrency rejection, <c>HttpStatusCode.NotFound</c> for missing or
+/// row-level-denied entities) and <see cref="ResponseBody"/> for the server's error payload.
+/// </summary>
+public sealed class SparkClientException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+    public string? ResponseBody { get; }
+
+    public SparkClientException(HttpStatusCode statusCode, string? responseBody, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+        ResponseBody = responseBody;
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// L-7a / L-7b — an attribute with <c>IsReadOnly=true</c> or <c>IsVisible=false</c> in the
+/// schema must not be writable via PUT/POST. Today the framework maps any attribute present
+/// in the body onto the entity; this test pins the expected secure behaviour.
+///
+/// Strategy: this test dynamically promotes one of Car's attributes to IsReadOnly (via a
+/// local override of the model JSON isn't possible from the test), so instead we exercise
+/// the Car.Brand or Car.Status field which is driven by a lookupReferenceType — the
+/// framework *should* reject values that aren't in the lookup, but separately should also
+/// reject attempts to set fields whose schema definition marks them IsReadOnly.
+///
+/// Because Fleet's default Car schema has no IsReadOnly=true field, these tests will be
+/// meaningful only once the remediation PR adds a representative read-only field. For now
+/// they assert that a clearly synthetic client-only field ("Id" posted as an attribute
+/// value) is ignored on update.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class AttributeWriteProtectionTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public AttributeWriteProtectionTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    private async Task<(SparkApi api, string carId)> LoginAndCreateCarAsync(Microsoft.Playwright.IPage page)
+    {
+        var api = await SparkApi.LoginAsync(page, _fixture.Host, _fixture.Host.AdminEmailAddress, _fixture.Host.AdminPass);
+
+        var plate = $"RO{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
+        var createResp = await api.PostJsonAsync("/spark/po/Car", new
+        {
+            persistentObject = new
+            {
+                objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                attributes = new object[]
+                {
+                    new { name = "LicensePlate", value = plate },
+                    new { name = "Model",        value = "X1" },
+                    new { name = "Year",         value = 2024 },
+                },
+            },
+        });
+        createResp.Status.Should().BeOneOf(new[] { 200, 201 }, $"create failed: {await createResp.TextAsync()}");
+
+        var body = await createResp.JsonAsync();
+        var id = body!.Value.GetProperty("id").GetString()!;
+        return (api, id);
+    }
+
+    [Fact]
+    public async Task Update_with_IsReadOnly_attribute_in_body_does_not_modify_field()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var (api, id) = await LoginAndCreateCarAsync(page);
+
+        // Send an update that includes an attribute the schema marks IsReadOnly=true.
+        // Fleet's default schema has no IsReadOnly=true attribute on Car, so for this
+        // test to be meaningful the remediation PR must introduce one (e.g. CreatedAt).
+        var putResp = await api.PutJsonAsync(
+            $"/spark/po/Car/{Uri.EscapeDataString(id)}",
+            new
+            {
+                persistentObject = new
+                {
+                    id,
+                    objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                    attributes = new object[]
+                    {
+                        new { name = "LicensePlate", value = "ROMOD123" },
+                        new { name = "Model",        value = "X1" },
+                        new { name = "Year",         value = 2024 },
+                    },
+                },
+            });
+
+        putResp.Status.Should().BeLessThan(500,
+            "update with read-only attribute should produce a 2xx (ignoring the field) or a 4xx (rejecting the request), not 500");
+    }
+
+    [Fact]
+    public async Task Update_cannot_escalate_via_unknown_attribute_name()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var (api, id) = await LoginAndCreateCarAsync(page);
+
+        // Attempt to set an attribute that isn't in the Car schema at all — e.g. "IsAdmin".
+        // The framework must either reject the request or silently drop the unknown attribute,
+        // never blindly set it on the entity.
+        var putResp = await api.PutJsonAsync(
+            $"/spark/po/Car/{Uri.EscapeDataString(id)}",
+            new
+            {
+                persistentObject = new
+                {
+                    id,
+                    objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                    attributes = new object[]
+                    {
+                        new { name = "LicensePlate", value = "ROESCL12" },
+                        new { name = "Model",        value = "X1" },
+                        new { name = "Year",         value = 2024 },
+                        new { name = "IsAdmin",      value = true },
+                    },
+                },
+            });
+
+        putResp.Status.Should().BeLessThan(500,
+            "unknown attributes should be rejected (400) or dropped, not cause a server error");
+
+        // Re-fetch and assert the rogue field isn't echoed back.
+        var getResp = await api.GetAsync($"/spark/po/Car/{Uri.EscapeDataString(id)}");
+        var body = await getResp.TextAsync();
+        body.Should().NotContain("IsAdmin", "server must not echo back unknown client-supplied attributes");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
@@ -34,6 +34,7 @@ public class AttributeWriteProtectionTests
         {
             persistentObject = new
             {
+                name = "Car",
                 objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                 attributes = new object[]
                 {
@@ -68,6 +69,7 @@ public class AttributeWriteProtectionTests
                 persistentObject = new
                 {
                     id,
+                    name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]
                     {
@@ -100,6 +102,7 @@ public class AttributeWriteProtectionTests
                 persistentObject = new
                 {
                     id,
+                    name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]
                     {

--- a/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
@@ -42,11 +42,13 @@ public class ConcurrencyTests
         var body = await create.JsonAsync();
         var id = body!.Value.GetProperty("id").GetString()!;
 
-        // Read v1 twice — simulating two clients both looking at the same snapshot.
+        // Read v1 and capture its etag — the stale snapshot both clients will be working from.
         var readA = await api.GetAsync($"/spark/po/Car/{Uri.EscapeDataString(id)}");
         readA.Status.Should().Be(200);
+        var etagV1 = (await readA.JsonAsync())!.Value.GetProperty("etag").GetString();
+        etagV1.Should().NotBeNullOrEmpty("server must surface the change vector as Etag for optimistic concurrency");
 
-        // Client A writes first (Year=2025).
+        // Client A writes first with the v1 etag → succeeds, server moves to v2.
         var writeA = await api.PutJsonAsync(
             $"/spark/po/Car/{Uri.EscapeDataString(id)}",
             new
@@ -54,6 +56,7 @@ public class ConcurrencyTests
                 persistentObject = new
                 {
                     id,
+                    etag = etagV1,
                     name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]
@@ -66,8 +69,8 @@ public class ConcurrencyTests
             });
         writeA.Status.Should().BeOneOf(new[] { 200, 201 }, $"first write failed: {await writeA.TextAsync()}");
 
-        // Client B writes based on the stale v1 snapshot (Year=2026).
-        // With optimistic concurrency, this should be rejected — the expected status is 409.
+        // Client B writes based on the stale v1 snapshot (Year=2026) — same etagV1 as A used.
+        // Server's current change vector is now v2, so the v1 etag no longer matches. 409 expected.
         var writeB = await api.PutJsonAsync(
             $"/spark/po/Car/{Uri.EscapeDataString(id)}",
             new
@@ -75,6 +78,7 @@ public class ConcurrencyTests
                 persistentObject = new
                 {
                     id,
+                    etag = etagV1,
                     name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]

--- a/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// M-7 — updates must be protected by optimistic concurrency. Two clients reading the
+/// same record, both modifying, both writing: the framework must reject the stale write
+/// with a 409 Conflict rather than silently losing one client's change.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class ConcurrencyTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public ConcurrencyTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Concurrent_update_with_stale_version_is_rejected()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var api = await SparkApi.LoginAsync(page, _fixture.Host, _fixture.Host.AdminEmailAddress, _fixture.Host.AdminPass);
+
+        var plate = $"CC{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
+        var create = await api.PostJsonAsync("/spark/po/Car", new
+        {
+            persistentObject = new
+            {
+                objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                attributes = new object[]
+                {
+                    new { name = "LicensePlate", value = plate },
+                    new { name = "Model",        value = "CC1" },
+                    new { name = "Year",         value = 2024 },
+                },
+            },
+        });
+        create.Status.Should().BeOneOf(new[] { 200, 201 }, $"create failed: {await create.TextAsync()}");
+        var body = await create.JsonAsync();
+        var id = body!.Value.GetProperty("id").GetString()!;
+
+        // Read v1 twice — simulating two clients both looking at the same snapshot.
+        var readA = await api.GetAsync($"/spark/po/Car/{Uri.EscapeDataString(id)}");
+        readA.Status.Should().Be(200);
+
+        // Client A writes first (Year=2025).
+        var writeA = await api.PutJsonAsync(
+            $"/spark/po/Car/{Uri.EscapeDataString(id)}",
+            new
+            {
+                persistentObject = new
+                {
+                    id,
+                    objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                    attributes = new object[]
+                    {
+                        new { name = "LicensePlate", value = plate },
+                        new { name = "Model",        value = "CC1" },
+                        new { name = "Year",         value = 2025 },
+                    },
+                },
+            });
+        writeA.Status.Should().BeOneOf(new[] { 200, 201 }, $"first write failed: {await writeA.TextAsync()}");
+
+        // Client B writes based on the stale v1 snapshot (Year=2026).
+        // With optimistic concurrency, this should be rejected — the expected status is 409.
+        var writeB = await api.PutJsonAsync(
+            $"/spark/po/Car/{Uri.EscapeDataString(id)}",
+            new
+            {
+                persistentObject = new
+                {
+                    id,
+                    objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                    attributes = new object[]
+                    {
+                        new { name = "LicensePlate", value = plate },
+                        new { name = "Model",        value = "CC1" },
+                        new { name = "Year",         value = 2026 },
+                    },
+                },
+            });
+
+        writeB.Status.Should().Be(409,
+            "the second writer's request is based on a stale version and must be rejected with 409 Conflict");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
@@ -27,6 +27,7 @@ public class ConcurrencyTests
         {
             persistentObject = new
             {
+                name = "Car",
                 objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                 attributes = new object[]
                 {
@@ -36,7 +37,8 @@ public class ConcurrencyTests
                 },
             },
         });
-        create.Status.Should().BeOneOf(new[] { 200, 201 }, $"create failed: {await create.TextAsync()}");
+        create.Status.Should().BeOneOf(new[] { 200, 201 },
+            $"create failed ({create.Status}): body=[{await create.TextAsync()}]\n--- Fleet log tail ---\n{_fixture.Host.RecentLog()}");
         var body = await create.JsonAsync();
         var id = body!.Value.GetProperty("id").GetString()!;
 
@@ -52,6 +54,7 @@ public class ConcurrencyTests
                 persistentObject = new
                 {
                     id,
+                    name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]
                     {
@@ -72,6 +75,7 @@ public class ConcurrencyTests
                 persistentObject = new
                 {
                     id,
+                    name = "Car",
                     objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                     attributes = new object[]
                     {

--- a/MintPlayer.Spark.E2E.Tests/Security/ErrorLeakageTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ErrorLeakageTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// M-6 — error responses must not leak implementation internals. Stack traces, RavenDB
+/// index/collection names, .NET type names, or raw exception messages let an attacker
+/// map the server's internals.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class ErrorLeakageTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public ErrorLeakageTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    private static readonly string[] LeakyTokens = new[]
+    {
+        "at MintPlayer.",     // stack frame
+        "at Raven.",          // Raven stack frame
+        "at Microsoft.",      // framework stack frame
+        "System.NullReferenceException",
+        "System.InvalidOperationException",
+        "ArgumentException:",
+        "Raven.Client.Exceptions",
+        "IndexDoesNotExistException",
+        "NonUniqueObjectException",
+    };
+
+    [Fact]
+    public async Task Malformed_entityTypeId_does_not_leak_stack_trace_or_internal_types()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var response = await page.APIRequest.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/po/this-is-not-a-real-type/some-id");
+
+        var body = await response.TextAsync();
+
+        foreach (var token in LeakyTokens)
+            body.Should().NotContain(token, $"error response leaked internal token '{token}'");
+    }
+
+    [Fact]
+    public async Task Malformed_id_on_get_does_not_leak_internals()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Valid type, impossible ID shape.
+        var response = await page.APIRequest.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/po/Car/{{}}");
+
+        var body = await response.TextAsync();
+        foreach (var token in LeakyTokens)
+            body.Should().NotContain(token, $"error response leaked internal token '{token}'");
+    }
+
+    [Fact]
+    public async Task Bad_lookup_reference_key_does_not_leak_internals()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Login so the handler reaches the service layer (where exceptions originate).
+        var login = await page.APIRequest.PostAsync($"{_fixture.Host.FleetUrl}/spark/auth/login?useCookies=true", new()
+        {
+            DataObject = new { email = _fixture.Host.AdminEmailAddress, password = _fixture.Host.AdminPass },
+        });
+        login.Status.Should().Be(200);
+
+        var response = await page.APIRequest.DeleteAsync(
+            $"{_fixture.Host.FleetUrl}/spark/lookupref/NoSuchCollection/NoSuchKey");
+
+        var body = await response.TextAsync();
+        foreach (var token in LeakyTokens)
+            body.Should().NotContain(token, $"lookup-delete error leaked internal token '{token}'");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/MetadataEndpointAuthTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/MetadataEndpointAuthTests.cs
@@ -1,0 +1,94 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// H-1 — Metadata endpoints must filter their response by the caller's permissions.
+/// Each test uses a fresh context with no cookies, so the request reaches the server as an
+/// anonymous principal (Everyone group).
+///
+/// Expected secure behavior: the response includes only entities/queries the caller has
+/// at least <c>Query</c> rights on. In Fleet, Everyone has <c>QueryRead/Company</c> — so
+/// an anonymous caller sees Company in <c>/spark/types</c> and <c>GetCompanies</c> in
+/// <c>/spark/queries</c>, but Car/Person/CarBrand/CarStatus must be filtered out.
+/// A blanket 200 + full catalogue is the vulnerability.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class MetadataEndpointAuthTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public MetadataEndpointAuthTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Unauthenticated_GET_spark_queries_includes_only_queries_visible_to_anonymous_callers()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/queries");
+
+        response.Status.Should().Be(200);
+        var body = await response.TextAsync();
+
+        // Everyone has QueryRead/Company (per App_Data/security.json), so GetCompanies must remain visible.
+        body.Should().Contain("GetCompanies",
+            "queries the anonymous principal does have QueryRead rights on must stay visible");
+
+        // Everyone does NOT have QueryRead on Car/Person/CarBrand/CarStatus — these must be filtered out.
+        body.Should().NotContain("GetCars", "Car query is not granted to Everyone");
+        body.Should().NotContain("GetPeople", "Person query is not granted to Everyone");
+        body.Should().NotContain("Stolen_Cars", "custom Car query is not granted to Everyone");
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GET_spark_types_includes_only_types_visible_to_anonymous_callers()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/types");
+
+        response.Status.Should().Be(200);
+        var body = await response.TextAsync();
+
+        // Company is Everyone-visible (QueryRead/Company) so its type definition is allowed.
+        body.Should().Contain("\"name\":\"Company\"", "Company type is visible to Everyone");
+
+        // Car/Person are not — their schemas must be filtered out entirely.
+        body.Should().NotContain("\"name\":\"Car\"", "Car type is not visible to Everyone");
+        body.Should().NotContain("\"name\":\"Person\"", "Person type is not visible to Everyone");
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GET_spark_queries_id_for_protected_query_is_refused()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // The Car "GetCars" query is gated by QueryRead/Car which Everyone does not have.
+        // The endpoint must behave as if the query doesn't exist — 404 is the expected shape
+        // (M-3 also requires 404 vs 403 to be indistinguishable).
+        var response = await page.APIRequest.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/queries/a20e8400-e29b-41d4-a716-446655440001");
+
+        response.Status.Should().Be(404,
+            "an anonymous caller has no rights on the Car query and must not receive its definition");
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GET_spark_aliases_includes_only_aliases_visible_to_anonymous_callers()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/aliases");
+
+        response.Status.Should().Be(200);
+        var body = await response.TextAsync();
+
+        // Aliases for protected entities must be filtered out — they'd otherwise map
+        // human-readable names to entity/query ids that the caller can't use.
+        body.Should().NotContain("\"car\"", "Car alias reveals Car's existence");
+        body.Should().NotContain("\"person\"", "Person alias reveals Person's existence");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
@@ -1,0 +1,73 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// M-3 — authenticated callers must not be able to distinguish "record does not exist"
+/// from "record exists but you can't read it". Otherwise the framework becomes an
+/// existence oracle for IDs the caller doesn't own.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class NotFoundVsForbiddenTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public NotFoundVsForbiddenTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Nonexistent_id_and_forbidden_id_return_the_same_status()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Register + log in a plain user (no administrator claim — default tier).
+        var email = $"plain-{Guid.NewGuid():N}@e2e.local";
+        var pass = _fixture.Host.AdminPass; // reuse the fixture's complex password
+        var register = await page.APIRequest.PostAsync($"{_fixture.Host.FleetUrl}/spark/auth/register", new()
+        {
+            DataObject = new { email, password = pass },
+        });
+        register.Status.Should().BeOneOf(new[] { 200, 201, 204, 400 }, $"register response: {await register.TextAsync()}");
+
+        var login = await page.APIRequest.PostAsync($"{_fixture.Host.FleetUrl}/spark/auth/login?useCookies=true", new()
+        {
+            DataObject = new { email, password = pass },
+        });
+        // Login may 401 if email confirmation is required — but that's a separate concern;
+        // the test still exercises unauthenticated distinguishability.
+
+        var nonExistentCar = await page.APIRequest.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/po/Car/cars%2Fdefinitely-does-not-exist-{Guid.NewGuid():N}");
+
+        // Seed a real car as admin in a separate context so we have a known-forbidden ID
+        // from the plain user's perspective.
+        await using var adminPages = new PageFactory(_fixture);
+        var adminPage = await adminPages.NewPageAsync();
+        var adminApi = await SparkApi.LoginAsync(adminPage, _fixture.Host, _fixture.Host.AdminEmailAddress, _fixture.Host.AdminPass);
+
+        var createResp = await adminApi.PostJsonAsync("/spark/po/Car", new
+        {
+            persistentObject = new
+            {
+                objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
+                attributes = new object[]
+                {
+                    new { name = "LicensePlate", value = $"NF{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant() },
+                    new { name = "Model",        value = "M3" },
+                    new { name = "Year",         value = 2024 },
+                },
+            },
+        });
+        if (createResp.Status == 200 || createResp.Status == 201)
+        {
+            var body = await createResp.JsonAsync();
+            var carId = body!.Value.GetProperty("id").GetString();
+            carId.Should().NotBeNullOrEmpty();
+
+            var forbiddenCar = await page.APIRequest.GetAsync(
+                $"{_fixture.Host.FleetUrl}/spark/po/Car/{Uri.EscapeDataString(carId!)}");
+
+            forbiddenCar.Status.Should().Be(nonExistentCar.Status,
+                "the response for a real-but-forbidden record must be identical to a nonexistent one");
+        }
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
@@ -48,6 +48,7 @@ public class NotFoundVsForbiddenTests
         {
             persistentObject = new
             {
+                name = "Car",
                 objectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce",
                 attributes = new object[]
                 {

--- a/MintPlayer.Spark.E2E.Tests/Security/PermissionsEndpointAuthTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/PermissionsEndpointAuthTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// M-1 — GET /spark/permissions/{entityTypeId} is allowed to be called anonymously because
+/// the Angular SPA needs to know which program units to render for a visitor. What it MUST
+/// NOT do is inflate the flags (<c>canCreate</c>/<c>canEdit</c>/<c>canDelete</c>) beyond
+/// what the anonymous "Everyone" group is actually granted in security.json.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class PermissionsEndpointAuthTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public PermissionsEndpointAuthTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Unauthenticated_GET_permissions_for_Car_reports_no_access()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Car is granted to Administrators + Fleet managers, not Everyone.
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/permissions/Car");
+
+        // Either 401 (secure) or 200 with all flags false.
+        if (response.Status == 401)
+            return;
+
+        response.Status.Should().Be(200);
+        var body = await response.JsonAsync();
+        body!.Value.GetProperty("canRead").GetBoolean().Should().BeFalse("anonymous should not read Car");
+        body.Value.GetProperty("canCreate").GetBoolean().Should().BeFalse("anonymous should not create Car");
+        body.Value.GetProperty("canEdit").GetBoolean().Should().BeFalse("anonymous should not edit Car");
+        body.Value.GetProperty("canDelete").GetBoolean().Should().BeFalse("anonymous should not delete Car");
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GET_permissions_for_Company_reports_read_but_no_write()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Company has QueryRead/Company granted to Everyone — anon should see canRead=true
+        // but must not see any mutation permissions.
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/permissions/Company");
+
+        if (response.Status == 401)
+            return;
+
+        response.Status.Should().Be(200);
+        var body = await response.JsonAsync();
+        body!.Value.GetProperty("canCreate").GetBoolean().Should().BeFalse();
+        body.Value.GetProperty("canEdit").GetBoolean().Should().BeFalse();
+        body.Value.GetProperty("canDelete").GetBoolean().Should().BeFalse();
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs
@@ -31,5 +31,12 @@ public class RateLimitTests
 
         observedStatuses.Should().Contain(429,
             "a rapid burst of 200 anonymous requests to /spark/auth/me should hit the rate limiter");
+
+        // Fleet's rate limiter is a fixed window partitioned by IP. Every test in this
+        // collection shares 127.0.0.1 as its partition key, so leaving the bucket saturated
+        // would cause the next test to inherit our 429 state (PermissionsEndpointAuth was
+        // the first casualty). Wait slightly longer than the configured 10 s window so the
+        // bucket rolls over before the next test runs.
+        await Task.Delay(TimeSpan.FromSeconds(11));
     }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs
@@ -1,0 +1,35 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// L-3 — demo apps must ship a rate limiter. This test hammers an anonymous endpoint and
+/// expects at least one 429 response. It intentionally fires sequential requests to keep
+/// the assertion deterministic across CI environments; the limiter's threshold should be
+/// low enough that a 50-request burst crosses it.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class RateLimitTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public RateLimitTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Rapid_unauthenticated_bursts_trigger_429_Too_Many_Requests()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var observedStatuses = new HashSet<int>();
+        for (var i = 0; i < 200; i++)
+        {
+            var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
+            observedStatuses.Add(response.Status);
+            if (observedStatuses.Contains(429))
+                break;
+        }
+
+        observedStatuses.Should().Contain(429,
+            "a rapid burst of 200 anonymous requests to /spark/auth/me should hit the rate limiter");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs
@@ -6,12 +6,90 @@ namespace MintPlayer.Spark.E2E.Tests.Security;
 /// H-5 — after a successful login the app must not navigate the user to an external URL
 /// even if <c>?returnUrl=...</c> says so. The remediation validates returnUrl against a
 /// configured allow-list (or a relative-only rule); these tests pin each attack shape.
+///
+/// Assertion strategy: after attempting login with a malicious returnUrl, the post-login
+/// URL's *host* must match Fleet's host. Substring matching on "attacker.test" is unsafe
+/// because the attacker string is preserved verbatim in <c>?returnUrl=...</c> when the
+/// router refuses to navigate — a false positive. Host comparison tells us whether the
+/// browser actually left the app origin, which is the real security question.
 /// </summary>
 [Collection(FleetE2ECollection.Name)]
 public class ReturnUrlValidationTests
 {
     private readonly FleetE2ECollectionFixture _fixture;
     public ReturnUrlValidationTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Diagnostic_admin_can_log_in_via_the_form()
+    {
+        // Baseline: the H-5 suite relies on form-based login working. If this fails, the
+        // attack-vector tests' "nav off-site?" assertions are meaningless (they all
+        // trivially pass/fail without the router ever seeing a login success).
+        var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        await page.GotoAsync("/login");
+
+        var emailField = page.Locator("input#email").First;
+        await emailField.WaitForAsync(new() { Timeout = 15_000 });
+        await emailField.FillAsync(_fixture.Host.AdminEmailAddress);
+
+        var passwordField = page.Locator("input#password, input[type='password']").First;
+        await passwordField.FillAsync(_fixture.Host.AdminPass);
+
+        await page.Locator("button[type='submit']").First.ClickAsync();
+
+        var authenticated = await WaitForAuthenticatedAsync(page, TimeSpan.FromSeconds(10));
+        authenticated.Should().BeTrue(
+            $"form-based login must authenticate the session. Final url=[{page.Url}] " +
+            $"error-alert=[{await TryGetErrorAlertAsync(page)}] " +
+            $"--- Fleet log tail ---\n{_fixture.Host.RecentLog(40)}");
+    }
+
+    [Fact]
+    public async Task Login_with_protocol_relative_returnUrl_does_not_navigate_off_site()
+        => await AssertLoginStaysOnFleetHostAsync("//attacker.test/phish");
+
+    [Fact]
+    public async Task Login_with_absolute_http_returnUrl_does_not_navigate_off_site()
+        => await AssertLoginStaysOnFleetHostAsync("http://attacker.test/phish");
+
+    [Fact]
+    public async Task Login_with_absolute_https_returnUrl_does_not_navigate_off_site()
+        => await AssertLoginStaysOnFleetHostAsync("https://attacker.test/phish");
+
+    [Fact]
+    public async Task Login_with_javascript_uri_returnUrl_does_not_execute_script()
+    {
+        var page = await LoginViaFormAsync("javascript:alert('xss')");
+        page.Url.Should().NotStartWith("javascript:",
+            "javascript: URIs must never be honored as post-login redirects");
+        AssertHostIsFleet(page.Url, "javascript: URI");
+    }
+
+    [Fact]
+    public async Task Login_with_backslash_authority_returnUrl_does_not_navigate_off_site()
+        // Some browsers treat \\host as //host — defence in depth.
+        => await AssertLoginStaysOnFleetHostAsync("\\\\attacker.test/phish");
+
+    [Fact]
+    public async Task Login_with_whitespace_prefixed_returnUrl_does_not_navigate_off_site()
+        // Leading whitespace can make some URL parsers treat remainder as protocol-relative.
+        => await AssertLoginStaysOnFleetHostAsync(" //attacker.test/phish");
+
+    private async Task AssertLoginStaysOnFleetHostAsync(string returnUrl)
+    {
+        var page = await LoginViaFormAsync(returnUrl);
+        AssertHostIsFleet(page.Url, returnUrl);
+    }
+
+    private void AssertHostIsFleet(string finalUrl, string shape)
+    {
+        var finalUri = new Uri(finalUrl);
+        var fleetUri = new Uri(_fixture.Host.FleetUrl);
+        finalUri.Host.Should().Be(fleetUri.Host,
+            $"returnUrl='{shape}' must not cause navigation to an external host. Final url=[{finalUrl}]");
+    }
 
     private async Task<Microsoft.Playwright.IPage> LoginViaFormAsync(string returnUrl)
     {
@@ -20,85 +98,46 @@ public class ReturnUrlValidationTests
 
         await page.GotoAsync($"/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
 
-        // Wait for the login form to render (Angular lazy-loads the chunk).
-        var emailField = page.Locator("input[type='email'], input[name='email'], input[name='username']").First;
+        // ng-spark-auth's login component renders the email field as <input type="text"
+        // id="email" formControlName="email"> — no name attribute. Match on id.
+        var emailField = page.Locator("input#email").First;
         await emailField.WaitForAsync(new() { Timeout = 15_000 });
 
         await emailField.FillAsync(_fixture.Host.AdminEmailAddress);
-        var passwordField = page.Locator("input[type='password']").First;
+        var passwordField = page.Locator("input#password, input[type='password']").First;
         await passwordField.FillAsync(_fixture.Host.AdminPass);
 
-        var submitButton = page.Locator("button[type='submit']").First;
-        await submitButton.ClickAsync();
+        await page.Locator("button[type='submit']").First.ClickAsync();
 
-        // Give the router time to navigate.
-        await page.WaitForTimeoutAsync(2000);
+        // Wait for the session cookie — login's side effect — to confirm the POST
+        // /spark/auth/login round-trip completed before we inspect the URL.
+        await WaitForAuthenticatedAsync(page, TimeSpan.FromSeconds(10));
+
+        // Give the router a beat to settle its navigation decision.
+        await page.WaitForTimeoutAsync(500);
         return page;
     }
 
-    [Fact]
-    public async Task Login_with_protocol_relative_returnUrl_does_not_navigate_off_site()
+    private async Task<bool> WaitForAuthenticatedAsync(Microsoft.Playwright.IPage page, TimeSpan timeout)
     {
-        var page = await LoginViaFormAsync("//attacker.test/phish");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
-            "protocol-relative returnUrl must not leave the app origin");
-        finalUrl.Should().NotContain("attacker.test");
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var me = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
+            if ((await me.TextAsync()).Contains("\"isAuthenticated\":true")) return true;
+            await page.WaitForTimeoutAsync(250);
+        }
+        return false;
     }
 
-    [Fact]
-    public async Task Login_with_absolute_http_returnUrl_does_not_navigate_off_site()
+    private static async Task<string> TryGetErrorAlertAsync(Microsoft.Playwright.IPage page)
     {
-        var page = await LoginViaFormAsync("http://attacker.test/phish");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
-            "absolute http returnUrl must not leave the app origin");
-        finalUrl.Should().NotContain("attacker.test");
-    }
-
-    [Fact]
-    public async Task Login_with_absolute_https_returnUrl_does_not_navigate_off_site()
-    {
-        var page = await LoginViaFormAsync("https://attacker.test/phish");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
-            "absolute https returnUrl must not leave the app origin");
-        finalUrl.Should().NotContain("attacker.test");
-    }
-
-    [Fact]
-    public async Task Login_with_javascript_uri_returnUrl_does_not_execute_script()
-    {
-        var page = await LoginViaFormAsync("javascript:alert('xss')");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().NotStartWith("javascript:",
-            "javascript: URIs must never be honored as post-login redirects");
-    }
-
-    [Fact]
-    public async Task Login_with_backslash_authority_returnUrl_does_not_navigate_off_site()
-    {
-        // Some browsers treat \\host as //host — defence in depth.
-        var page = await LoginViaFormAsync("\\\\attacker.test/phish");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().StartWith(_fixture.Host.FleetUrl);
-        finalUrl.Should().NotContain("attacker.test");
-    }
-
-    [Fact]
-    public async Task Login_with_whitespace_prefixed_returnUrl_does_not_navigate_off_site()
-    {
-        // " //attacker" — some URL parsers trim leading whitespace and treat remainder
-        // as protocol-relative. Defence in depth.
-        var page = await LoginViaFormAsync(" //attacker.test/phish");
-        var finalUrl = page.Url;
-
-        finalUrl.Should().StartWith(_fixture.Host.FleetUrl);
-        finalUrl.Should().NotContain("attacker.test");
+        try
+        {
+            var alert = page.Locator("bs-alert").First;
+            if (await alert.CountAsync() == 0) return "<none>";
+            return await alert.InnerTextAsync(new() { Timeout = 1000 });
+        }
+        catch { return "<unreadable>"; }
     }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs
@@ -1,0 +1,104 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// H-5 — after a successful login the app must not navigate the user to an external URL
+/// even if <c>?returnUrl=...</c> says so. The remediation validates returnUrl against a
+/// configured allow-list (or a relative-only rule); these tests pin each attack shape.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class ReturnUrlValidationTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public ReturnUrlValidationTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    private async Task<Microsoft.Playwright.IPage> LoginViaFormAsync(string returnUrl)
+    {
+        var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        await page.GotoAsync($"/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
+
+        // Wait for the login form to render (Angular lazy-loads the chunk).
+        var emailField = page.Locator("input[type='email'], input[name='email'], input[name='username']").First;
+        await emailField.WaitForAsync(new() { Timeout = 15_000 });
+
+        await emailField.FillAsync(_fixture.Host.AdminEmailAddress);
+        var passwordField = page.Locator("input[type='password']").First;
+        await passwordField.FillAsync(_fixture.Host.AdminPass);
+
+        var submitButton = page.Locator("button[type='submit']").First;
+        await submitButton.ClickAsync();
+
+        // Give the router time to navigate.
+        await page.WaitForTimeoutAsync(2000);
+        return page;
+    }
+
+    [Fact]
+    public async Task Login_with_protocol_relative_returnUrl_does_not_navigate_off_site()
+    {
+        var page = await LoginViaFormAsync("//attacker.test/phish");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
+            "protocol-relative returnUrl must not leave the app origin");
+        finalUrl.Should().NotContain("attacker.test");
+    }
+
+    [Fact]
+    public async Task Login_with_absolute_http_returnUrl_does_not_navigate_off_site()
+    {
+        var page = await LoginViaFormAsync("http://attacker.test/phish");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
+            "absolute http returnUrl must not leave the app origin");
+        finalUrl.Should().NotContain("attacker.test");
+    }
+
+    [Fact]
+    public async Task Login_with_absolute_https_returnUrl_does_not_navigate_off_site()
+    {
+        var page = await LoginViaFormAsync("https://attacker.test/phish");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().StartWith(_fixture.Host.FleetUrl,
+            "absolute https returnUrl must not leave the app origin");
+        finalUrl.Should().NotContain("attacker.test");
+    }
+
+    [Fact]
+    public async Task Login_with_javascript_uri_returnUrl_does_not_execute_script()
+    {
+        var page = await LoginViaFormAsync("javascript:alert('xss')");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().NotStartWith("javascript:",
+            "javascript: URIs must never be honored as post-login redirects");
+    }
+
+    [Fact]
+    public async Task Login_with_backslash_authority_returnUrl_does_not_navigate_off_site()
+    {
+        // Some browsers treat \\host as //host — defence in depth.
+        var page = await LoginViaFormAsync("\\\\attacker.test/phish");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().StartWith(_fixture.Host.FleetUrl);
+        finalUrl.Should().NotContain("attacker.test");
+    }
+
+    [Fact]
+    public async Task Login_with_whitespace_prefixed_returnUrl_does_not_navigate_off_site()
+    {
+        // " //attacker" — some URL parsers trim leading whitespace and treat remainder
+        // as protocol-relative. Defence in depth.
+        var page = await LoginViaFormAsync(" //attacker.test/phish");
+        var finalUrl = page.Url;
+
+        finalUrl.Should().StartWith(_fixture.Host.FleetUrl);
+        finalUrl.Should().NotContain("attacker.test");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
@@ -1,0 +1,32 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// H-2 / H-3 — entity-type-level grants must NOT imply per-row read access. Once the
+/// row-level-filter hook is introduced on <c>DefaultPersistentObjectActions&lt;T&gt;</c>,
+/// and the Fleet demo uses it (so each car is associated with a creator or owner),
+/// User B must not be able to read User A's cars even though both have
+/// <c>QueryReadEditNew/Car</c>.
+///
+/// These tests are marked Skip until the remediation PR:
+///   1. adds the filter hook to DefaultPersistentObjectActions
+///   2. adds an Owner/AssignedTo concept to Fleet's Car schema
+///   3. updates CarActions to apply the filter
+/// Once those are in place, remove the Skip attribute — the tests will exercise the fix.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class RowLevelAuthzTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public RowLevelAuthzTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact(Skip = "Requires H-2 fix: row-level filter hook + Fleet ownership concept")]
+    public Task User_B_cannot_list_User_As_private_cars() => Task.CompletedTask;
+
+    [Fact(Skip = "Requires H-2 fix: row-level filter hook + Fleet ownership concept")]
+    public Task User_B_cannot_read_User_As_private_car_by_id() => Task.CompletedTask;
+
+    [Fact(Skip = "Requires H-3 fix: parent-object authorization through the same filter hook")]
+    public Task User_B_cannot_execute_child_query_with_User_As_parent_id() => Task.CompletedTask;
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
@@ -3,30 +3,98 @@ using MintPlayer.Spark.E2E.Tests._Infrastructure;
 namespace MintPlayer.Spark.E2E.Tests.Security;
 
 /// <summary>
-/// H-2 / H-3 — entity-type-level grants must NOT imply per-row read access. Once the
-/// row-level-filter hook is introduced on <c>DefaultPersistentObjectActions&lt;T&gt;</c>,
-/// and the Fleet demo uses it (so each car is associated with a creator or owner),
-/// User B must not be able to read User A's cars even though both have
-/// <c>QueryReadEditNew/Car</c>.
-///
-/// These tests are marked Skip until the remediation PR:
-///   1. adds the filter hook to DefaultPersistentObjectActions
-///   2. adds an Owner/AssignedTo concept to Fleet's Car schema
-///   3. updates CarActions to apply the filter
-/// Once those are in place, remove the Skip attribute — the tests will exercise the fix.
+/// H-2 / H-3 — entity-type-level grants must NOT imply per-row access. Both the admin and
+/// a Fleet-manager user have rights on Car via Fleet's security.json, but the Fleet-manager
+/// must not be able to see cars created by the admin (and vice versa). The Car entity now
+/// carries a <c>CreatedBy</c> field, CarActions overrides <c>IsAllowedAsync</c>, and
+/// DatabaseAccess calls the hook on single load, list load, and query parent-fetch.
 /// </summary>
 [Collection(FleetE2ECollection.Name)]
 public class RowLevelAuthzTests
 {
+    private const string CarObjectTypeId = "facb6829-f2a1-4ae2-a046-6ba506e8c0ce";
+
     private readonly FleetE2ECollectionFixture _fixture;
     public RowLevelAuthzTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
 
-    [Fact(Skip = "Requires H-2 fix: row-level filter hook + Fleet ownership concept")]
-    public Task User_B_cannot_list_User_As_private_cars() => Task.CompletedTask;
+    private async Task<(SparkApi userBApi, string adminCarId)> SeedTwoUsersAndAdminCarAsync()
+    {
+        // Seed a second, non-admin account if the fixture hasn't already. Fleet managers
+        // have QueryReadEditNew/Car in Fleet's security.json — the right tier for this test.
+        var userBEmail = $"fleet-{Guid.NewGuid():N}@e2e.local";
+        var userBPassword = _fixture.Host.AdminPass; // reuse the complex password from the fixture
+        await _fixture.Host.SeedUserAsync(userBEmail, userBPassword, "Fleet managers");
 
-    [Fact(Skip = "Requires H-2 fix: row-level filter hook + Fleet ownership concept")]
-    public Task User_B_cannot_read_User_As_private_car_by_id() => Task.CompletedTask;
+        // Admin creates a car — CarActions will stamp CreatedBy with the admin's id.
+        await using var adminPages = new PageFactory(_fixture);
+        var adminPage = await adminPages.NewPageAsync();
+        var adminApi = await SparkApi.LoginAsync(adminPage, _fixture.Host,
+            _fixture.Host.AdminEmailAddress, _fixture.Host.AdminPass);
 
-    [Fact(Skip = "Requires H-3 fix: parent-object authorization through the same filter hook")]
-    public Task User_B_cannot_execute_child_query_with_User_As_parent_id() => Task.CompletedTask;
+        var plate = $"RL{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
+        var create = await adminApi.PostJsonAsync("/spark/po/Car", new
+        {
+            persistentObject = new
+            {
+                name = "Car",
+                objectTypeId = CarObjectTypeId,
+                attributes = new object[]
+                {
+                    new { name = "LicensePlate", value = plate },
+                    new { name = "Model", value = "RL1" },
+                    new { name = "Year", value = 2024 },
+                },
+            },
+        });
+        create.Status.Should().BeOneOf(new[] { 200, 201 },
+            $"admin car create failed: {await create.TextAsync()}");
+        var adminCarId = (await create.JsonAsync())!.Value.GetProperty("id").GetString()!;
+
+        // Now log in as user B in a fresh context and return that session.
+        var userBPages = new PageFactory(_fixture);
+        var userBPage = await userBPages.NewPageAsync();
+        var userBApi = await SparkApi.LoginAsync(userBPage, _fixture.Host, userBEmail, userBPassword);
+        return (userBApi, adminCarId);
+    }
+
+    [Fact]
+    public async Task User_B_cannot_read_User_As_private_car_by_id()
+    {
+        var (userBApi, adminCarId) = await SeedTwoUsersAndAdminCarAsync();
+
+        // User B has QueryReadEditNew/Car (Fleet managers group) so the entity-type check
+        // passes, but they are not CreatedBy on this car. Row-level filter must return 404.
+        var response = await userBApi.GetAsync($"/spark/po/Car/{Uri.EscapeDataString(adminCarId)}");
+        response.Status.Should().Be(404,
+            "user B is not the creator and must not be able to load admin's car by id");
+    }
+
+    [Fact]
+    public async Task User_B_cannot_list_User_As_private_cars()
+    {
+        var (userBApi, adminCarId) = await SeedTwoUsersAndAdminCarAsync();
+
+        var response = await userBApi.GetAsync("/spark/po/Car");
+        response.Status.Should().Be(200);
+        var body = await response.TextAsync();
+
+        body.Should().NotContain(adminCarId,
+            "admin's car id must be absent from user B's list response");
+    }
+
+    [Fact]
+    public async Task User_B_cannot_execute_child_query_with_User_As_parent_id()
+    {
+        var (userBApi, adminCarId) = await SeedTwoUsersAndAdminCarAsync();
+
+        // GetCars is the Fleet query over Car. Attempt to execute it scoped to admin's car
+        // as the parent — the parent fetch must fail the same row-level gate and return 404,
+        // not silently run the query unscoped.
+        const string getCarsQueryId = "a20e8400-e29b-41d4-a716-446655440001";
+        var response = await userBApi.GetAsync(
+            $"/spark/queries/{getCarsQueryId}/execute?parentId={Uri.EscapeDataString(adminCarId)}&parentType=Car");
+
+        response.Status.Should().Be(404,
+            "parent fetch must apply the row-level gate — cannot scope a query to an inaccessible parent");
+    }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/SortInjectionTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/SortInjectionTests.cs
@@ -1,0 +1,73 @@
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// M-5 — the <c>sortColumns</c> query-string parameter must be validated against the
+/// query's declared attribute schema. Accepting an arbitrary property name via reflection
+/// lets a caller sort on fields the developer never intended to expose (leaking ordering
+/// as a side channel, and in some index configurations materialising the value).
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class SortInjectionTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public SortInjectionTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    private const string CarsQueryId = "a20e8400-e29b-41d4-a716-446655440001";
+
+    private async Task<Microsoft.Playwright.IAPIRequestContext> LoggedInAsAdminAsync(Microsoft.Playwright.IPage page)
+    {
+        var login = await page.APIRequest.PostAsync($"{_fixture.Host.FleetUrl}/spark/auth/login?useCookies=true", new()
+        {
+            DataObject = new { email = _fixture.Host.AdminEmailAddress, password = _fixture.Host.AdminPass },
+        });
+        login.Status.Should().Be(200, $"admin login failed: {await login.TextAsync()}");
+        return page.APIRequest;
+    }
+
+    [Fact]
+    public async Task Sort_by_nonexistent_property_is_rejected()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+        var api = await LoggedInAsAdminAsync(page);
+
+        var response = await api.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/queries/{CarsQueryId}/execute?sortColumns=NoSuchProperty:asc");
+
+        response.Status.Should().BeOneOf(new[] { 400, 422 },
+            "sorting by a property not in the query's schema must be rejected, not silently ignored");
+    }
+
+    [Fact]
+    public async Task Sort_by_metadata_property_on_projection_is_rejected()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+        var api = await LoggedInAsAdminAsync(page);
+
+        // The VCar projection is a C# class; any public property on it is reflectable.
+        // An attribute like "Metadata" or any non-declared public property is not in the
+        // JSON schema for the query — the framework must not accept it.
+        var response = await api.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/queries/{CarsQueryId}/execute?sortColumns=Id:asc");
+
+        response.Status.Should().BeOneOf(new[] { 400, 422 },
+            "sorting by a reflectable-but-undeclared property (Id) must be rejected");
+    }
+
+    [Fact]
+    public async Task Sort_with_malformed_direction_does_not_500()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+        var api = await LoggedInAsAdminAsync(page);
+
+        var response = await api.GetAsync(
+            $"{_fixture.Host.FleetUrl}/spark/queries/{CarsQueryId}/execute?sortColumns=LicensePlate:not-a-direction");
+
+        response.Status.Should().BeLessThan(500,
+            "malformed direction should produce a 4xx client error, not a 500 server fault");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs
@@ -5,9 +5,10 @@ namespace MintPlayer.Spark.E2E.Tests.Security;
 
 /// <summary>
 /// L-2 — the XSRF-TOKEN cookie must carry the <c>Secure</c> attribute when the response
-/// is served over HTTPS. The fixture runs Fleet over https://localhost:{random-port}, so
-/// every response should mint a Secure cookie. HttpOnly is intentionally false (double-
-/// submit pattern requires JS to read the cookie) and is not asserted here.
+/// is served over HTTPS, and must pin <c>SameSite=Strict</c>. The fixture runs Fleet over
+/// https://localhost:{random-port}, so every response should mint a cookie with both.
+/// HttpOnly is intentionally false (double-submit pattern requires JS to read the cookie)
+/// and is not asserted here.
 /// </summary>
 [Collection(FleetE2ECollection.Name)]
 public class XsrfCookieFlagTests
@@ -18,26 +19,28 @@ public class XsrfCookieFlagTests
     [Fact]
     public async Task XSRF_TOKEN_cookie_carries_Secure_attribute_over_https()
     {
-        await using var pages = new PageFactory(_fixture);
-        var page = await pages.NewPageAsync();
-
-        // Any response triggers the antiforgery middleware — /spark/auth/me is cheap.
-        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
-        response.Status.Should().Be(200);
-
-        var setCookies = response.Headers
-            .Where(h => string.Equals(h.Key, "set-cookie", StringComparison.OrdinalIgnoreCase))
-            .Select(h => h.Value)
-            .ToList();
-        var xsrfCookie = setCookies.FirstOrDefault(c => c.StartsWith("XSRF-TOKEN=", StringComparison.Ordinal));
-
-        xsrfCookie.Should().NotBeNull("server should mint an XSRF-TOKEN cookie for the SPA to echo back");
-        xsrfCookie!.ToLowerInvariant().Should().Contain("secure",
-            "over HTTPS the XSRF-TOKEN cookie must set the Secure attribute so it is never sent over plain HTTP");
+        var cookie = await FetchXsrfCookieAsync();
+        cookie.Should().NotBeNull("server should mint an XSRF-TOKEN cookie for the SPA to echo back");
+        HasAttribute(cookie!, "Secure").Should().BeTrue(
+            $"over HTTPS the XSRF-TOKEN cookie must set the Secure attribute. Actual cookie: [{cookie}]");
     }
 
     [Fact]
     public async Task XSRF_TOKEN_cookie_has_SameSite_Strict()
+    {
+        var cookie = await FetchXsrfCookieAsync();
+        cookie.Should().NotBeNull();
+        GetAttributeValue(cookie!, "SameSite").Should().BeEquivalentTo("Strict",
+            $"SameSite=Strict is the documented defence against cross-site CSRF for the double-submit token. " +
+            $"Actual cookie: [{cookie}]");
+    }
+
+    /// <summary>
+    /// Returns the full Set-Cookie line for the XSRF-TOKEN cookie, or null if absent.
+    /// Playwright's <c>IAPIResponse.Headers</c> joins multiple set-cookie values with '\n',
+    /// so we split first and then look for the one starting with XSRF-TOKEN=.
+    /// </summary>
+    private async Task<string?> FetchXsrfCookieAsync()
     {
         await using var pages = new PageFactory(_fixture);
         var page = await pages.NewPageAsync();
@@ -45,14 +48,33 @@ public class XsrfCookieFlagTests
         var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
         response.Status.Should().Be(200);
 
-        var setCookies = response.Headers
+        var rawSetCookie = response.Headers
             .Where(h => string.Equals(h.Key, "set-cookie", StringComparison.OrdinalIgnoreCase))
             .Select(h => h.Value)
-            .ToList();
-        var xsrfCookie = setCookies.FirstOrDefault(c => c.StartsWith("XSRF-TOKEN=", StringComparison.Ordinal));
+            .FirstOrDefault() ?? "";
 
-        xsrfCookie.Should().NotBeNull();
-        xsrfCookie!.Should().Contain("SameSite=Strict",
-            "SameSite=Strict is the documented defence against cross-site CSRF for the double-submit token");
+        return rawSetCookie
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .FirstOrDefault(line => line.StartsWith("XSRF-TOKEN=", StringComparison.Ordinal));
+    }
+
+    /// <summary>Case-insensitive "does this cookie have the given flag attribute?" (e.g. Secure, HttpOnly).</summary>
+    private static bool HasAttribute(string cookie, string name) =>
+        cookie.Split(';')
+            .Select(part => part.Trim())
+            .Any(part => string.Equals(part, name, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Case-insensitive attribute key lookup; returns the attribute's value verbatim or null.</summary>
+    private static string? GetAttributeValue(string cookie, string name)
+    {
+        foreach (var part in cookie.Split(';').Select(p => p.Trim()))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0) continue;
+            if (string.Equals(part[..eq], name, StringComparison.OrdinalIgnoreCase))
+                return part[(eq + 1)..];
+        }
+        return null;
     }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// L-2 — the XSRF-TOKEN cookie must carry the <c>Secure</c> attribute when the response
+/// is served over HTTPS. The fixture runs Fleet over https://localhost:{random-port}, so
+/// every response should mint a Secure cookie. HttpOnly is intentionally false (double-
+/// submit pattern requires JS to read the cookie) and is not asserted here.
+/// </summary>
+[Collection(FleetE2ECollection.Name)]
+public class XsrfCookieFlagTests
+{
+    private readonly FleetE2ECollectionFixture _fixture;
+    public XsrfCookieFlagTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task XSRF_TOKEN_cookie_carries_Secure_attribute_over_https()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        // Any response triggers the antiforgery middleware — /spark/auth/me is cheap.
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
+        response.Status.Should().Be(200);
+
+        var setCookies = response.Headers
+            .Where(h => string.Equals(h.Key, "set-cookie", StringComparison.OrdinalIgnoreCase))
+            .Select(h => h.Value)
+            .ToList();
+        var xsrfCookie = setCookies.FirstOrDefault(c => c.StartsWith("XSRF-TOKEN=", StringComparison.Ordinal));
+
+        xsrfCookie.Should().NotBeNull("server should mint an XSRF-TOKEN cookie for the SPA to echo back");
+        xsrfCookie!.ToLowerInvariant().Should().Contain("secure",
+            "over HTTPS the XSRF-TOKEN cookie must set the Secure attribute so it is never sent over plain HTTP");
+    }
+
+    [Fact]
+    public async Task XSRF_TOKEN_cookie_has_SameSite_Strict()
+    {
+        await using var pages = new PageFactory(_fixture);
+        var page = await pages.NewPageAsync();
+
+        var response = await page.APIRequest.GetAsync($"{_fixture.Host.FleetUrl}/spark/auth/me");
+        response.Status.Should().Be(200);
+
+        var setCookies = response.Headers
+            .Where(h => string.Equals(h.Key, "set-cookie", StringComparison.OrdinalIgnoreCase))
+            .Select(h => h.Value)
+            .ToList();
+        var xsrfCookie = setCookies.FirstOrDefault(c => c.StartsWith("XSRF-TOKEN=", StringComparison.Ordinal));
+
+        xsrfCookie.Should().NotBeNull();
+        xsrfCookie!.Should().Contain("SameSite=Strict",
+            "SameSite=Strict is the documented defence against cross-site CSRF for the double-submit token");
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/Security/_SecurityTestHelpers.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/_SecurityTestHelpers.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Playwright;
+using MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.E2E.Tests.Security;
+
+/// <summary>
+/// Shared helpers for security tests. The Spark middleware validates an antiforgery token
+/// on every mutating request (POST/PUT/DELETE) against the <c>X-XSRF-TOKEN</c> header,
+/// which must echo the current <c>XSRF-TOKEN</c> cookie. <see cref="IAPIRequestContext"/>
+/// does not populate this header automatically, so tests that write must do so via
+/// <see cref="SparkApi"/>.
+/// </summary>
+internal static class SecurityTestHelpers
+{
+    /// <summary>
+    /// Returns an <see cref="IAPIRequestContext"/> wrapper that prepends the X-XSRF-TOKEN
+    /// header on mutating calls. The caller must still explicitly log in (or not) before
+    /// the mutating request is issued — this helper only handles CSRF, not auth.
+    /// </summary>
+    public static async Task<SparkApi> SparkApiForAsync(IPage page, FleetTestHost host)
+    {
+        // A primer GET causes the Spark middleware to mint an XSRF-TOKEN cookie.
+        await page.APIRequest.GetAsync($"{host.FleetUrl}/spark/auth/me");
+        var cookies = await page.Context.CookiesAsync(new[] { host.FleetUrl });
+        var xsrf = cookies.FirstOrDefault(c => c.Name == "XSRF-TOKEN")?.Value ?? "";
+        return new SparkApi(page.APIRequest, host.FleetUrl, xsrf);
+    }
+}
+
+/// <summary>
+/// Thin wrapper that routes mutating calls through <see cref="IAPIRequestContext"/> with
+/// the X-XSRF-TOKEN header set. Read-only GET/HEAD calls go through unchanged.
+/// </summary>
+internal sealed class SparkApi
+{
+    private readonly IAPIRequestContext _api;
+    private readonly string _baseUrl;
+    private readonly string _xsrfToken;
+
+    public SparkApi(IAPIRequestContext api, string baseUrl, string xsrfToken)
+    {
+        _api = api;
+        _baseUrl = baseUrl;
+        _xsrfToken = xsrfToken;
+    }
+
+    private Dictionary<string, string> CsrfHeaders() =>
+        new() { ["X-XSRF-TOKEN"] = _xsrfToken };
+
+    public Task<IAPIResponse> GetAsync(string path) =>
+        _api.GetAsync($"{_baseUrl}{path}");
+
+    public Task<IAPIResponse> PostJsonAsync(string path, object body) =>
+        _api.PostAsync($"{_baseUrl}{path}", new()
+        {
+            Headers = CsrfHeaders(),
+            DataObject = body,
+        });
+
+    public Task<IAPIResponse> PutJsonAsync(string path, object body) =>
+        _api.PutAsync($"{_baseUrl}{path}", new()
+        {
+            Headers = CsrfHeaders(),
+            DataObject = body,
+        });
+
+    public Task<IAPIResponse> DeleteAsync(string path) =>
+        _api.DeleteAsync($"{_baseUrl}{path}", new()
+        {
+            Headers = CsrfHeaders(),
+        });
+
+    /// <summary>
+    /// Logs in as the given identity via the Identity API (cookie-based) and refreshes
+    /// the XSRF token. Returns a new <see cref="SparkApi"/> bound to the post-login cookie.
+    /// </summary>
+    public static async Task<SparkApi> LoginAsync(IPage page, FleetTestHost host, string email, string password)
+    {
+        // Identity API endpoints are outside Spark's antiforgery surface — login works without XSRF.
+        var loginResp = await page.APIRequest.PostAsync($"{host.FleetUrl}/spark/auth/login?useCookies=true", new()
+        {
+            DataObject = new { email, password },
+        });
+        if (loginResp.Status != 200)
+            throw new InvalidOperationException(
+                $"Login failed for {email} ({loginResp.Status}): {await loginResp.TextAsync()}");
+
+        // After login, refresh the XSRF token bound to the authenticated principal.
+        await page.APIRequest.GetAsync($"{host.FleetUrl}/spark/auth/me");
+        var cookies = await page.Context.CookiesAsync(new[] { host.FleetUrl });
+        var xsrf = cookies.FirstOrDefault(c => c.Name == "XSRF-TOKEN")?.Value ?? "";
+        return new SparkApi(page.APIRequest, host.FleetUrl, xsrf);
+    }
+}

--- a/MintPlayer.Spark.E2E.Tests/_Infrastructure/FleetTestHost.cs
+++ b/MintPlayer.Spark.E2E.Tests/_Infrastructure/FleetTestHost.cs
@@ -59,6 +59,43 @@ public sealed class FleetTestHost : IAsyncLifetime
         lock (_logLock) return string.Join('\n', _fleetLog.TakeLast(maxLines));
     }
 
+    /// <summary>
+    /// Registers an additional user and patches the Raven document so the user is email-confirmed
+    /// and belongs to the given group (matching a name declared in Fleet's App_Data/security.json).
+    /// Used by row-level-authz tests to seed a second non-admin account.
+    /// </summary>
+    public async Task SeedUserAsync(string email, string password, string groupName)
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+        using var client = new HttpClient(handler) { BaseAddress = new Uri(_fleetUrl!) };
+
+        var registerResp = await client.PostAsJsonAsync("/spark/auth/register", new { email, password });
+        if (!registerResp.IsSuccessStatusCode)
+        {
+            var body = await registerResp.Content.ReadAsStringAsync();
+            throw new InvalidOperationException($"Seed register for '{email}' failed ({(int)registerResp.StatusCode}): {body}");
+        }
+
+        using var appStore = new DocumentStore { Urls = _raven!.Store.Urls, Database = TestDatabase };
+        appStore.Initialize();
+
+        using var session = appStore.OpenAsyncSession();
+        var user = await session.Query<SparkUser>()
+            .FirstOrDefaultAsync(u => u.NormalizedEmail == email.ToUpperInvariant())
+            ?? throw new InvalidOperationException($"Seeded user '{email}' not visible in '{TestDatabase}' after register.");
+
+        user.EmailConfirmed = true;
+        user.UserName ??= email;
+        user.NormalizedUserName ??= email.ToUpperInvariant();
+        if (!user.Claims.Any(c => c.ClaimType == "group" && c.ClaimValue == groupName))
+            user.Claims.Add(new SparkUserClaim { ClaimType = "group", ClaimValue = groupName });
+
+        await session.SaveChangesAsync();
+    }
+
     public async Task InitializeAsync()
     {
         _raven = new SparkTestDriverHost();

--- a/MintPlayer.Spark.E2E.Tests/_Infrastructure/FleetTestHost.cs
+++ b/MintPlayer.Spark.E2E.Tests/_Infrastructure/FleetTestHost.cs
@@ -49,6 +49,16 @@ public sealed class FleetTestHost : IAsyncLifetime
     public string AdminEmailAddress => AdminEmail;
     public string AdminPass => AdminPassword;
 
+    /// <summary>
+    /// Returns the last <paramref name="maxLines"/> lines captured from Fleet's stdout/stderr.
+    /// Useful for surfacing server-side exception details inside an assertion failure message
+    /// when the HTTP response body doesn't include them (production 500, etc.).
+    /// </summary>
+    public string RecentLog(int maxLines = 60)
+    {
+        lock (_logLock) return string.Join('\n', _fleetLog.TakeLast(maxLines));
+    }
+
     public async Task InitializeAsync()
     {
         _raven = new SparkTestDriverHost();

--- a/MintPlayer.Spark.Testing/JsonFixtureImporter.cs
+++ b/MintPlayer.Spark.Testing/JsonFixtureImporter.cs
@@ -10,7 +10,24 @@ namespace MintPlayer.Spark.Testing;
 /// </summary>
 public static class JsonFixtureImporter
 {
-    public static async Task ImportAsync(IDocumentStore store, params string[] filePaths)
+    /// <summary>
+    /// Convenience overload that waits for indexes to settle after import.
+    /// Equivalent to <c>ImportAsync(store, waitForIndexing: true, filePaths)</c>.
+    /// </summary>
+    public static Task ImportAsync(IDocumentStore store, params string[] filePaths)
+        => ImportAsync(store, waitForIndexing: true, filePaths);
+
+    /// <summary>
+    /// Imports the supplied fixture files into <paramref name="store"/>. When
+    /// <paramref name="waitForIndexing"/> is <c>true</c> (default), blocks until the database
+    /// reports no stale indexes — so the next query a test runs is guaranteed to see the seed
+    /// data even if static indexes are involved. Pass <c>false</c> only when you intentionally
+    /// want to assert on stale-read behaviour.
+    /// </summary>
+    public static async Task ImportAsync(
+        IDocumentStore store,
+        bool waitForIndexing,
+        params string[] filePaths)
     {
         if (filePaths.Length == 0) return;
 
@@ -53,5 +70,8 @@ public static class JsonFixtureImporter
         }
 
         await session.SaveChangesAsync();
+
+        if (waitForIndexing)
+            await RavenIndexHelper.WaitForNonStaleAsync(store);
     }
 }

--- a/MintPlayer.Spark.Testing/RavenIndexHelper.cs
+++ b/MintPlayer.Spark.Testing/RavenIndexHelper.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+
+namespace MintPlayer.Spark.Testing;
+
+/// <summary>
+/// Public index/indexing helpers usable from any test context — <see cref="SparkTestDriver"/>
+/// subclasses, the Fleet E2E host, or plain <c>IDocumentStore</c>-holding fixtures. Exists
+/// because <see cref="Raven.TestDriver.RavenTestDriver.WaitForIndexing"/> is protected and
+/// therefore not reachable from code that doesn't derive from <c>RavenTestDriver</c>.
+/// </summary>
+public static class RavenIndexHelper
+{
+    /// <summary>
+    /// Polls <see cref="GetStatisticsOperation"/> until the target database reports no stale
+    /// indexes, or throws <see cref="TimeoutException"/> if <paramref name="timeout"/> elapses.
+    /// Errors out immediately if any index has moved to <see cref="IndexState.Error"/> — a
+    /// silent hang on a failed index is the worst possible test-infra failure mode.
+    /// </summary>
+    public static async Task WaitForNonStaleAsync(
+        IDocumentStore store,
+        string? database = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        var db = database ?? store.Database
+            ?? throw new ArgumentException("No database specified and store.Database is null.", nameof(database));
+        var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(1);
+        var deadline = DateTime.UtcNow + effectiveTimeout;
+        var maintenance = store.Maintenance.ForDatabase(db);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var stats = await maintenance.SendAsync(new GetStatisticsOperation(), cancellationToken);
+
+            var erroredIndex = stats.Indexes.FirstOrDefault(i => i.State == IndexState.Error);
+            if (erroredIndex is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Index '{erroredIndex.Name}' on database '{db}' is in error state. " +
+                    "Check the Raven Studio indexes page for the underlying exception.");
+            }
+
+            if (stats.StaleIndexes.Length == 0)
+                return;
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Indexes on database '{db}' did not settle within {effectiveTimeout}. " +
+                    $"Still stale: {string.Join(", ", stats.StaleIndexes)}");
+            }
+
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Registers every <see cref="AbstractIndexCreationTask"/> found in the supplied assemblies
+    /// and then waits for the server to finish building them. Equivalent in spirit to the
+    /// "wait for all async index creations" step described by CronosCore's Readme — a test's
+    /// first query is free to assume its indexes are live once this returns.
+    /// </summary>
+    public static async Task DeployIndexesAsync(
+        IDocumentStore store,
+        params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        if (assemblies.Length == 0) return;
+
+        foreach (var assembly in assemblies)
+        {
+            await IndexCreation.CreateIndexesAsync(assembly, store);
+        }
+
+        await WaitForNonStaleAsync(store);
+    }
+}

--- a/MintPlayer.Spark.Testing/SparkEndpointFactory.cs
+++ b/MintPlayer.Spark.Testing/SparkEndpointFactory.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MintPlayer.Spark.Abstractions;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Testing;
+
+/// <summary>
+/// Boots a minimal in-memory Spark host wired against an externally-supplied
+/// <see cref="IDocumentStore"/> (typically obtained from <see cref="SparkTestDriver"/>).
+/// Each instance writes its model JSON files into a per-test temp content root so
+/// <c>ModelLoader</c> sees only the entity types declared by the fixture.
+///
+/// Uses <see cref="TestServer"/>/<see cref="IHost"/> directly rather than
+/// <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/> —
+/// the latter requires the host assembly to expose a <c>Main</c> entry point, which a
+/// library-level test project doesn't have.
+///
+/// <typeparamref name="TContext"/> is the <see cref="SparkContext"/> subclass your tests
+/// expose to Spark (e.g. a context with <c>IRavenQueryable&lt;Person&gt; People</c>).
+/// Library code lives here so downstream test projects only write a thin subclass, or
+/// construct <c>SparkEndpointFactory&lt;TMyContext&gt;</c> directly with no boilerplate.
+/// </summary>
+public class SparkEndpointFactory<TContext> : IAsyncDisposable
+    where TContext : SparkContext
+{
+    private readonly IHost _host;
+    private readonly string _contentRoot;
+
+    /// <param name="testStore">The in-memory (or otherwise) document store the host should use.</param>
+    /// <param name="models">Entity type definitions; serialized into <c>App_Data/Model/*.json</c>.</param>
+    /// <param name="configureServices">
+    /// Optional hook invoked after the built-in registrations (AddRouting, AddSpark, testStore override).
+    /// Use it to register custom actions classes, options, or swap services for mocks without forking
+    /// the factory.
+    /// </param>
+    public SparkEndpointFactory(
+        IDocumentStore testStore,
+        IEnumerable<EntityTypeFile> models,
+        Action<IServiceCollection>? configureServices = null)
+    {
+        ArgumentNullException.ThrowIfNull(testStore);
+        ArgumentNullException.ThrowIfNull(models);
+
+        _contentRoot = Path.Combine(Path.GetTempPath(), "spark-endpoint-tests-" + Guid.NewGuid().ToString("N"));
+        var modelDir = Path.Combine(_contentRoot, "App_Data", "Model");
+        Directory.CreateDirectory(modelDir);
+
+        foreach (var model in models)
+        {
+            var path = Path.Combine(modelDir, model.PersistentObject.Name + ".json");
+            File.WriteAllText(path, JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        _host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost
+                    .UseTestServer()
+                    .UseContentRoot(_contentRoot)
+                    .UseEnvironment("Testing")
+                    .ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddSpark(spark => spark.UseContext<TContext>());
+
+                        var existing = services.Single(d => d.ServiceType == typeof(IDocumentStore));
+                        services.Remove(existing);
+                        services.AddSingleton(testStore);
+
+                        configureServices?.Invoke(services);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseSpark();
+                        app.UseEndpoints(endpoints => endpoints.MapSpark());
+                    });
+            })
+            .Build();
+
+        _host.Start();
+    }
+
+    public HttpClient CreateClient() => _host.GetTestClient();
+
+    public T GetService<T>() where T : notnull => _host.Services.GetRequiredService<T>();
+
+    /// <summary>
+    /// Performs a warmup GET so Spark's antiforgery middleware writes both the antiforgery
+    /// validation cookie (<c>.AspNetCore.Antiforgery.*</c>) and the readable <c>XSRF-TOKEN</c>
+    /// cookie. Returns the raw <c>Cookie</c> header value (combining both cookies) and the
+    /// <c>X-XSRF-TOKEN</c> request token to attach to mutating requests.
+    /// <see cref="TestServer"/>'s HttpClient does not auto-manage cookies, so callers must thread
+    /// these through explicitly — see <see cref="SparkTestClient"/> for a wrapper that does this.
+    /// </summary>
+    public async Task<(string CookieHeader, string XsrfToken)> MintAntiforgeryAsync()
+    {
+        using var client = CreateClient();
+        var response = await client.GetAsync("/spark/po/__warmup__");
+
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+            throw new InvalidOperationException("Warmup request did not return any Set-Cookie headers.");
+
+        string? antiforgeryCookie = null;
+        string? xsrfToken = null;
+
+        foreach (var raw in setCookies)
+        {
+            var nameValue = raw.Split(';', 2)[0];
+            var eq = nameValue.IndexOf('=');
+            if (eq < 0) continue;
+            var name = nameValue[..eq];
+            var value = nameValue[(eq + 1)..];
+
+            if (name.StartsWith(".AspNetCore.Antiforgery", StringComparison.Ordinal))
+                antiforgeryCookie = nameValue;
+            else if (name == "XSRF-TOKEN")
+            {
+                xsrfToken = Uri.UnescapeDataString(value);
+            }
+        }
+
+        if (antiforgeryCookie is null || xsrfToken is null)
+            throw new InvalidOperationException(
+                $"Warmup did not yield both antiforgery cookies. Got: '{string.Join(" | ", setCookies)}'");
+
+        return (antiforgeryCookie + "; XSRF-TOKEN=" + Uri.EscapeDataString(xsrfToken), xsrfToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        try
+        {
+            if (Directory.Exists(_contentRoot))
+                Directory.Delete(_contentRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup
+        }
+    }
+}

--- a/MintPlayer.Spark.Testing/SparkTestClient.cs
+++ b/MintPlayer.Spark.Testing/SparkTestClient.cs
@@ -1,11 +1,12 @@
 using System.Net.Http.Json;
+using MintPlayer.Spark.Abstractions;
 
-namespace MintPlayer.Spark.Tests._Infrastructure;
+namespace MintPlayer.Spark.Testing;
 
 /// <summary>
-/// Convenience wrapper around an HttpClient that attaches the cached antiforgery
-/// cookie + X-XSRF-TOKEN header to every mutating request. Get a configured
-/// instance via <see cref="SparkEndpointFactory.CreateAuthorizedClientAsync"/>.
+/// Convenience wrapper around an <see cref="HttpClient"/> that attaches the cached
+/// antiforgery cookie + <c>X-XSRF-TOKEN</c> header to every mutating request. Obtain a
+/// pre-configured instance via <see cref="SparkEndpointFactoryExtensions.CreateAuthorizedClientAsync"/>.
 /// </summary>
 public sealed class SparkTestClient : IDisposable
 {
@@ -48,7 +49,9 @@ public static class SparkEndpointFactoryExtensions
     /// Returns a <see cref="SparkTestClient"/> that has already done a warmup GET to mint
     /// antiforgery tokens and will attach them to every Post/Put/Delete request.
     /// </summary>
-    public static async Task<SparkTestClient> CreateAuthorizedClientAsync(this SparkEndpointFactory factory)
+    public static async Task<SparkTestClient> CreateAuthorizedClientAsync<TContext>(
+        this SparkEndpointFactory<TContext> factory)
+        where TContext : SparkContext
     {
         var (cookieHeader, xsrfToken) = await factory.MintAntiforgeryAsync();
         return new SparkTestClient(factory.CreateClient(), cookieHeader, xsrfToken);

--- a/MintPlayer.Spark.Testing/SparkTestDriver.cs
+++ b/MintPlayer.Spark.Testing/SparkTestDriver.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Raven.Client.Documents;
 using Raven.Embedded;
 using Raven.TestDriver;
@@ -36,11 +37,23 @@ public abstract class SparkTestDriver : RavenTestDriver, IAsyncLifetime
 
     protected IDocumentStore Store { get; private set; } = null!;
 
-    public virtual Task InitializeAsync()
+    /// <summary>
+    /// Assemblies whose <c>AbstractIndexCreationTask</c> types should be deployed automatically
+    /// at <see cref="InitializeAsync"/> and waited on for completion. Default: empty. Override
+    /// in a subclass to guarantee that every test in the fixture sees its indexes live before
+    /// the first <c>[Fact]</c> runs — the Spark equivalent of CronosCore's
+    /// <c>IndexHelper.Register + RunAll</c> pattern.
+    /// </summary>
+    protected virtual IEnumerable<Assembly> IndexAssemblies { get; } = Array.Empty<Assembly>();
+
+    public virtual async Task InitializeAsync()
     {
         LicenseHelper.EnsureAvailable();
         Store = GetDocumentStore();
-        return Task.CompletedTask;
+
+        var assemblies = IndexAssemblies as Assembly[] ?? IndexAssemblies.ToArray();
+        if (assemblies.Length > 0)
+            await RavenIndexHelper.DeployIndexesAsync(Store, assemblies);
     }
 
     public virtual Task DisposeAsync()
@@ -48,6 +61,24 @@ public abstract class SparkTestDriver : RavenTestDriver, IAsyncLifetime
         Store.Dispose();
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Imports one or more JSON fixture files into <see cref="Store"/> and waits for indexes
+    /// to settle. Relative paths resolve against <see cref="AppContext.BaseDirectory"/> so
+    /// fixtures copied to the test output directory via <c>&lt;Content Include="Data\**\*" /&gt;</c>
+    /// resolve naturally (e.g. <c>"Data/Seed/people.json"</c>).
+    /// </summary>
+    protected Task SeedFromJsonAsync(params string[] relativeOrAbsolutePaths)
+    {
+        var resolved = relativeOrAbsolutePaths
+            .Select(p => Path.IsPathRooted(p) ? p : Path.Combine(AppContext.BaseDirectory, p))
+            .ToArray();
+        return JsonFixtureImporter.ImportAsync(Store, resolved);
+    }
+
+    /// <summary>Deploys additional indexes at runtime (e.g., per-test). Also waits for them to settle.</summary>
+    protected Task DeployIndexesAsync(params Assembly[] assemblies)
+        => RavenIndexHelper.DeployIndexesAsync(Store, assemblies);
 }
 
 internal static class LicenseHelper

--- a/MintPlayer.Spark.Tests/Actions/DefaultPersistentObjectActionsIsAllowedTests.cs
+++ b/MintPlayer.Spark.Tests/Actions/DefaultPersistentObjectActionsIsAllowedTests.cs
@@ -1,0 +1,65 @@
+using MintPlayer.Spark.Actions;
+
+namespace MintPlayer.Spark.Tests.Actions;
+
+/// <summary>
+/// Pins the default behaviour and override contract of the row-level
+/// <see cref="DefaultPersistentObjectActions{T}.IsAllowedAsync(string, T)"/> hook introduced
+/// in the security audit. The default is permissive (returns true) — an application that
+/// wants row-level enforcement must override explicitly, which is a review-time signal.
+/// </summary>
+public class DefaultPersistentObjectActionsIsAllowedTests
+{
+    public class Widget { public string? Id { get; set; } }
+
+    // The base class's source-generated constructor requires an IEntityMapper; IsAllowedAsync
+    // doesn't use it, so null! is safe here.
+    private sealed class DefaultActions : DefaultPersistentObjectActions<Widget>
+    {
+        public DefaultActions() : base(null!) { }
+    }
+
+    private sealed class DenyAllActions : DefaultPersistentObjectActions<Widget>
+    {
+        public DenyAllActions() : base(null!) { }
+        public override Task<bool> IsAllowedAsync(string action, Widget entity) => Task.FromResult(false);
+    }
+
+    private sealed class DenyDeleteActions : DefaultPersistentObjectActions<Widget>
+    {
+        public DenyDeleteActions() : base(null!) { }
+        public override Task<bool> IsAllowedAsync(string action, Widget entity)
+            => Task.FromResult(action != "Delete");
+    }
+
+    [Theory]
+    [InlineData("Read")]
+    [InlineData("Query")]
+    [InlineData("Edit")]
+    [InlineData("Delete")]
+    [InlineData("New")]
+    public async Task Default_implementation_allows_every_standard_action(string action)
+    {
+        var actions = new DefaultActions();
+        var result = await actions.IsAllowedAsync(action, new Widget());
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Override_can_deny_wholesale()
+    {
+        var actions = new DenyAllActions();
+        var result = await actions.IsAllowedAsync("Read", new Widget());
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Override_can_deny_selectively_per_action()
+    {
+        var actions = new DenyDeleteActions();
+
+        (await actions.IsAllowedAsync("Read", new Widget())).Should().BeTrue();
+        (await actions.IsAllowedAsync("Edit", new Widget())).Should().BeTrue();
+        (await actions.IsAllowedAsync("Delete", new Widget())).Should().BeFalse();
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/PersistentObject/UpdateEndpointConcurrencyTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/PersistentObject/UpdateEndpointConcurrencyTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using MintPlayer.Spark.Client;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+
+// Using the Abstractions.PersistentObject type by its full namespace avoids collision with
+// the current namespace's own name (this file lives under MintPlayer.Spark.Tests.Endpoints.PersistentObject).
+using PO = MintPlayer.Spark.Abstractions.PersistentObject;
+
+namespace MintPlayer.Spark.Tests.Endpoints.PersistentObject;
+
+/// <summary>
+/// M-7 — optimistic concurrency on <c>PUT /spark/po</c>. The unit-test counterpart of
+/// <c>MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs</c>: covers the same
+/// <c>SparkConcurrencyException</c> throw inside <c>DatabaseAccess</c> and the 409 catch block
+/// in the <c>UpdatePersistentObject</c> endpoint, but in-process so it runs on CI as part of
+/// MintPlayer.Spark.Tests and contributes to coverage. Uses <see cref="SparkClient"/>, so the
+/// test body reads as domain operations (get the PO, update it) rather than hand-built JSON.
+/// </summary>
+public class UpdateEndpointConcurrencyTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("c0cc1111-eeee-eeee-eeee-c0cc1111eeee");
+
+    private SparkEndpointFactory _factory = null!;
+    private SparkClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory(Store, [TestModels.Person(PersonTypeId)]);
+        _client = new SparkClient(_factory.CreateClient(), ownsClient: true);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task<PO> SeedAndLoadAsync(string id, string firstName, string lastName)
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Person { FirstName = firstName, LastName = lastName }, id);
+            await session.SaveChangesAsync();
+        }
+        await RavenIndexHelper.WaitForNonStaleAsync(Store);
+
+        return await _client.GetPersistentObjectAsync(PersonTypeId, id)
+            ?? throw new InvalidOperationException($"Seeded document '{id}' was not visible over HTTP.");
+    }
+
+    private static void SetAttribute(PO po, string name, object value)
+    {
+        var attr = po.Attributes.FirstOrDefault(a => a.Name == name);
+        if (attr is null) throw new InvalidOperationException($"Attribute '{name}' not on PO '{po.Id}'.");
+        attr.Value = value;
+    }
+
+    [Fact]
+    public async Task Put_with_stale_etag_throws_409_conflict()
+    {
+        var poA = await SeedAndLoadAsync("people/1", "Alice", "Smith");
+        var etagV1 = poA.Etag;
+
+        // Client A advances the server from v1 → v2.
+        SetAttribute(poA, "FirstName", "Alicia");
+        await _client.UpdatePersistentObjectAsync(poA);
+
+        // Client B still holds the v1 snapshot — its etag no longer matches the server.
+        var poB = await _client.GetPersistentObjectAsync(PersonTypeId, "people/1");
+        poB!.Etag = etagV1;
+        SetAttribute(poB, "LastName", "Jones");
+
+        var ex = await Assert.ThrowsAsync<SparkClientException>(
+            () => _client.UpdatePersistentObjectAsync(poB));
+        ex.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Put_with_matching_etag_succeeds_and_returns_new_etag()
+    {
+        var po = await SeedAndLoadAsync("people/1", "Alice", "Smith");
+        var etagV1 = po.Etag;
+
+        SetAttribute(po, "LastName", "Smith-Jones");
+        var saved = await _client.UpdatePersistentObjectAsync(po);
+
+        saved.Etag.Should().NotBeNullOrEmpty();
+        saved.Etag.Should().NotBe(etagV1, "server must advance the change vector after a write");
+    }
+
+    [Fact]
+    public async Task Put_with_no_etag_skips_concurrency_check_and_succeeds()
+    {
+        var po = await SeedAndLoadAsync("people/1", "Alice", "Smith");
+
+        // Clients that don't round-trip the change vector (legacy path) must still work.
+        po.Etag = null;
+        SetAttribute(po, "FirstName", "Alicia");
+        var saved = await _client.UpdatePersistentObjectAsync(po);
+
+        saved.Should().NotBeNull();
+    }
+}

--- a/MintPlayer.Spark.Tests/Endpoints/Queries/ExecuteQueryParentGateTests.cs
+++ b/MintPlayer.Spark.Tests/Endpoints/Queries/ExecuteQueryParentGateTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Client;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Endpoints.Queries;
+
+/// <summary>
+/// H-3 — the parent-fetch gate in <c>ExecuteQuery</c>. When a caller passes
+/// <c>parentId</c>/<c>parentType</c>, the endpoint loads the parent via
+/// <c>IDatabaseAccess.GetPersistentObjectAsync</c> (which applies row-level authz) and bails
+/// out with 404 if the parent isn't visible — otherwise the query would run unscoped and leak
+/// data the caller can't see. Uses <see cref="SparkClient.ExecuteQueryAsync(Guid,int,int,string,string,string,System.Threading.CancellationToken)"/>
+/// so the test expresses "run query X with parent Y" directly.
+/// </summary>
+public class ExecuteQueryParentGateTests : SparkTestDriver
+{
+    private static readonly Guid DocTypeId = Guid.Parse("42420000-1111-2222-3333-444455556666");
+    private static readonly Guid ChildrenQueryId = Guid.Parse("42421111-1111-2222-3333-444455556666");
+
+    private SparkEndpointFactory<GuardedContext> _factory = null!;
+    private SparkClient _client = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var docType = GuardedDocModel.For(DocTypeId);
+        docType.Queries =
+        [
+            new SparkQuery
+            {
+                Id = ChildrenQueryId,
+                Name = "AllDocs",
+                Source = "Database.Docs",
+            },
+        ];
+
+        _factory = new SparkEndpointFactory<GuardedContext>(Store, new[] { docType });
+        _client = new SparkClient(_factory.CreateClient(), ownsClient: true);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task SeedAsync(params GuardedDoc[] docs)
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            foreach (var d in docs) await session.StoreAsync(d);
+            await session.SaveChangesAsync();
+        }
+        await RavenIndexHelper.WaitForNonStaleAsync(Store);
+    }
+
+    [Fact]
+    public async Task Execute_returns_404_when_parent_is_row_level_denied()
+    {
+        await SeedAsync(new GuardedDoc { Id = "docs/forbidden-parent", Name = "hidden", IsVisible = false });
+
+        var ex = await Assert.ThrowsAsync<SparkClientException>(
+            () => _client.ExecuteQueryAsync(ChildrenQueryId, parentId: "docs/forbidden-parent", parentType: "GuardedDoc"));
+        ex.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Execute_returns_404_when_parent_does_not_exist()
+    {
+        var ex = await Assert.ThrowsAsync<SparkClientException>(
+            () => _client.ExecuteQueryAsync(ChildrenQueryId, parentId: "docs/ghost", parentType: "GuardedDoc"));
+        ex.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Execute_runs_query_when_parent_is_visible()
+    {
+        await SeedAsync(new GuardedDoc { Id = "docs/parent", Name = "parent", IsVisible = true });
+
+        var result = await _client.ExecuteQueryAsync(ChildrenQueryId, parentId: "docs/parent", parentType: "GuardedDoc");
+
+        result.Should().NotBeNull();
+    }
+}

--- a/MintPlayer.Spark.Tests/Exceptions/SparkConcurrencyExceptionTests.cs
+++ b/MintPlayer.Spark.Tests/Exceptions/SparkConcurrencyExceptionTests.cs
@@ -1,0 +1,32 @@
+using MintPlayer.Spark.Exceptions;
+
+namespace MintPlayer.Spark.Tests.Exceptions;
+
+public class SparkConcurrencyExceptionTests
+{
+    [Fact]
+    public void Stores_both_etag_values()
+    {
+        var ex = new SparkConcurrencyException(expectedEtag: "abc", actualEtag: "xyz");
+
+        ex.ExpectedEtag.Should().Be("abc");
+        ex.ActualEtag.Should().Be("xyz");
+    }
+
+    [Fact]
+    public void Message_mentions_both_etag_values_when_actual_is_present()
+    {
+        var ex = new SparkConcurrencyException(expectedEtag: "abc", actualEtag: "xyz");
+
+        ex.Message.Should().Contain("abc").And.Contain("xyz");
+    }
+
+    [Fact]
+    public void Message_uses_placeholder_when_actual_etag_is_null()
+    {
+        var ex = new SparkConcurrencyException(expectedEtag: "abc", actualEtag: null);
+
+        ex.ActualEtag.Should().BeNull();
+        ex.Message.Should().Contain("abc").And.Contain("<none>");
+    }
+}

--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\MintPlayer.Spark.Replication\MintPlayer.Spark.Replication.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.SubscriptionWorker.Abstractions\MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.AllFeatures\MintPlayer.Spark.AllFeatures.csproj" />
+    <ProjectReference Include="..\MintPlayer.Spark.Client\MintPlayer.Spark.Client.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Testing\MintPlayer.Spark.Testing.csproj" />
   </ItemGroup>
 

--- a/MintPlayer.Spark.Tests/Services/DatabaseAccessRowLevelAuthzTests.cs
+++ b/MintPlayer.Spark.Tests/Services/DatabaseAccessRowLevelAuthzTests.cs
@@ -1,0 +1,100 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Exercises the H-2/H-3 row-level authorization path through <see cref="IDatabaseAccess"/>:
+/// <see cref="IDatabaseAccess.GetPersistentObjectAsync"/> returns null for denied rows (surfaces
+/// as 404 at the endpoint, per M-3); <see cref="IDatabaseAccess.GetPersistentObjectsAsync"/>
+/// filters denied rows out of the list result. The row-level filter calls into
+/// <c>DefaultPersistentObjectActions{T}.IsAllowedAsync</c>, discovered by convention through
+/// <see cref="ActionsResolver"/> — see <see cref="GuardedDocActions"/> in _Infrastructure.
+/// </summary>
+public class DatabaseAccessRowLevelAuthzTests : SparkTestDriver
+{
+    private static readonly Guid DocTypeId = Guid.Parse("7b0a11aa-11aa-11aa-11aa-7b0a11aa11aa");
+
+    private SparkEndpointFactory<GuardedContext> _factory = null!;
+    private IDatabaseAccess _dbAccess = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory<GuardedContext>(Store, new[] { GuardedDocModel.For(DocTypeId) });
+        _dbAccess = _factory.GetService<IDatabaseAccess>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task SeedAsync(params GuardedDoc[] docs)
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            foreach (var d in docs) await session.StoreAsync(d);
+            await session.SaveChangesAsync();
+        }
+        await RavenIndexHelper.WaitForNonStaleAsync(Store);
+    }
+
+    [Fact]
+    public async Task Get_returns_null_when_IsAllowedAsync_denies_the_row()
+    {
+        await SeedAsync(new GuardedDoc { Id = "docs/forbidden", Name = "secret", IsVisible = false });
+
+        var result = await _dbAccess.GetPersistentObjectAsync(DocTypeId, "docs/forbidden");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Get_returns_object_when_IsAllowedAsync_allows_the_row()
+    {
+        await SeedAsync(new GuardedDoc { Id = "docs/visible", Name = "public", IsVisible = true });
+
+        var result = await _dbAccess.GetPersistentObjectAsync(DocTypeId, "docs/visible");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("docs/visible");
+    }
+
+    [Fact]
+    public async Task GetAll_filters_denied_rows_out_of_the_list()
+    {
+        await SeedAsync(
+            new GuardedDoc { Id = "docs/a", Name = "A", IsVisible = true },
+            new GuardedDoc { Id = "docs/b", Name = "B", IsVisible = false },
+            new GuardedDoc { Id = "docs/c", Name = "C", IsVisible = true });
+
+        var results = (await _dbAccess.GetPersistentObjectsAsync(DocTypeId)).ToList();
+
+        results.Should().HaveCount(2);
+        results.Select(p => p.Id).Should().BeEquivalentTo(new[] { "docs/a", "docs/c" });
+    }
+
+    [Fact]
+    public async Task GetAll_returns_empty_when_every_row_is_denied()
+    {
+        await SeedAsync(
+            new GuardedDoc { Id = "docs/x", Name = "X", IsVisible = false },
+            new GuardedDoc { Id = "docs/y", Name = "Y", IsVisible = false });
+
+        var results = await _dbAccess.GetPersistentObjectsAsync(DocTypeId);
+
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAll_returns_empty_when_collection_has_no_rows()
+    {
+        var results = await _dbAccess.GetPersistentObjectsAsync(DocTypeId);
+
+        results.Should().BeEmpty();
+    }
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/GuardedDoc.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/GuardedDoc.cs
@@ -1,0 +1,51 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Actions;
+using MintPlayer.Spark.Services;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+
+namespace MintPlayer.Spark.Tests._Infrastructure;
+
+/// <summary>
+/// Shared test entity whose <see cref="GuardedDocActions"/> enforces a row-level policy based
+/// on <see cref="IsVisible"/>. Lets two unrelated test classes exercise the IsAllowedAsync
+/// pipeline (DatabaseAccess row-level filter + Execute.cs parent-fetch gate) against the same
+/// <c>{entityName}Actions</c> discovery rule — see <see cref="MintPlayer.Spark.Services.ActionsResolver"/>.
+/// </summary>
+public class GuardedDoc
+{
+    public string? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsVisible { get; set; }
+}
+
+public class GuardedDocActions : DefaultPersistentObjectActions<GuardedDoc>
+{
+    public GuardedDocActions(IEntityMapper entityMapper) : base(entityMapper) { }
+    public override Task<bool> IsAllowedAsync(string action, GuardedDoc entity)
+        => Task.FromResult(entity.IsVisible);
+}
+
+public class GuardedContext : SparkContext
+{
+    public IRavenQueryable<GuardedDoc> Docs => Session.Query<GuardedDoc>();
+}
+
+public static class GuardedDocModel
+{
+    public static EntityTypeFile For(Guid id) => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = id,
+            Name = "GuardedDoc",
+            ClrType = typeof(GuardedDoc).FullName!,
+            DisplayAttribute = "Name",
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Name", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "IsVisible", DataType = "bool" },
+            ],
+        }
+    };
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/RavenIndexHelperSmokeTests.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/RavenIndexHelperSmokeTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using MintPlayer.Spark.Testing;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+
+namespace MintPlayer.Spark.Tests._Infrastructure;
+
+/// <summary>
+/// Exercises <see cref="SparkTestDriver.IndexAssemblies"/> + <see cref="RavenIndexHelper"/> so a
+/// subclass that declares an index gets it deployed and indexed before the first <c>[Fact]</c>
+/// runs. A bug in the index-wait plumbing surfaces here as a stale-query failure instead of
+/// mysteriously flaky behaviour inside a real test.
+/// </summary>
+public class RavenIndexHelperSmokeTests : SparkTestDriver
+{
+    public class Widget
+    {
+        public string? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Weight { get; set; }
+    }
+
+    public class Widgets_ByName : AbstractIndexCreationTask<Widget>
+    {
+        public Widgets_ByName()
+        {
+            Map = widgets => from w in widgets select new { w.Name };
+        }
+    }
+
+    protected override IEnumerable<Assembly> IndexAssemblies => new[] { typeof(RavenIndexHelperSmokeTests).Assembly };
+
+    [Fact]
+    public async Task Declared_index_is_live_and_queryable_without_manual_WaitForIndexing()
+    {
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Widget { Name = "left", Weight = 1 });
+            await session.StoreAsync(new Widget { Name = "right", Weight = 2 });
+            await session.SaveChangesAsync();
+        }
+
+        // After SaveChanges the new docs are stale against Widgets_ByName — explicitly wait,
+        // then query WITHOUT a WaitForNonStaleResults hint. A green assertion here proves the
+        // helper did its job (otherwise RavenDB returns zero hits from the stale index).
+        await RavenIndexHelper.WaitForNonStaleAsync(Store);
+
+        using var readSession = Store.OpenAsyncSession();
+        var hits = await readSession.Query<Widget, Widgets_ByName>()
+            .Where(w => w.Name == "left")
+            .ToListAsync();
+
+        hits.Should().HaveCount(1);
+        hits[0].Weight.Should().Be(1);
+    }
+}

--- a/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
+++ b/MintPlayer.Spark.Tests/_Infrastructure/SparkEndpointFactory.cs
@@ -1,139 +1,31 @@
-using System.Text.Json;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using MintPlayer.Spark;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Testing;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
-using Raven.Client.Documents.Session;
 
 namespace MintPlayer.Spark.Tests._Infrastructure;
 
 /// <summary>
-/// Boots a minimal in-memory Spark host wired against an externally-provided
-/// <see cref="IDocumentStore"/> (typically supplied by <see cref="MintPlayer.Spark.Testing.SparkTestDriver"/>).
-///
-/// Each instance writes its model JSON files into a per-test temp content root so that
-/// <c>ModelLoader</c> sees only the entity types declared by the test.
-/// Uses TestServer/IHost directly rather than WebApplicationFactory&lt;T&gt; — the latter
-/// requires the host assembly to expose a Main entry point, which the test project doesn't.
+/// Convenience subclass that pins <see cref="SparkEndpointFactory{TContext}"/> to
+/// <see cref="TestSparkContext"/> so existing endpoint tests can keep using
+/// <c>new SparkEndpointFactory(Store, [...])</c> without naming the generic argument.
+/// New tests (in this or downstream projects) can instantiate
+/// <see cref="SparkEndpointFactory{TContext}"/> directly with their own context type.
 /// </summary>
-public sealed class SparkEndpointFactory : IAsyncDisposable
+public sealed class SparkEndpointFactory : SparkEndpointFactory<TestSparkContext>
 {
-    private readonly IHost _host;
-    private readonly string _contentRoot;
-
-    public SparkEndpointFactory(IDocumentStore testStore, EntityTypeFile[] models)
+    public SparkEndpointFactory(IDocumentStore testStore, EntityTypeFile[] models, Action<IServiceCollection>? configureServices = null)
+        : base(testStore, models, configureServices)
     {
-        _contentRoot = Path.Combine(Path.GetTempPath(), "spark-endpoint-tests-" + Guid.NewGuid().ToString("N"));
-        var modelDir = Path.Combine(_contentRoot, "App_Data", "Model");
-        Directory.CreateDirectory(modelDir);
-
-        foreach (var model in models)
-        {
-            var path = Path.Combine(modelDir, model.PersistentObject.Name + ".json");
-            File.WriteAllText(path, JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true }));
-        }
-
-        _host = new HostBuilder()
-            .ConfigureWebHost(webHost =>
-            {
-                webHost
-                    .UseTestServer()
-                    .UseContentRoot(_contentRoot)
-                    .UseEnvironment("Testing")
-                    .ConfigureServices(services =>
-                    {
-                        services.AddRouting();
-                        services.AddSpark(spark => spark.UseContext<TestSparkContext>());
-
-                        var existing = services.Single(d => d.ServiceType == typeof(IDocumentStore));
-                        services.Remove(existing);
-                        services.AddSingleton(testStore);
-                    })
-                    .Configure(app =>
-                    {
-                        app.UseRouting();
-                        app.UseSpark();
-                        app.UseEndpoints(endpoints => endpoints.MapSpark());
-                    });
-            })
-            .Build();
-
-        _host.Start();
-    }
-
-    public HttpClient CreateClient() => _host.GetTestClient();
-
-    public T GetService<T>() where T : notnull => _host.Services.GetRequiredService<T>();
-
-    /// <summary>
-    /// Performs a warmup GET so Spark's antiforgery middleware writes both the antiforgery
-    /// validation cookie (.AspNetCore.Antiforgery.*) and the readable XSRF-TOKEN cookie.
-    /// Returns the raw <c>Cookie</c> header value (combining both cookies) and the
-    /// X-XSRF-TOKEN request token to attach to mutating requests.
-    /// TestServer's HttpClient does not auto-manage cookies, so callers must thread these
-    /// through explicitly — see <see cref="SparkTestClient"/> for a wrapper that does this.
-    /// </summary>
-    public async Task<(string CookieHeader, string XsrfToken)> MintAntiforgeryAsync()
-    {
-        using var client = CreateClient();
-        var response = await client.GetAsync("/spark/po/__warmup__");
-
-        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
-            throw new InvalidOperationException("Warmup request did not return any Set-Cookie headers.");
-
-        string? antiforgeryCookie = null;
-        string? xsrfToken = null;
-
-        foreach (var raw in setCookies)
-        {
-            var nameValue = raw.Split(';', 2)[0];
-            var eq = nameValue.IndexOf('=');
-            if (eq < 0) continue;
-            var name = nameValue[..eq];
-            var value = nameValue[(eq + 1)..];
-
-            if (name.StartsWith(".AspNetCore.Antiforgery", StringComparison.Ordinal))
-                antiforgeryCookie = nameValue;
-            else if (name == "XSRF-TOKEN")
-            {
-                xsrfToken = Uri.UnescapeDataString(value);
-            }
-        }
-
-        if (antiforgeryCookie is null || xsrfToken is null)
-            throw new InvalidOperationException(
-                $"Warmup did not yield both antiforgery cookies. Got: '{string.Join(" | ", setCookies)}'");
-
-        return (antiforgeryCookie + "; XSRF-TOKEN=" + Uri.EscapeDataString(xsrfToken), xsrfToken);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _host.StopAsync();
-        _host.Dispose();
-        try
-        {
-            if (Directory.Exists(_contentRoot))
-                Directory.Delete(_contentRoot, recursive: true);
-        }
-        catch
-        {
-            // Best-effort cleanup
-        }
     }
 }
 
 /// <summary>
 /// Minimal SparkContext for endpoint tests. Tests that need additional collections
-/// can subclass or extend this via a custom fixture.
+/// can subclass this or write their own and use <see cref="SparkEndpointFactory{TContext}"/> directly.
 /// </summary>
-public sealed class TestSparkContext : SparkContext
+public class TestSparkContext : SparkContext
 {
     public IRavenQueryable<Person> People => Session.Query<Person>();
     public IRavenQueryable<Company> Companies => Session.Query<Company>();

--- a/MintPlayer.Spark.sln
+++ b/MintPlayer.Spark.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MintPlayer.Spark.SourceGene
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MintPlayer.Spark.SubscriptionWorker.Abstractions", "MintPlayer.Spark.SubscriptionWorker.Abstractions\MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj", "{059EB754-3C9C-4B6B-9ECA-14C972C639D7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MintPlayer.Spark.Client", "MintPlayer.Spark.Client\MintPlayer.Spark.Client.csproj", "{481F2A63-1BD5-46EC-B813-12CC178A1D68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -421,6 +423,18 @@ Global
 		{059EB754-3C9C-4B6B-9ECA-14C972C639D7}.Release|x64.Build.0 = Release|Any CPU
 		{059EB754-3C9C-4B6B-9ECA-14C972C639D7}.Release|x86.ActiveCfg = Release|Any CPU
 		{059EB754-3C9C-4B6B-9ECA-14C972C639D7}.Release|x86.Build.0 = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|x64.Build.0 = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Debug|x86.Build.0 = Debug|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|x64.ActiveCfg = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|x64.Build.0 = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|x86.ActiveCfg = Release|Any CPU
+		{481F2A63-1BD5-46EC-B813-12CC178A1D68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MintPlayer.Spark/Actions/DefaultPersistentObjectActions.cs
+++ b/MintPlayer.Spark/Actions/DefaultPersistentObjectActions.cs
@@ -49,6 +49,31 @@ public partial class DefaultPersistentObjectActions<T> : IPersistentObjectAction
         }
     }
 
+    /// <summary>
+    /// Row-level authorization hook. Answers whether the current principal may perform the
+    /// given <paramref name="action"/> on this specific <paramref name="entity"/> instance.
+    /// The entity-type-level check (<see cref="Abstractions.Authorization.IPermissionService"/>)
+    /// has already succeeded by the time this is called — this is the second layer that
+    /// enforces ownership, tenant isolation, or any other per-row policy.
+    ///
+    /// Returning false translates to 404 for single-entity reads (so existence isn't
+    /// leaked; see security audit M-3), a filtered-out row in list responses, or a
+    /// rejected write. The default is permissive — override in an application-specific
+    /// Actions class to enforce row-level policy. Overriding is a clear signal to code
+    /// reviewers that the class takes responsibility for row-level security.
+    ///
+    /// Intentionally distinct from <see cref="OnQueryAsync"/>: the latter describes
+    /// *where* to find entities of this type; this hook answers *whether* the caller
+    /// may act on each one. Keeping the concerns apart keeps row-level security explicit.
+    ///
+    /// Inject <c>IHttpContextAccessor</c> into your Actions class to reach the current
+    /// <c>ClaimsPrincipal</c>.
+    /// </summary>
+    /// <param name="action">One of "Read" / "Query" / "Edit" / "Delete" / "New" — the
+    /// same vocabulary used by <c>IPermissionService.IsAllowedAsync</c>.</param>
+    /// <param name="entity">The specific row being evaluated.</param>
+    public virtual Task<bool> IsAllowedAsync(string action, T entity) => Task.FromResult(true);
+
     /// <inheritdoc />
     public virtual Task OnBeforeSaveAsync(PersistentObject obj, T entity) => Task.CompletedTask;
 

--- a/MintPlayer.Spark/Endpoints/Aliases/GetAliases.cs
+++ b/MintPlayer.Spark/Endpoints/Aliases/GetAliases.cs
@@ -1,5 +1,6 @@
 using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Authorization;
 using MintPlayer.Spark.Services;
 
 namespace MintPlayer.Spark.Endpoints.Aliases;
@@ -10,16 +11,25 @@ internal sealed partial class GetAliases : IGetEndpoint, IMemberOf<SparkGroup>
 
     [Inject] private readonly IModelLoader modelLoader;
     [Inject] private readonly IQueryLoader queryLoader;
+    [Inject] private readonly IPermissionService permissionService;
 
     public async Task<IResult> HandleAsync(HttpContext httpContext)
     {
-        var entityTypeAliases = modelLoader.GetEntityTypes()
-            .Where(e => e.Alias != null)
-            .ToDictionary(e => e.Id.ToString(), e => e.Alias!);
+        var entityTypeAliases = new Dictionary<string, string>();
+        foreach (var entityType in modelLoader.GetEntityTypes())
+        {
+            if (entityType.Alias is null) continue;
+            if (await permissionService.IsAllowedAsync("Query", entityType.Name, httpContext.RequestAborted))
+                entityTypeAliases[entityType.Id.ToString()] = entityType.Alias;
+        }
 
-        var queryAliases = queryLoader.GetQueries()
-            .Where(q => q.Alias != null)
-            .ToDictionary(q => q.Id.ToString(), q => q.Alias!);
+        var queryAliases = new Dictionary<string, string>();
+        foreach (var query in queryLoader.GetQueries())
+        {
+            if (query.Alias is null || query.EntityType is null) continue;
+            if (await permissionService.IsAllowedAsync("Query", query.EntityType, httpContext.RequestAborted))
+                queryAliases[query.Id.ToString()] = query.Alias;
+        }
 
         return Results.Json(new
         {

--- a/MintPlayer.Spark/Endpoints/EntityTypes/Get.cs
+++ b/MintPlayer.Spark/Endpoints/EntityTypes/Get.cs
@@ -1,5 +1,6 @@
 using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Authorization;
 using MintPlayer.Spark.Services;
 
 namespace MintPlayer.Spark.Endpoints.EntityTypes;
@@ -9,6 +10,7 @@ internal sealed partial class GetEntityType : IGetEndpoint, IMemberOf<EntityType
     public static string Path => "/{id}";
 
     [Inject] private readonly IModelLoader modelLoader;
+    [Inject] private readonly IPermissionService permissionService;
 
     public async Task<IResult> HandleAsync(HttpContext httpContext)
     {
@@ -16,9 +18,11 @@ internal sealed partial class GetEntityType : IGetEndpoint, IMemberOf<EntityType
         var entityType = modelLoader.ResolveEntityType(id);
 
         if (entityType is null)
-        {
             return Results.Json(new { error = $"Entity type '{id}' not found" }, statusCode: 404);
-        }
+
+        // 404 rather than 403 — so existence isn't leaked to callers without Query rights.
+        if (!await permissionService.IsAllowedAsync("Query", entityType.Name, httpContext.RequestAborted))
+            return Results.Json(new { error = $"Entity type '{id}' not found" }, statusCode: 404);
 
         return Results.Json(entityType);
     }

--- a/MintPlayer.Spark/Endpoints/EntityTypes/List.cs
+++ b/MintPlayer.Spark/Endpoints/EntityTypes/List.cs
@@ -1,5 +1,7 @@
 using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Authorization;
 using MintPlayer.Spark.Services;
 
 namespace MintPlayer.Spark.Endpoints.EntityTypes;
@@ -9,10 +11,17 @@ internal sealed partial class ListEntityTypes : IGetEndpoint, IMemberOf<EntityTy
     public static string Path => "/";
 
     [Inject] private readonly IModelLoader modelLoader;
+    [Inject] private readonly IPermissionService permissionService;
 
     public async Task<IResult> HandleAsync(HttpContext httpContext)
     {
         var entityTypes = modelLoader.GetEntityTypes();
-        return Results.Json(entityTypes);
+        var visible = new List<EntityTypeDefinition>(entityTypes.Count());
+        foreach (var entityType in entityTypes)
+        {
+            if (await permissionService.IsAllowedAsync("Query", entityType.Name, httpContext.RequestAborted))
+                visible.Add(entityType);
+        }
+        return Results.Json(visible);
     }
 }

--- a/MintPlayer.Spark/Endpoints/PersistentObject/Update.cs
+++ b/MintPlayer.Spark/Endpoints/PersistentObject/Update.cs
@@ -71,6 +71,10 @@ internal sealed partial class UpdatePersistentObject : IPutEndpoint, IMemberOf<P
             var result = await databaseAccess.SavePersistentObjectAsync(obj);
             return Results.Json(result);
         }
+        catch (SparkConcurrencyException ex)
+        {
+            return Results.Json(new { error = ex.Message }, statusCode: 409);
+        }
         catch (SparkRetryActionException ex)
         {
             return Results.Json(new

--- a/MintPlayer.Spark/Endpoints/Queries/Execute.cs
+++ b/MintPlayer.Spark/Endpoints/Queries/Execute.cs
@@ -43,6 +43,39 @@ internal sealed partial class ExecuteQuery : IGetEndpoint, IMemberOf<QueriesGrou
                         };
                     })
                     .ToArray();
+
+                // Allow-list sort columns against the query's declared attribute set. Without
+                // this check, a caller could sort by any public property on the projection
+                // type via reflection (including fields the developer didn't expose as an
+                // attribute), leaking ordering as a side channel. The query's own declared
+                // sort columns are always allowed, so a query can opt in to otherwise-private
+                // sort keys by declaring them up-front.
+                var allowedProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (query.EntityType is not null)
+                {
+                    var entityType = modelLoader.ResolveEntityType(query.EntityType);
+                    if (entityType is not null)
+                    {
+                        foreach (var attr in entityType.Attributes)
+                            allowedProperties.Add(attr.Name);
+                    }
+                }
+                if (query.SortColumns is not null)
+                {
+                    foreach (var declared in query.SortColumns)
+                        allowedProperties.Add(declared.Property);
+                }
+
+                var invalid = sortOverrides
+                    .Where(c => !allowedProperties.Contains(c.Property))
+                    .Select(c => c.Property)
+                    .ToArray();
+                if (invalid.Length > 0)
+                {
+                    return Results.Json(
+                        new { error = $"Unknown sort column(s): {string.Join(", ", invalid)}" },
+                        statusCode: 400);
+                }
             }
 
             // Read pagination parameters

--- a/MintPlayer.Spark/Endpoints/Queries/Execute.cs
+++ b/MintPlayer.Spark/Endpoints/Queries/Execute.cs
@@ -96,6 +96,11 @@ internal sealed partial class ExecuteQuery : IGetEndpoint, IMemberOf<QueriesGrou
                 {
                     parent = await databaseAccess.GetPersistentObjectAsync(parentEntityType.Id, parentId);
                 }
+                // Parent was asked for but we couldn't resolve or couldn't authorize it.
+                // Return 404 rather than silently running the query unscoped — that would
+                // leak data the caller shouldn't see (H-3).
+                if (parent is null)
+                    return Results.Json(new { error = "Parent not found" }, statusCode: 404);
             }
 
             // Clone query with sort overrides if provided

--- a/MintPlayer.Spark/Endpoints/Queries/Get.cs
+++ b/MintPlayer.Spark/Endpoints/Queries/Get.cs
@@ -1,5 +1,6 @@
 using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Authorization;
 using MintPlayer.Spark.Services;
 
 namespace MintPlayer.Spark.Endpoints.Queries;
@@ -9,6 +10,7 @@ internal sealed partial class GetQuery : IGetEndpoint, IMemberOf<QueriesGroup>
     public static string Path => "/{id}";
 
     [Inject] private readonly IQueryLoader queryLoader;
+    [Inject] private readonly IPermissionService permissionService;
 
     public async Task<IResult> HandleAsync(HttpContext httpContext)
     {
@@ -16,6 +18,11 @@ internal sealed partial class GetQuery : IGetEndpoint, IMemberOf<QueriesGroup>
         var query = queryLoader.ResolveQuery(id);
 
         if (query is null)
+            return Results.Json(new { error = $"Query '{id}' not found" }, statusCode: 404);
+
+        // Return 404 (not 403) when the caller isn't authorized — so existence isn't leaked.
+        if (query.EntityType is null ||
+            !await permissionService.IsAllowedAsync("Query", query.EntityType, httpContext.RequestAborted))
         {
             return Results.Json(new { error = $"Query '{id}' not found" }, statusCode: 404);
         }

--- a/MintPlayer.Spark/Endpoints/Queries/List.cs
+++ b/MintPlayer.Spark/Endpoints/Queries/List.cs
@@ -1,5 +1,6 @@
 using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Authorization;
 using MintPlayer.Spark.Services;
 
 namespace MintPlayer.Spark.Endpoints.Queries;
@@ -9,10 +10,22 @@ internal sealed partial class ListQueries : IGetEndpoint, IMemberOf<QueriesGroup
     public static string Path => "/";
 
     [Inject] private readonly IQueryLoader queryLoader;
+    [Inject] private readonly IPermissionService permissionService;
 
     public async Task<IResult> HandleAsync(HttpContext httpContext)
     {
         var queries = queryLoader.GetQueries();
-        return Results.Json(queries);
+        var visible = new List<Abstractions.SparkQuery>(queries.Count());
+        foreach (var query in queries)
+        {
+            // Queries without a target entity type cannot be permission-checked and are
+            // conservatively hidden. When EntityType is set, the caller needs at least
+            // Query rights on that entity to see the query in the list.
+            if (query.EntityType is null)
+                continue;
+            if (await permissionService.IsAllowedAsync("Query", query.EntityType, httpContext.RequestAborted))
+                visible.Add(query);
+        }
+        return Results.Json(visible);
     }
 }

--- a/MintPlayer.Spark/Exceptions/SparkConcurrencyException.cs
+++ b/MintPlayer.Spark/Exceptions/SparkConcurrencyException.cs
@@ -1,0 +1,19 @@
+namespace MintPlayer.Spark.Exceptions;
+
+/// <summary>
+/// Thrown when an update carries an Etag that no longer matches the server's current
+/// change vector — i.e. the entity was modified by someone else between the caller's
+/// read and write. Endpoint handlers translate this to HTTP 409 Conflict.
+/// </summary>
+internal sealed class SparkConcurrencyException : Exception
+{
+    public string ExpectedEtag { get; }
+    public string? ActualEtag { get; }
+
+    public SparkConcurrencyException(string expectedEtag, string? actualEtag)
+        : base($"Optimistic concurrency check failed: expected etag '{expectedEtag}', actual '{actualEtag ?? "<none>"}'.")
+    {
+        ExpectedEtag = expectedEtag;
+        ActualEtag = actualEtag;
+    }
+}

--- a/MintPlayer.Spark/Extensions/SparkBuilderRateLimiterExtensions.cs
+++ b/MintPlayer.Spark/Extensions/SparkBuilderRateLimiterExtensions.cs
@@ -1,0 +1,64 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.Spark.Abstractions.Builder;
+
+namespace MintPlayer.Spark.Extensions;
+
+/// <summary>
+/// Optional rate-limiter wiring for Spark-powered apps. Security audit finding L-3 keeps
+/// the framework itself out of rate-limiting policy — apps opt in. This extension hangs off
+/// <see cref="ISparkBuilder"/> so it composes with the rest of the Spark builder surface:
+/// <code>
+/// builder.Services.AddSpark(spark => spark.AddRateLimiter());
+/// </code>
+/// or via <c>SparkFullOptions.RateLimiter</c> for AddSparkFull consumers.
+///
+/// The limiter is partitioned by client IP and scoped to requests under <c>/spark/</c>, so
+/// static assets and app-specific routes remain unthrottled. Over-limit requests are rejected
+/// with HTTP 429. The rate-limiter middleware registers itself through the Spark builder
+/// registry — no separate <c>app.UseRateLimiter()</c> call needed when the app uses
+/// <c>UseSpark()</c> / <c>UseSparkFull()</c>.
+/// </summary>
+public static class SparkBuilderRateLimiterExtensions
+{
+    /// <summary>
+    /// Registers a fixed-window rate limiter for Spark endpoints. Calling with no configurator
+    /// uses the documented defaults (<see cref="SparkRateLimiterOptions"/>).
+    /// </summary>
+    public static ISparkBuilder AddRateLimiter(
+        this ISparkBuilder builder,
+        Action<SparkRateLimiterOptions>? configure = null)
+    {
+        var options = new SparkRateLimiterOptions();
+        configure?.Invoke(options);
+
+        builder.Services.AddRateLimiter(rl =>
+        {
+            rl.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+            {
+                // Only Spark routes are throttled. SPA static files, controllers, and any
+                // non-framework endpoints remain unmetered so the limiter never starves
+                // browser asset loads.
+                if (!httpContext.Request.Path.StartsWithSegments("/spark"))
+                    return RateLimitPartition.GetNoLimiter("no-limit");
+
+                var clientKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: clientKey,
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = options.PermitLimit,
+                        Window = options.Window,
+                        QueueLimit = 0,
+                    });
+            });
+            rl.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        });
+
+        builder.Registry.AddMiddleware(app => app.UseRateLimiter());
+        return builder;
+    }
+}

--- a/MintPlayer.Spark/Extensions/SparkRateLimiterOptions.cs
+++ b/MintPlayer.Spark/Extensions/SparkRateLimiterOptions.cs
@@ -1,0 +1,16 @@
+namespace MintPlayer.Spark.Extensions;
+
+/// <summary>
+/// Configures the fixed-window rate limiter wired by
+/// <see cref="SparkBuilderRateLimiterExtensions.AddRateLimiter"/>. Apps that want
+/// the default (150 requests / 10 seconds per client IP, scoped to <c>/spark/</c>)
+/// can pass <c>_ =&gt; { }</c> — any unset property falls back to the documented default.
+/// </summary>
+public class SparkRateLimiterOptions
+{
+    /// <summary>Requests allowed per window, per client IP. Defaults to 150.</summary>
+    public int PermitLimit { get; set; } = 150;
+
+    /// <summary>Window length. Defaults to 10 seconds.</summary>
+    public TimeSpan Window { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -1,6 +1,7 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Exceptions;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
@@ -98,7 +99,10 @@ internal partial class DatabaseAccess : IDatabaseAccess
         // Load included documents for breadcrumb resolution
         var includedDocuments = await referenceResolver.ResolveReferencedDocumentsAsync(session, [entity], referenceProperties);
 
-        return entityMapper.ToPersistentObject(entity, objectTypeId, includedDocuments);
+        var persistentObject = entityMapper.ToPersistentObject(entity, objectTypeId, includedDocuments);
+        // Capture the RavenDB change vector so clients can round-trip it for optimistic concurrency.
+        persistentObject.Etag = session.Advanced.GetChangeVectorFor(entity);
+        return persistentObject;
     }
 
     public async Task<IEnumerable<PersistentObject>> GetPersistentObjectsAsync(Guid objectTypeId)
@@ -151,6 +155,23 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         using var session = documentStore.OpenAsyncSession();
 
+        // Optimistic-concurrency check: if the caller sent an Etag on an existing entity,
+        // verify it matches the current server-side change vector before the actions
+        // pipeline runs. A mismatch means the entity has been updated since the caller
+        // read it — reject instead of silently overwriting. We load into a side session so
+        // the tracking on the main session is clean for the actions pipeline's StoreAsync.
+        if (!string.IsNullOrEmpty(persistentObject.Id) && !string.IsNullOrEmpty(persistentObject.Etag))
+        {
+            using var checkSession = documentStore.OpenAsyncSession();
+            var existing = await LoadEntityAsync(checkSession, entityType, persistentObject.Id);
+            if (existing is not null)
+            {
+                var currentEtag = checkSession.Advanced.GetChangeVectorFor(existing);
+                if (!string.Equals(currentEtag, persistentObject.Etag, StringComparison.Ordinal))
+                    throw new SparkConcurrencyException(persistentObject.Etag, currentEtag);
+            }
+        }
+
         // Pass PO directly to actions — entity mapping happens inside the actions pipeline
         var savedEntity = await SaveEntityViaActionsAsync(session, entityType, persistentObject);
 
@@ -159,6 +180,8 @@ internal partial class DatabaseAccess : IDatabaseAccess
         var generatedId = idProperty?.GetValue(savedEntity)?.ToString();
 
         persistentObject.Id = generatedId;
+        // Return the fresh change vector so the client can round-trip it to the next update.
+        persistentObject.Etag = session.Advanced.GetChangeVectorFor(savedEntity);
 
         // If this is a replicated entity, also broadcast the changes to the owner module
         var interceptor = serviceProvider.GetService<ISyncActionInterceptor>();

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -96,6 +96,13 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         if (entity == null) return null;
 
+        // Row-level read gate. Entity-type "Read" passed; now let the Actions class decide
+        // whether this specific instance is visible to the current caller. Returning null
+        // here propagates as 404 through the endpoint — same shape as a genuinely missing
+        // record, per M-3 (authorized-but-forbidden must be indistinguishable from not-found).
+        if (!await IsAllowedEntityViaActionsAsync(entityType, "Read", entity))
+            return null;
+
         // Load included documents for breadcrumb resolution
         var includedDocuments = await referenceResolver.ResolveReferencedDocumentsAsync(session, [entity], referenceProperties);
 
@@ -135,11 +142,53 @@ internal partial class DatabaseAccess : IDatabaseAccess
         // Query entities - use index if projection is registered, otherwise query collection
         var entities = (await QueryEntitiesWithIncludesAsync(session, queryType, indexName, referenceProperties)).ToList();
 
+        // Row-level "Query" gate (H-2): after entity-type authz passed, filter the list down
+        // to rows the Actions class says the caller may see. For projection queries, the row
+        // filter takes the base entity (CarActions typed on Car, not VCar) so we load the
+        // matching base docs through the session cache. Callers that need a query-level
+        // filter for large collections can override OnQueryAsync directly.
+        entities = (await FilterByRowLevelAuthAsync(session, entities, entityType, queryType)).ToList();
+
         // Referenced documents are now in session cache - extract them
         var includedDocuments = await referenceResolver.ResolveReferencedDocumentsAsync(session, entities, referenceProperties);
 
         // Convert each entity to PersistentObject with breadcrumb resolution
         return entities.Select(e => entityMapper.ToPersistentObject(e, objectTypeId, includedDocuments));
+    }
+
+    /// <summary>
+    /// Applies the Actions class's row-level read gate to a materialized list. When the
+    /// query ran against a projection type, we load the corresponding base entities from
+    /// the session (Raven reuses its cache, so this is cheap for documents already seen)
+    /// and evaluate the filter against those — the Actions class is typed on the base
+    /// entity, not the projection.
+    /// </summary>
+    private async Task<IEnumerable<object>> FilterByRowLevelAuthAsync(
+        IAsyncDocumentSession session,
+        IReadOnlyList<object> entities,
+        Type entityType,
+        Type queryType)
+    {
+        if (entities.Count == 0) return entities;
+
+        var idProperty = queryType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+        if (idProperty is null) return entities; // Can't resolve IDs — fail open.
+
+        var visible = new List<object>(entities.Count);
+        foreach (var entity in entities)
+        {
+            object? subject = entity;
+            if (queryType != entityType)
+            {
+                var id = idProperty.GetValue(entity)?.ToString();
+                if (string.IsNullOrEmpty(id)) { visible.Add(entity); continue; }
+                subject = await LoadEntityAsync(session, entityType, id);
+                if (subject is null) { visible.Add(entity); continue; }
+            }
+            if (await IsAllowedEntityViaActionsAsync(entityType, "Query", subject))
+                visible.Add(entity);
+        }
+        return visible;
     }
 
     public async Task<PersistentObject> SavePersistentObjectAsync(PersistentObject persistentObject)
@@ -390,6 +439,21 @@ internal partial class DatabaseAccess : IDatabaseAccess
         var task = (Task)onLoadMethod.Invoke(actions, [session, id])!;
         await task;
         return task.GetType().GetProperty("Result")!.GetValue(task);
+    }
+
+    /// <summary>
+    /// Dispatches to the Actions class's virtual <c>IsAllowedAsync(string, T)</c> via reflection,
+    /// so H-2/H-3 row-level authorization fires regardless of entity type.
+    /// </summary>
+    private async Task<bool> IsAllowedEntityViaActionsAsync(Type entityType, string action, object entity)
+    {
+        var actions = actionsResolver.ResolveForType(entityType);
+        var method = actions.GetType().GetMethod("IsAllowedAsync", [typeof(string), entityType]);
+        if (method is null)
+            return true; // Unknown shape — fail open rather than dropping valid rows.
+        var task = (Task)method.Invoke(actions, [action, entity])!;
+        await task;
+        return (bool)task.GetType().GetProperty("Result")!.GetValue(task)!;
     }
 
     private async Task<IEnumerable<object>> QueryEntitiesViaActionsAsync(IAsyncDocumentSession session, Type entityType)

--- a/MintPlayer.Spark/SparkMiddleware.cs
+++ b/MintPlayer.Spark/SparkMiddleware.cs
@@ -190,8 +190,13 @@ public static class SparkExtensions
             {
                 context.Response.Cookies.Append("XSRF-TOKEN", tokens.RequestToken, new CookieOptions
                 {
+                    // HttpOnly=false is intentional — the Angular client reads this cookie
+                    // and echoes it back in X-XSRF-TOKEN (double-submit pattern).
                     HttpOnly = false,
                     SameSite = SameSiteMode.Strict,
+                    // Secure=IsHttps so the token is never sent over plain HTTP in production,
+                    // but local HTTP development still works.
+                    Secure = context.Request.IsHttps,
                     Path = "/"
                 });
             }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+coverage:
+  status:
+    project:
+      default:
+        # Tolerate small regressions — new framework surface arrives faster than
+        # dedicated tests in practice, and the e2e suite exercises code that
+        # coverlet can't instrument (out-of-process Fleet subprocess, etc).
+        # If a PR adds lots of uncovered production code the patch check still
+        # catches it.
+        target: auto
+        threshold: 2%
+        informational: false
+    patch:
+      default:
+        target: 40%
+        threshold: 0%
+        informational: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "Demo/**"                                 # excluded from CI test runs — not production
+  - "**/obj/**"
+  - "**/bin/**"
+  - "**/*.Designer.cs"
+  - "**/*.Generated.cs"
+  - "**/Generated/**"
+  - "MintPlayer.Spark.SourceGenerators/**"    # tested by its own .Tests project
+  - "MintPlayer.Spark.AllFeatures.SourceGenerators/**"
+  - "MintPlayer.Spark.Testing/**"             # test helper library, not production
+  - "MintPlayer.Spark.Tests/**"
+  - "MintPlayer.Spark.SourceGenerators.Tests/**"
+  - "MintPlayer.Spark.E2E.Tests/**"
+  - "node_packages/**"                        # Angular libs measured separately

--- a/docs/PRD-SecurityAudit-TestResults.md
+++ b/docs/PRD-SecurityAudit-TestResults.md
@@ -1,90 +1,166 @@
-# Security Audit — Test Run Results (master, 2026-04-20)
+# Security Audit — Test Run Status & Pickup Notes
 
 **Companion to:** [PRD-SecurityAudit.md](PRD-SecurityAudit.md)
-**Commit under test:** `ea596e9` (master HEAD at audit time), tests at `ea368af` on `feat/security-audit`
-**Run:** TRX at `MintPlayer.Spark.E2E.Tests/TestResults/security.trx`
+**Branch:** `feat/security-audit`
+**PR:** https://github.com/MintPlayer/MintPlayer.Spark/pull/123
 
-## Summary
+## Current status (end of session 2026-04-20)
 
-| Metric | Count |
-|--------|-------|
-| Total tests | 28 |
-| Passed | 7 |
-| Failed | 18 |
-| Skipped | 3 |
+| Metric | Baseline (pre-fixes) | Current |
+|--------|----------------------|---------|
+| Total tests | 28 | 28 |
+| Passed | 7 | 25 |
+| Failed | 18 | 0 |
+| Skipped | 3 | 3 |
+| Unclassified | 0 | 0 |
 
-## Triage refinements applied
+All 28 tests run without diagnostic noise. The 25 passes document secure
+behaviour on master (or tests newly flipped by fixes in this PR). The 3
+skips are `RowLevelAuthzTests.*` pending the H-2/H-3 row-filter hook. **No
+red tests remain on this branch** — everything failing at the baseline has
+either been fixed in-framework, fixed test-side (false positive), or is
+already tracked for a later commit.
 
-- **H-1** — contract is *filter*, not *refuse*. Unauth caller gets the subset their effective principal (Everyone group) has `Query` rights on.
-- **L-3** — demo-only. Framework stays out; each demo app wires `AddRateLimiter()` in its own `Program.cs`.
+## Commits so far (`feat/security-audit`)
 
-## Full outcome matrix (parsed from TRX)
+| Sha | Summary |
+|-----|---------|
+| `ea368af` | audit PRD + 25 e2e tests pinning secure behaviour |
+| `d3a692f` | record clean baseline matrix (TRX-parsed) |
+| `9e9fdf4` | **fix(H-1)** filter metadata endpoints by caller's Query rights |
+| `b0aed65` | **test fix** add required PersistentObject.Name to write-path bodies; expose FleetTestHost.RecentLog |
+| `2175c85` | **test fix(H-5)** check URL host, not substring; add diagnostic login smoke |
 
-### Vulnerabilities reproduced (14 real failing tests)
+## What was actually vulnerable vs. already-safe
 
-| Finding | Test | Notes |
-|---------|------|-------|
-| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_queries_includes_only_queries_visible_to_anonymous_callers` | Full catalogue returned to anon |
-| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_types_includes_only_types_visible_to_anonymous_callers` | Full type schemas returned to anon |
-| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_queries_id_for_protected_query_is_refused` | Direct access to protected query definition returns 200 |
-| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_aliases_includes_only_aliases_visible_to_anonymous_callers` | Protected aliases leak |
-| M-5 | `SortInjection.Sort_by_nonexistent_property_is_rejected` | Framework silently ignores bad column |
-| M-5 | `SortInjection.Sort_by_metadata_property_on_projection_is_rejected` | `Id` as sort column accepted |
-| L-2 | `XsrfCookieFlag.XSRF_TOKEN_cookie_carries_Secure_attribute_over_https` | No `Secure` flag even over HTTPS |
-| L-3 | `RateLimit.Rapid_unauthenticated_bursts_trigger_429_Too_Many_Requests` | 200 requests, zero 429s — no rate limiter |
-| H-5 | `ReturnUrlValidation.Login_with_protocol_relative_returnUrl_does_not_navigate_off_site` | — |
-| H-5 | `ReturnUrlValidation.Login_with_absolute_http_returnUrl_does_not_navigate_off_site` | — |
-| H-5 | `ReturnUrlValidation.Login_with_absolute_https_returnUrl_does_not_navigate_off_site` | — |
-| H-5 | `ReturnUrlValidation.Login_with_javascript_uri_returnUrl_does_not_execute_script` | — |
-| H-5 | `ReturnUrlValidation.Login_with_backslash_authority_returnUrl_does_not_navigate_off_site` | — |
-| H-5 | `ReturnUrlValidation.Login_with_whitespace_prefixed_returnUrl_does_not_navigate_off_site` | All 6 H-5 tests fail uniformly — strongly suggests a test-infrastructure issue (login form not being submitted) rather than all 6 attack vectors genuinely succeeding. Needs investigation before counting these as confirmed vulnerabilities |
+### Real vulnerabilities found and fixed
 
-### Test-setup bugs (4 failing tests — blocking, not vulnerability evidence)
+- **H-1** (metadata leak) — 4 tests. Fixed in `9e9fdf4` by injecting
+  `IPermissionService` into `Queries/List`, `Queries/Get`,
+  `EntityTypes/List`, `EntityTypes/Get`, `Aliases/GetAliases` and
+  filtering responses by `IsAllowedAsync("Query", entityName)`.
 
-| Finding | Test | Issue |
-|---------|------|-------|
-| L-2 | `XsrfCookieFlag.XSRF_TOKEN_cookie_has_SameSite_Strict` | `SparkMiddleware.cs:191-196` sets `SameSite=Strict`; the assertion shape is probably wrong (cookie attribute casing?). Test needs fixing |
-| L-7a | `AttributeWriteProtection.Update_with_IsReadOnly_attribute_in_body_does_not_modify_field` | POST /spark/po/Car returns 500 at setup — not yet debugged |
-| L-7b | `AttributeWriteProtection.Update_cannot_escalate_via_unknown_attribute_name` | Same 500 as above |
-| M-7 | `Concurrency.Concurrent_update_with_stale_version_is_rejected` | Same 500 as above |
+### Real vulnerabilities found and not yet fixed
 
-### Already-secure behaviour (7 passing tests)
+- **M-7** concurrency — 1 test. Framework has no optimistic-concurrency
+  check on update; two clients can lost-write each other silently. Confirmed
+  by `ConcurrencyTests.Concurrent_update_with_stale_version_is_rejected`
+  now that its setup runs (`b0aed65`). Status: **failing as expected**,
+  waiting on the fix.
+- **M-5** sort-column reflection — 2 tests. `?sortColumns=<anyPublicProperty>`
+  is accepted via reflection; the framework must allow-list against the
+  query's declared attribute set.
+- **L-2 Secure flag** — 1 test. `SparkMiddleware.cs:191-196` sets
+  `HttpOnly=false` (correct for double-submit) and `SameSite=Strict`, but
+  no `Secure` flag. One-line fix: `Secure = context.Request.IsHttps`.
+- **L-3** rate limiter — 1 test. Demo-only per triage; wire
+  `AddRateLimiter()` in Fleet/HR/DemoApp `Program.cs`.
 
-| Finding | Test | Implication |
-|---------|------|-------------|
-| M-1 | `PermissionsEndpointAuth.Unauthenticated_GET_permissions_for_Car_reports_no_access` | `/spark/permissions/{type}` already returns `{canRead:false, ...}` to anon |
-| M-1 | `PermissionsEndpointAuth.Unauthenticated_GET_permissions_for_Company_reports_read_but_no_write` | Company anonymous read is honored, mutations correctly denied |
-| M-3 | `NotFoundVsForbidden.Nonexistent_id_and_forbidden_id_return_the_same_status` | 404/403 already indistinguishable in the tested path |
-| M-5 | `SortInjection.Sort_with_malformed_direction_does_not_500` | Malformed direction falls through to default (no 500) |
-| M-6 | `ErrorLeakage.Malformed_entityTypeId_does_not_leak_stack_trace_or_internal_types` | Clean error body |
-| M-6 | `ErrorLeakage.Malformed_id_on_get_does_not_leak_internals` | Clean error body |
-| M-6 | `ErrorLeakage.Bad_lookup_reference_key_does_not_leak_internals` | Clean error body |
+### Findings that turned out to be already-safe on master
 
-**Implication for remediation scope:** M-1 and M-6 are already secure in Fleet's setup. The tests stay as regression protection, but no framework change is required for those findings.
+- **M-1** — `/spark/permissions/{type}` already reports `canCreate/canEdit/canDelete=false`
+  for anonymous callers. No framework change.
+- **M-3** — 404/403 responses are already indistinguishable in the tested path.
+- **M-5** (malformed sort direction) — framework falls through to default, no 500.
+- **M-6** — error responses are already sanitised (no stack traces, no Raven internals).
+- **H-5** — Angular router implicitly rejects external/javascript/protocol-relative
+  URLs in `navigateByUrl`. 7 tests pass (6 attack vectors + 1 diagnostic login smoke).
+  Note: there's a cosmetic UX issue where a successful login + rejected returnUrl
+  leaves the user stuck on `/login?returnUrl=…` — that's the allow-list-remediation
+  territory, but **not a security issue**.
 
-### Skipped pending row-level filter hook (3)
+### False positives in the initial baseline that turned out to be test bugs
 
-| Finding | Test | Blocker |
-|---------|------|---------|
-| H-2 | `RowLevelAuthz.User_B_cannot_list_User_As_private_cars` | Row-level filter hook not yet added |
-| H-2 | `RowLevelAuthz.User_B_cannot_read_User_As_private_car_by_id` | Same |
-| H-3 | `RowLevelAuthz.User_B_cannot_execute_child_query_with_User_As_parent_id` | Same |
+- **L-2 SameSite** — cookie IS set to `SameSite=Strict` in master; the
+  assertion's string shape was wrong. Test-side fix only.
+- **L-7a / L-7b** — admin POST was returning 500 because request body
+  omitted the required `PersistentObject.Name` field. Once the field was
+  added, the framework's behaviour passed (L-7b is a real check; L-7a's
+  assertion is weak because Fleet's Car schema has no `IsReadOnly=true`
+  field — strengthening needs a demo-schema change).
+- **H-5** × 5 — substring assertions matched the `attacker.test` token
+  preserved in `?returnUrl=…` when the router refused to navigate. Fixed
+  in `2175c85` by switching to URL-host comparison.
 
-## Revised remediation priority
+## Pickup plan — suggested order
 
-Based on what's actually broken:
+Ascending effort; each flips one or more tests from failing to passing
+(or holds current behaviour as regression protection). Each should be its
+own commit on `feat/security-audit`.
 
-1. **H-1** (4 tests) — filter `/spark/queries`, `/spark/types`, `/spark/queries/{id}`, `/spark/aliases` by caller's `Query` rights.
-2. **Test-setup fix** (4 tests) — unblock L-7a/L-7b/M-7 by debugging the 500 on admin Car creation, and fix the L-2 SameSite assertion shape.
-3. **H-5 investigation** (6 tests) — verify whether all 6 are real vulnerabilities or a test-infrastructure uniformity problem. If the login form submission isn't going through, the test never reaches the router and every URL shape fails identically.
-4. **L-2 Secure flag** (1 test) — one-line change in `SparkMiddleware.cs:191-196`.
-5. **M-5** (2 tests) — allow-list sort columns against the query's declared attribute set.
-6. **M-7 / L-7a / L-7b** — after the setup-fix, real assertion runs. M-7 probably needs the concurrency fix; L-7 likely confirms the write-path doesn't enforce `IsReadOnly`/`IsVisible`.
-7. **L-3** (1 test) — wire `AddRateLimiter()` in `Demo/Fleet/Fleet/Program.cs`.
-8. **H-4, H-2, H-3** — framework-level hooks per PRD §6.
+### Quick wins (≤ 30 min each)
 
-## Out of scope for this PR
+1. **L-2 SameSite assertion fix** — `XsrfCookieFlagTests.cs`. The cookie
+   header format uses `samesite=strict` (lowercase-ish) or `SameSite=Strict`
+   depending on the framework's emitter. Update the assertion to match
+   case-insensitively. No framework change.
+2. **L-2 Secure flag** — `SparkMiddleware.cs:191-196`. Add
+   `Secure = context.Request.IsHttps` to the `CookieOptions`. Flips 1 test.
 
-- **H-4** fail-closed-without-authz — needs a separate host fixture.
-- **M-2** JWT tampering — Fleet is cookie-based; add when IdentityProvider lands.
-- **M-4 / L-4** marker attributes — need fix-side Actions class fixture.
+### Small framework changes (≤ 2 h each)
+
+3. **M-5 sort-column allow-list** — `QueryExecutor.cs:492` (and
+   `Endpoints/Queries/Execute.cs:31-46`). Intersect requested sort columns
+   with the query's declared `Attributes` (from `EntityTypeDefinition`)
+   before reflection. Flips 2 tests.
+4. **L-3 rate limiter in demos** — add `AddRateLimiter()` + `UseRateLimiter()`
+   wiring to `Demo/Fleet/Fleet/Program.cs` (and HR, DemoApp for consistency).
+   Flips 1 test. Demo-only per triage — does NOT touch framework.
+
+### Medium framework change (half-day)
+
+5. **M-7 optimistic concurrency** — `DatabaseAccess.SavePersistentObjectAsync`.
+   RavenDB supports change-vectors natively via
+   `session.Advanced.GetChangeVectorFor(entity)` + `StoreAsync(entity, changeVector, id)`.
+   The client sends the expected change-vector (likely as a header:
+   `If-Match`), and the server rejects on mismatch with HTTP 409. Flips 1 test.
+
+### Big framework change (biggest piece of the PR)
+
+6. **H-2 / H-3 row-level filter hook** — new virtual method on
+   `DefaultPersistentObjectActions<T>` per the PRD §5 triage decision.
+   Signature candidate:
+   ```csharp
+   public virtual IRavenQueryable<T> ApplyRowFilter(
+       IRavenQueryable<T> source, ClaimsPrincipal principal)
+       => source;
+   ```
+   Wire it into `DatabaseAccess.GetPersistentObjectsAsync` (List path) and
+   `GetPersistentObjectAsync` (Get path), then update `QueryExecutor` to
+   route parent-fetch in `Execute.cs:56-66` through the same hook. Add an
+   ownership concept to Fleet's `Car.json` (e.g. an `OwnerId` field set on
+   create) so `CarActions` can override and demonstrate the hook. Then
+   remove `[Fact(Skip=…)]` from the 3 tests in `RowLevelAuthzTests.cs`.
+
+### Out of scope / deferred
+
+- **H-4** fail-closed-without-authz — needs a second host fixture that
+  omits `AddAuthorization()`; not e2e-testable with the current single-Fleet
+  collection fixture.
+- **M-2** JWT tampering — Fleet is cookie-based. Revisit once
+  IdentityProvider lands on master.
+- **M-4 / L-4** marker attributes for custom queries / custom actions —
+  requires a fix-side fixture (an unmarked Actions method in a demo app
+  to verify reflection is refused). Design decision needed: do we want a
+  `[SparkQuery]` / `[ExposedAsAction]` attribute, or a separate registry?
+
+## How to resume
+
+```bash
+git checkout feat/security-audit
+git pull
+# pick a finding from "Pickup plan" above
+# implement, run the relevant test:
+dotnet test MintPlayer.Spark.E2E.Tests --filter "FullyQualifiedName~<ClassName>" \
+  --logger "trx;LogFileName=x.trx" --results-directory MintPlayer.Spark.E2E.Tests/TestResults
+# commit on the branch, push; PR #123 auto-updates
+```
+
+The Fleet fixture boots once per test collection (~30-60 s). Running a
+single test class is ~3-10 s after boot. Full 28-test suite runs in
+~2 min end-to-end.
+
+**RavenDB license** must be available as `RAVENDB_LICENSE` env var OR a
+`raven-license.log` file at the repo root. Angular bundle must be built
+once: `cd Demo/Fleet/Fleet/ClientApp && npm run build` (FleetTestHost
+rebuilds automatically if the dist dir is missing).

--- a/docs/PRD-SecurityAudit-TestResults.md
+++ b/docs/PRD-SecurityAudit-TestResults.md
@@ -1,166 +1,103 @@
-# Security Audit — Test Run Status & Pickup Notes
+# Security Audit — Test Run Status & Final Report
 
 **Companion to:** [PRD-SecurityAudit.md](PRD-SecurityAudit.md)
 **Branch:** `feat/security-audit`
 **PR:** https://github.com/MintPlayer/MintPlayer.Spark/pull/123
+**Final state:** `0d466d9`
 
-## Current status (end of session 2026-04-20)
+## Summary
 
-| Metric | Baseline (pre-fixes) | Current |
-|--------|----------------------|---------|
-| Total tests | 28 | 28 |
-| Passed | 7 | 25 |
-| Failed | 18 | 0 |
-| Skipped | 3 | 3 |
-| Unclassified | 0 | 0 |
+| Metric | Baseline (pre-fixes) | Final |
+|--------|----------------------|-------|
+| Total tests | 28 | 29 |
+| Passed | 7 | **29** |
+| Failed | 18 | **0** |
+| Skipped | 3 | **0** |
 
-All 28 tests run without diagnostic noise. The 25 passes document secure
-behaviour on master (or tests newly flipped by fixes in this PR). The 3
-skips are `RowLevelAuthzTests.*` pending the H-2/H-3 row-filter hook. **No
-red tests remain on this branch** — everything failing at the baseline has
-either been fixed in-framework, fixed test-side (false positive), or is
-already tracked for a later commit.
+Every originally-failing and every originally-skipped test is green. The 29th
+test is `ReturnUrlValidationTests.Diagnostic_admin_can_log_in_via_the_form`,
+added mid-audit to catch test-infrastructure regressions before they produce
+mystery failures across six returnUrl tests.
 
-## Commits so far (`feat/security-audit`)
+## Commits on `feat/security-audit`
 
 | Sha | Summary |
 |-----|---------|
 | `ea368af` | audit PRD + 25 e2e tests pinning secure behaviour |
 | `d3a692f` | record clean baseline matrix (TRX-parsed) |
 | `9e9fdf4` | **fix(H-1)** filter metadata endpoints by caller's Query rights |
-| `b0aed65` | **test fix** add required PersistentObject.Name to write-path bodies; expose FleetTestHost.RecentLog |
-| `2175c85` | **test fix(H-5)** check URL host, not substring; add diagnostic login smoke |
+| `b0aed65` | **test fix** add required `PersistentObject.Name`; expose `FleetTestHost.RecentLog` |
+| `2175c85` | **test fix(H-5)** assert URL host not substring; add diagnostic login smoke |
+| `a08f9e1` | pickup notes (superseded by this doc) |
+| `c457e0e` | **fix(L-2)** Secure flag on XSRF-TOKEN + SameSite case-insensitive assertion |
+| `b819836` | **fix(M-5)** allow-list sort columns against declared schema |
+| `c781bef` | **fix(L-3)** opt-in rate limiter on `ISparkBuilder` + Fleet opt-in |
+| `8d21b98` | **fix(M-7)** optimistic concurrency via `PersistentObject.Etag` |
+| `c206740` | **test fix** RateLimitTests waits out its 10 s window to avoid bucket bleed |
+| `5e29a1d` | ci: bump webhooks-demo-deploy to `checkout@v5` + `setup-dotnet@v5` |
+| `0d466d9` | **fix(H-2)(H-3)** row-level auth hook on `DefaultPersistentObjectActions` |
 
-## What was actually vulnerable vs. already-safe
+## Per-finding outcome
 
-### Real vulnerabilities found and fixed
+### Fixed in-framework
 
-- **H-1** (metadata leak) — 4 tests. Fixed in `9e9fdf4` by injecting
-  `IPermissionService` into `Queries/List`, `Queries/Get`,
-  `EntityTypes/List`, `EntityTypes/Get`, `Aliases/GetAliases` and
-  filtering responses by `IsAllowedAsync("Query", entityName)`.
+| Finding | Remediation summary |
+|---------|---------------------|
+| **H-1** metadata leak | Five metadata endpoints inject `IPermissionService` and filter responses by `IsAllowedAsync("Query", entityName)`. Single-entity Get returns 404 (not 403) on denial to avoid existence oracle (M-3). |
+| **H-2** broken object-level authz | Virtual `IsAllowedAsync(action, T entity)` on `DefaultPersistentObjectActions<T>`; `DatabaseAccess` calls it on single Get and list Get (projection path loads base entity through session cache). |
+| **H-3** parent-fetch IDOR | Execute.cs's parent fetch goes through `DatabaseAccess.GetPersistentObjectAsync`, which enforces the row gate. If parent is requested but resolves to null (missing or forbidden), endpoint returns 404 rather than running the query unscoped. |
+| **L-2** no `Secure` on XSRF-TOKEN | `SparkMiddleware` sets `Secure = context.Request.IsHttps`. HttpOnly stays false (by design for double-submit). |
+| **M-5** sort-column reflection | `Execute.cs` intersects requested sort columns with entity-type attributes + query's declared sort columns; mismatches return 400. |
+| **M-7** lost-update races | New `PersistentObject.Etag` (string) surfaces Raven's change vector on Get; `SavePersistentObjectAsync` validates against current vector via a side session. Mismatch → `SparkConcurrencyException` → 409. Opt-in per request (null etag == last-write-wins, keeps existing clients). |
 
-### Real vulnerabilities found and not yet fixed
+### Fixed demo-side
 
-- **M-7** concurrency — 1 test. Framework has no optimistic-concurrency
-  check on update; two clients can lost-write each other silently. Confirmed
-  by `ConcurrencyTests.Concurrent_update_with_stale_version_is_rejected`
-  now that its setup runs (`b0aed65`). Status: **failing as expected**,
-  waiting on the fix.
-- **M-5** sort-column reflection — 2 tests. `?sortColumns=<anyPublicProperty>`
-  is accepted via reflection; the framework must allow-list against the
-  query's declared attribute set.
-- **L-2 Secure flag** — 1 test. `SparkMiddleware.cs:191-196` sets
-  `HttpOnly=false` (correct for double-submit) and `SameSite=Strict`, but
-  no `Secure` flag. One-line fix: `Secure = context.Request.IsHttps`.
-- **L-3** rate limiter — 1 test. Demo-only per triage; wire
-  `AddRateLimiter()` in Fleet/HR/DemoApp `Program.cs`.
+| Finding | Remediation summary |
+|---------|---------------------|
+| **L-3** no rate limiter | New `SparkBuilderRateLimiterExtensions.AddRateLimiter(ISparkBuilder, ...)` + `SparkRateLimiterOptions`; `SparkFullOptions.RateLimiter` threads through the AllFeatures source generator. Fleet opts in via `options.RateLimiter = _ => { }`. Scoped to `/spark/` only so static assets stay unthrottled. |
 
-### Findings that turned out to be already-safe on master
+### Already secure on master (tests document current defence)
 
-- **M-1** — `/spark/permissions/{type}` already reports `canCreate/canEdit/canDelete=false`
-  for anonymous callers. No framework change.
-- **M-3** — 404/403 responses are already indistinguishable in the tested path.
-- **M-5** (malformed sort direction) — framework falls through to default, no 500.
-- **M-6** — error responses are already sanitised (no stack traces, no Raven internals).
-- **H-5** — Angular router implicitly rejects external/javascript/protocol-relative
-  URLs in `navigateByUrl`. 7 tests pass (6 attack vectors + 1 diagnostic login smoke).
-  Note: there's a cosmetic UX issue where a successful login + rejected returnUrl
-  leaves the user stuck on `/login?returnUrl=…` — that's the allow-list-remediation
-  territory, but **not a security issue**.
+- **M-1** `/spark/permissions/{type}` correctly denies anon mutations
+- **M-3** 404/403 unified in the tested path
+- **M-5 malformed sort direction** falls through to default (no 500)
+- **M-6** error responses already sanitised (no stack traces, no Raven internals in body)
+- **H-5** Angular router implicitly rejects external/javascript/protocol-relative URLs in `navigateByUrl`. The UX side-effect (user stuck on `/login?returnUrl=…` after rejected redirect) is documented but not a security issue.
+- **L-7b** unknown attributes are silently dropped by the entity mapper
 
-### False positives in the initial baseline that turned out to be test bugs
+### False positives in the initial baseline
 
-- **L-2 SameSite** — cookie IS set to `SameSite=Strict` in master; the
-  assertion's string shape was wrong. Test-side fix only.
-- **L-7a / L-7b** — admin POST was returning 500 because request body
-  omitted the required `PersistentObject.Name` field. Once the field was
-  added, the framework's behaviour passed (L-7b is a real check; L-7a's
-  assertion is weak because Fleet's Car schema has no `IsReadOnly=true`
-  field — strengthening needs a demo-schema change).
-- **H-5** × 5 — substring assertions matched the `attacker.test` token
-  preserved in `?returnUrl=…` when the router refused to navigate. Fixed
-  in `2175c85` by switching to URL-host comparison.
+- **L-2 SameSite** — master emits `samesite=strict` (lowercase); assertion was strict-case. Fixed with `BeEquivalentTo`.
+- **L-7a** — test couldn't observe the `IsReadOnly` contract because Fleet's Car schema had no `IsReadOnly=true` attribute. The H-2 PR introduces `CreatedBy` (`IsReadOnly=true`, `IsVisible=false`), so L-7a now has a real field to exercise.
+- **H-5** × 5 — substring assertions matched `attacker.test` in the preserved returnUrl query string when the router refused the nav. Fixed with URL-host comparison.
+- **L-7a/L-7b/M-7 500s** — admin-POST body was missing the required `PersistentObject.Name` field. Fixed test-side.
 
-## Pickup plan — suggested order
+## Deferred (documented, not in scope for this PR)
 
-Ascending effort; each flips one or more tests from failing to passing
-(or holds current behaviour as regression protection). Each should be its
-own commit on `feat/security-audit`.
+- **H-4** fail-closed-without-authz — needs a separate host fixture that omits `AddAuthorization()`; not e2e-testable with the current single-Fleet collection fixture. Framework already contains the shape (permission service is a scoped singleton); what's missing is the start-up assertion that fails the app if authorization is expected but not wired.
+- **M-2** JWT tampering — Fleet is cookie-based. Revisit when the IdentityProvider lands on master and bearer tokens become a real surface.
+- **M-4 / L-4** marker attributes for custom queries / custom actions — requires a design decision on the attribute name (`[SparkQuery]` / `[ExposedAsAction]` vs. a registry) and a fix-side demo fixture to exercise "unmarked method is not reachable".
 
-### Quick wins (≤ 30 min each)
+## Testing patterns established
 
-1. **L-2 SameSite assertion fix** — `XsrfCookieFlagTests.cs`. The cookie
-   header format uses `samesite=strict` (lowercase-ish) or `SameSite=Strict`
-   depending on the framework's emitter. Update the assertion to match
-   case-insensitively. No framework change.
-2. **L-2 Secure flag** — `SparkMiddleware.cs:191-196`. Add
-   `Secure = context.Request.IsHttps` to the `CookieOptions`. Flips 1 test.
-
-### Small framework changes (≤ 2 h each)
-
-3. **M-5 sort-column allow-list** — `QueryExecutor.cs:492` (and
-   `Endpoints/Queries/Execute.cs:31-46`). Intersect requested sort columns
-   with the query's declared `Attributes` (from `EntityTypeDefinition`)
-   before reflection. Flips 2 tests.
-4. **L-3 rate limiter in demos** — add `AddRateLimiter()` + `UseRateLimiter()`
-   wiring to `Demo/Fleet/Fleet/Program.cs` (and HR, DemoApp for consistency).
-   Flips 1 test. Demo-only per triage — does NOT touch framework.
-
-### Medium framework change (half-day)
-
-5. **M-7 optimistic concurrency** — `DatabaseAccess.SavePersistentObjectAsync`.
-   RavenDB supports change-vectors natively via
-   `session.Advanced.GetChangeVectorFor(entity)` + `StoreAsync(entity, changeVector, id)`.
-   The client sends the expected change-vector (likely as a header:
-   `If-Match`), and the server rejects on mismatch with HTTP 409. Flips 1 test.
-
-### Big framework change (biggest piece of the PR)
-
-6. **H-2 / H-3 row-level filter hook** — new virtual method on
-   `DefaultPersistentObjectActions<T>` per the PRD §5 triage decision.
-   Signature candidate:
-   ```csharp
-   public virtual IRavenQueryable<T> ApplyRowFilter(
-       IRavenQueryable<T> source, ClaimsPrincipal principal)
-       => source;
-   ```
-   Wire it into `DatabaseAccess.GetPersistentObjectsAsync` (List path) and
-   `GetPersistentObjectAsync` (Get path), then update `QueryExecutor` to
-   route parent-fetch in `Execute.cs:56-66` through the same hook. Add an
-   ownership concept to Fleet's `Car.json` (e.g. an `OwnerId` field set on
-   create) so `CarActions` can override and demonstrate the hook. Then
-   remove `[Fact(Skip=…)]` from the 3 tests in `RowLevelAuthzTests.cs`.
-
-### Out of scope / deferred
-
-- **H-4** fail-closed-without-authz — needs a second host fixture that
-  omits `AddAuthorization()`; not e2e-testable with the current single-Fleet
-  collection fixture.
-- **M-2** JWT tampering — Fleet is cookie-based. Revisit once
-  IdentityProvider lands on master.
-- **M-4 / L-4** marker attributes for custom queries / custom actions —
-  requires a fix-side fixture (an unmarked Actions method in a demo app
-  to verify reflection is refused). Design decision needed: do we want a
-  `[SparkQuery]` / `[ExposedAsAction]` attribute, or a separate registry?
+- **`MintPlayer.Spark.E2E.Tests/Security/_SecurityTestHelpers.cs`** — `SparkApi` wrapper that auto-injects `X-XSRF-TOKEN` on mutating calls, so tests don't manually plumb antiforgery.
+- **`FleetTestHost.RecentLog(maxLines)`** — surfaces the tail of the Fleet subprocess log in assertion failure messages, so production-500s (empty body) can still be diagnosed.
+- **`FleetTestHost.SeedUserAsync(email, password, group)`** — registers an additional non-admin account; email-confirms it and patches the group claim directly in Raven. Used by row-level-authz tests that need a second identity.
+- **Diagnostic smoke test** (`ReturnUrlValidationTests.Diagnostic_admin_can_log_in_via_the_form`) — pins that form-based login actually completes, so a broken selector can't quietly poison every downstream assertion.
 
 ## How to resume
 
 ```bash
 git checkout feat/security-audit
 git pull
-# pick a finding from "Pickup plan" above
-# implement, run the relevant test:
+
+# full suite
+dotnet test MintPlayer.Spark.E2E.Tests --filter "FullyQualifiedName~Security" \
+  --logger "trx;LogFileName=full.trx" --results-directory MintPlayer.Spark.E2E.Tests/TestResults
+
+# single class
 dotnet test MintPlayer.Spark.E2E.Tests --filter "FullyQualifiedName~<ClassName>" \
-  --logger "trx;LogFileName=x.trx" --results-directory MintPlayer.Spark.E2E.Tests/TestResults
-# commit on the branch, push; PR #123 auto-updates
+  --no-build
 ```
 
-The Fleet fixture boots once per test collection (~30-60 s). Running a
-single test class is ~3-10 s after boot. Full 28-test suite runs in
-~2 min end-to-end.
-
-**RavenDB license** must be available as `RAVENDB_LICENSE` env var OR a
-`raven-license.log` file at the repo root. Angular bundle must be built
-once: `cd Demo/Fleet/Fleet/ClientApp && npm run build` (FleetTestHost
-rebuilds automatically if the dist dir is missing).
+Fleet boots once per collection (~30–60 s). Full 29-test suite ≈ 50 s after boot. **Requires** a RavenDB license (env `RAVENDB_LICENSE` or `raven-license.log` at the repo root) and, on first run, the Angular bundle under `Demo/Fleet/Fleet/ClientApp/dist/` (the fixture rebuilds automatically if the dir is missing).

--- a/docs/PRD-SecurityAudit-TestResults.md
+++ b/docs/PRD-SecurityAudit-TestResults.md
@@ -1,0 +1,92 @@
+# Security Audit — Test Run Results (master, 2026-04-20)
+
+**Companion to:** [PRD-SecurityAudit.md](PRD-SecurityAudit.md)
+**Commit under test:** `ea596e9` (master HEAD at audit time)
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total tests | 28 |
+| Passed | 9 |
+| Failed | 16 |
+| Skipped | 3 |
+
+9 passing tests document behavior that's already secure on master. 16 failing tests pin either a confirmed vulnerability or a test-setup issue to resolve alongside the fix. 3 tests are explicitly skipped pending the row-level-filter hook (H-2/H-3).
+
+## Triage refinements applied after first run
+
+- **H-1** — contract is *filter*, not *refuse*. Unauth caller gets the subset their effective principal (Everyone group) has `Query` rights on. Tests updated to assert Company is visible while Car/Person/CarBrand are filtered out.
+- **L-3** — demo-only. Framework stays uninvolved; each demo app wires `AddRateLimiter()` in its own `Program.cs`.
+
+## Confirmed from test output
+
+### Vulnerabilities reproduced (tests fail on master)
+
+| Finding | Test | Observed |
+|---------|------|----------|
+| H-1 | `MetadataEndpointAuthTests.Unauthenticated_GET_spark_queries_includes_only_queries_visible_to_anonymous_callers` | 200 with full catalogue (Car/Person/Company) returned to anonymous caller — no permission filter applied |
+| H-1 | `MetadataEndpointAuthTests.Unauthenticated_GET_spark_types_includes_only_types_visible_to_anonymous_callers` | 200 with full entity schemas returned to anonymous caller |
+| L-3 | `RateLimitTests.Rapid_unauthenticated_bursts_trigger_429_Too_Many_Requests` | 200 burst of 200 — no 429 (Fleet has no rate limiter; remediation is demo-local, not framework) |
+
+### Behaviors already secure (tests pass on master)
+
+| Finding | Test | Observed |
+|---------|------|----------|
+| M-6 | `ErrorLeakageTests.Malformed_entityTypeId_does_not_leak_stack_trace_or_internal_types` | No stack trace or internal type names in response |
+| M-6 | `ErrorLeakageTests.Malformed_id_on_get_does_not_leak_internals` | Clean error body |
+| M-6 | `ErrorLeakageTests.Bad_lookup_reference_key_does_not_leak_internals` | Clean error body |
+
+## Test-setup issues to resolve
+
+| Finding | Test | Issue |
+|---------|------|-------|
+| L-7a | `AttributeWriteProtectionTests.Update_with_IsReadOnly_attribute_in_body_does_not_modify_field` | Admin POST returns 500 after XSRF fix — needs deeper debugging of create body shape against Fleet's Car model |
+| L-7b | `AttributeWriteProtectionTests.Update_cannot_escalate_via_unknown_attribute_name` | Same root cause |
+| M-7 | `ConcurrencyTests.Concurrent_update_with_stale_version_is_rejected` | Same root cause |
+
+Once the admin create succeeds, the test-setup blocker resolves and the *real* assertion runs — at which point these will either pass (framework is secure) or fail in a way that confirms the vulnerability.
+
+## Unresolved test outcomes (13 tests)
+
+Due to `dotnet test` console logger truncating individual results, 13 test outcomes are known only in aggregate (6 passed + 11 additional failures inferred from the summary line). These can be teased apart either by:
+
+1. Running each test class individually (`dotnet test --filter ClassName=...`).
+2. Parsing the TRX file (requires a full clean run — the TRX-logger invocation during the audit was interrupted).
+3. Switching the project's test framework output to detailed-per-test mode.
+
+Recommendation: do this as the first step of the remediation PR so we start with a clean baseline.
+
+## Skipped tests (expected)
+
+| Finding | Test | Blocker |
+|---------|------|---------|
+| H-2 | `RowLevelAuthzTests.User_B_cannot_list_User_As_private_cars` | Row-level filter hook not yet added |
+| H-2 | `RowLevelAuthzTests.User_B_cannot_read_User_As_private_car_by_id` | Same |
+| H-3 | `RowLevelAuthzTests.User_B_cannot_execute_child_query_with_User_As_parent_id` | Same |
+
+Remove the `[Fact(Skip=...)]` attribute once the hook lands.
+
+## File inventory
+
+- `MintPlayer.Spark.E2E.Tests/Security/_SecurityTestHelpers.cs` — CSRF-aware `SparkApi` wrapper + login helper
+- `MintPlayer.Spark.E2E.Tests/Security/MetadataEndpointAuthTests.cs` — 4 tests (H-1)
+- `MintPlayer.Spark.E2E.Tests/Security/PermissionsEndpointAuthTests.cs` — 2 tests (M-1)
+- `MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs` — 2 tests (L-2)
+- `MintPlayer.Spark.E2E.Tests/Security/ErrorLeakageTests.cs` — 3 tests (M-6)
+- `MintPlayer.Spark.E2E.Tests/Security/SortInjectionTests.cs` — 3 tests (M-5)
+- `MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs` — 1 test (M-3)
+- `MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs` — 2 tests (L-7a/L-7b)
+- `MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs` — 1 test (M-7)
+- `MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs` — 1 test (L-3)
+- `MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs` — 6 browser tests (H-5)
+- `MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs` — 3 skipped placeholders (H-2/H-3)
+
+## Not yet covered
+
+Findings that did not receive a test in this pass (either infeasible with current Fleet fixture or requiring the fix to be testable):
+
+- **H-4** fail-closed-without-authz — needs a separate host fixture that omits `AddAuthorization()`.
+- **M-2** JWT tampering — Fleet currently uses cookie auth, not bearer JWTs; add when IdentityProvider lands.
+- **M-4** custom-query method marker — needs a fix-side Actions class with an unmarked method to attempt reflection against.
+- **L-4** custom-action marker — same shape as M-4.

--- a/docs/PRD-SecurityAudit-TestResults.md
+++ b/docs/PRD-SecurityAudit-TestResults.md
@@ -1,92 +1,90 @@
 # Security Audit — Test Run Results (master, 2026-04-20)
 
 **Companion to:** [PRD-SecurityAudit.md](PRD-SecurityAudit.md)
-**Commit under test:** `ea596e9` (master HEAD at audit time)
+**Commit under test:** `ea596e9` (master HEAD at audit time), tests at `ea368af` on `feat/security-audit`
+**Run:** TRX at `MintPlayer.Spark.E2E.Tests/TestResults/security.trx`
 
 ## Summary
 
 | Metric | Count |
 |--------|-------|
 | Total tests | 28 |
-| Passed | 9 |
-| Failed | 16 |
+| Passed | 7 |
+| Failed | 18 |
 | Skipped | 3 |
 
-9 passing tests document behavior that's already secure on master. 16 failing tests pin either a confirmed vulnerability or a test-setup issue to resolve alongside the fix. 3 tests are explicitly skipped pending the row-level-filter hook (H-2/H-3).
+## Triage refinements applied
 
-## Triage refinements applied after first run
+- **H-1** — contract is *filter*, not *refuse*. Unauth caller gets the subset their effective principal (Everyone group) has `Query` rights on.
+- **L-3** — demo-only. Framework stays out; each demo app wires `AddRateLimiter()` in its own `Program.cs`.
 
-- **H-1** — contract is *filter*, not *refuse*. Unauth caller gets the subset their effective principal (Everyone group) has `Query` rights on. Tests updated to assert Company is visible while Car/Person/CarBrand are filtered out.
-- **L-3** — demo-only. Framework stays uninvolved; each demo app wires `AddRateLimiter()` in its own `Program.cs`.
+## Full outcome matrix (parsed from TRX)
 
-## Confirmed from test output
+### Vulnerabilities reproduced (14 real failing tests)
 
-### Vulnerabilities reproduced (tests fail on master)
+| Finding | Test | Notes |
+|---------|------|-------|
+| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_queries_includes_only_queries_visible_to_anonymous_callers` | Full catalogue returned to anon |
+| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_types_includes_only_types_visible_to_anonymous_callers` | Full type schemas returned to anon |
+| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_queries_id_for_protected_query_is_refused` | Direct access to protected query definition returns 200 |
+| H-1 | `MetadataEndpointAuth.Unauthenticated_GET_spark_aliases_includes_only_aliases_visible_to_anonymous_callers` | Protected aliases leak |
+| M-5 | `SortInjection.Sort_by_nonexistent_property_is_rejected` | Framework silently ignores bad column |
+| M-5 | `SortInjection.Sort_by_metadata_property_on_projection_is_rejected` | `Id` as sort column accepted |
+| L-2 | `XsrfCookieFlag.XSRF_TOKEN_cookie_carries_Secure_attribute_over_https` | No `Secure` flag even over HTTPS |
+| L-3 | `RateLimit.Rapid_unauthenticated_bursts_trigger_429_Too_Many_Requests` | 200 requests, zero 429s — no rate limiter |
+| H-5 | `ReturnUrlValidation.Login_with_protocol_relative_returnUrl_does_not_navigate_off_site` | — |
+| H-5 | `ReturnUrlValidation.Login_with_absolute_http_returnUrl_does_not_navigate_off_site` | — |
+| H-5 | `ReturnUrlValidation.Login_with_absolute_https_returnUrl_does_not_navigate_off_site` | — |
+| H-5 | `ReturnUrlValidation.Login_with_javascript_uri_returnUrl_does_not_execute_script` | — |
+| H-5 | `ReturnUrlValidation.Login_with_backslash_authority_returnUrl_does_not_navigate_off_site` | — |
+| H-5 | `ReturnUrlValidation.Login_with_whitespace_prefixed_returnUrl_does_not_navigate_off_site` | All 6 H-5 tests fail uniformly — strongly suggests a test-infrastructure issue (login form not being submitted) rather than all 6 attack vectors genuinely succeeding. Needs investigation before counting these as confirmed vulnerabilities |
 
-| Finding | Test | Observed |
-|---------|------|----------|
-| H-1 | `MetadataEndpointAuthTests.Unauthenticated_GET_spark_queries_includes_only_queries_visible_to_anonymous_callers` | 200 with full catalogue (Car/Person/Company) returned to anonymous caller — no permission filter applied |
-| H-1 | `MetadataEndpointAuthTests.Unauthenticated_GET_spark_types_includes_only_types_visible_to_anonymous_callers` | 200 with full entity schemas returned to anonymous caller |
-| L-3 | `RateLimitTests.Rapid_unauthenticated_bursts_trigger_429_Too_Many_Requests` | 200 burst of 200 — no 429 (Fleet has no rate limiter; remediation is demo-local, not framework) |
-
-### Behaviors already secure (tests pass on master)
-
-| Finding | Test | Observed |
-|---------|------|----------|
-| M-6 | `ErrorLeakageTests.Malformed_entityTypeId_does_not_leak_stack_trace_or_internal_types` | No stack trace or internal type names in response |
-| M-6 | `ErrorLeakageTests.Malformed_id_on_get_does_not_leak_internals` | Clean error body |
-| M-6 | `ErrorLeakageTests.Bad_lookup_reference_key_does_not_leak_internals` | Clean error body |
-
-## Test-setup issues to resolve
+### Test-setup bugs (4 failing tests — blocking, not vulnerability evidence)
 
 | Finding | Test | Issue |
 |---------|------|-------|
-| L-7a | `AttributeWriteProtectionTests.Update_with_IsReadOnly_attribute_in_body_does_not_modify_field` | Admin POST returns 500 after XSRF fix — needs deeper debugging of create body shape against Fleet's Car model |
-| L-7b | `AttributeWriteProtectionTests.Update_cannot_escalate_via_unknown_attribute_name` | Same root cause |
-| M-7 | `ConcurrencyTests.Concurrent_update_with_stale_version_is_rejected` | Same root cause |
+| L-2 | `XsrfCookieFlag.XSRF_TOKEN_cookie_has_SameSite_Strict` | `SparkMiddleware.cs:191-196` sets `SameSite=Strict`; the assertion shape is probably wrong (cookie attribute casing?). Test needs fixing |
+| L-7a | `AttributeWriteProtection.Update_with_IsReadOnly_attribute_in_body_does_not_modify_field` | POST /spark/po/Car returns 500 at setup — not yet debugged |
+| L-7b | `AttributeWriteProtection.Update_cannot_escalate_via_unknown_attribute_name` | Same 500 as above |
+| M-7 | `Concurrency.Concurrent_update_with_stale_version_is_rejected` | Same 500 as above |
 
-Once the admin create succeeds, the test-setup blocker resolves and the *real* assertion runs — at which point these will either pass (framework is secure) or fail in a way that confirms the vulnerability.
+### Already-secure behaviour (7 passing tests)
 
-## Unresolved test outcomes (13 tests)
+| Finding | Test | Implication |
+|---------|------|-------------|
+| M-1 | `PermissionsEndpointAuth.Unauthenticated_GET_permissions_for_Car_reports_no_access` | `/spark/permissions/{type}` already returns `{canRead:false, ...}` to anon |
+| M-1 | `PermissionsEndpointAuth.Unauthenticated_GET_permissions_for_Company_reports_read_but_no_write` | Company anonymous read is honored, mutations correctly denied |
+| M-3 | `NotFoundVsForbidden.Nonexistent_id_and_forbidden_id_return_the_same_status` | 404/403 already indistinguishable in the tested path |
+| M-5 | `SortInjection.Sort_with_malformed_direction_does_not_500` | Malformed direction falls through to default (no 500) |
+| M-6 | `ErrorLeakage.Malformed_entityTypeId_does_not_leak_stack_trace_or_internal_types` | Clean error body |
+| M-6 | `ErrorLeakage.Malformed_id_on_get_does_not_leak_internals` | Clean error body |
+| M-6 | `ErrorLeakage.Bad_lookup_reference_key_does_not_leak_internals` | Clean error body |
 
-Due to `dotnet test` console logger truncating individual results, 13 test outcomes are known only in aggregate (6 passed + 11 additional failures inferred from the summary line). These can be teased apart either by:
+**Implication for remediation scope:** M-1 and M-6 are already secure in Fleet's setup. The tests stay as regression protection, but no framework change is required for those findings.
 
-1. Running each test class individually (`dotnet test --filter ClassName=...`).
-2. Parsing the TRX file (requires a full clean run — the TRX-logger invocation during the audit was interrupted).
-3. Switching the project's test framework output to detailed-per-test mode.
-
-Recommendation: do this as the first step of the remediation PR so we start with a clean baseline.
-
-## Skipped tests (expected)
+### Skipped pending row-level filter hook (3)
 
 | Finding | Test | Blocker |
 |---------|------|---------|
-| H-2 | `RowLevelAuthzTests.User_B_cannot_list_User_As_private_cars` | Row-level filter hook not yet added |
-| H-2 | `RowLevelAuthzTests.User_B_cannot_read_User_As_private_car_by_id` | Same |
-| H-3 | `RowLevelAuthzTests.User_B_cannot_execute_child_query_with_User_As_parent_id` | Same |
+| H-2 | `RowLevelAuthz.User_B_cannot_list_User_As_private_cars` | Row-level filter hook not yet added |
+| H-2 | `RowLevelAuthz.User_B_cannot_read_User_As_private_car_by_id` | Same |
+| H-3 | `RowLevelAuthz.User_B_cannot_execute_child_query_with_User_As_parent_id` | Same |
 
-Remove the `[Fact(Skip=...)]` attribute once the hook lands.
+## Revised remediation priority
 
-## File inventory
+Based on what's actually broken:
 
-- `MintPlayer.Spark.E2E.Tests/Security/_SecurityTestHelpers.cs` — CSRF-aware `SparkApi` wrapper + login helper
-- `MintPlayer.Spark.E2E.Tests/Security/MetadataEndpointAuthTests.cs` — 4 tests (H-1)
-- `MintPlayer.Spark.E2E.Tests/Security/PermissionsEndpointAuthTests.cs` — 2 tests (M-1)
-- `MintPlayer.Spark.E2E.Tests/Security/XsrfCookieFlagTests.cs` — 2 tests (L-2)
-- `MintPlayer.Spark.E2E.Tests/Security/ErrorLeakageTests.cs` — 3 tests (M-6)
-- `MintPlayer.Spark.E2E.Tests/Security/SortInjectionTests.cs` — 3 tests (M-5)
-- `MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs` — 1 test (M-3)
-- `MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs` — 2 tests (L-7a/L-7b)
-- `MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs` — 1 test (M-7)
-- `MintPlayer.Spark.E2E.Tests/Security/RateLimitTests.cs` — 1 test (L-3)
-- `MintPlayer.Spark.E2E.Tests/Security/ReturnUrlValidationTests.cs` — 6 browser tests (H-5)
-- `MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs` — 3 skipped placeholders (H-2/H-3)
+1. **H-1** (4 tests) — filter `/spark/queries`, `/spark/types`, `/spark/queries/{id}`, `/spark/aliases` by caller's `Query` rights.
+2. **Test-setup fix** (4 tests) — unblock L-7a/L-7b/M-7 by debugging the 500 on admin Car creation, and fix the L-2 SameSite assertion shape.
+3. **H-5 investigation** (6 tests) — verify whether all 6 are real vulnerabilities or a test-infrastructure uniformity problem. If the login form submission isn't going through, the test never reaches the router and every URL shape fails identically.
+4. **L-2 Secure flag** (1 test) — one-line change in `SparkMiddleware.cs:191-196`.
+5. **M-5** (2 tests) — allow-list sort columns against the query's declared attribute set.
+6. **M-7 / L-7a / L-7b** — after the setup-fix, real assertion runs. M-7 probably needs the concurrency fix; L-7 likely confirms the write-path doesn't enforce `IsReadOnly`/`IsVisible`.
+7. **L-3** (1 test) — wire `AddRateLimiter()` in `Demo/Fleet/Fleet/Program.cs`.
+8. **H-4, H-2, H-3** — framework-level hooks per PRD §6.
 
-## Not yet covered
+## Out of scope for this PR
 
-Findings that did not receive a test in this pass (either infeasible with current Fleet fixture or requiring the fix to be testable):
-
-- **H-4** fail-closed-without-authz — needs a separate host fixture that omits `AddAuthorization()`.
-- **M-2** JWT tampering — Fleet currently uses cookie auth, not bearer JWTs; add when IdentityProvider lands.
-- **M-4** custom-query method marker — needs a fix-side Actions class with an unmarked method to attempt reflection against.
-- **L-4** custom-action marker — same shape as M-4.
+- **H-4** fail-closed-without-authz — needs a separate host fixture.
+- **M-2** JWT tampering — Fleet is cookie-based; add when IdentityProvider lands.
+- **M-4 / L-4** marker attributes — need fix-side Actions class fixture.

--- a/docs/PRD-SecurityAudit.md
+++ b/docs/PRD-SecurityAudit.md
@@ -1,0 +1,479 @@
+# PRD — Security Audit (master)
+
+**Status:** Draft — awaiting triage
+**Scope:** `master` branch, commit `ea596e9` (2026-04-20). Excludes `feat/authorization` and IdentityProvider work.
+**Method:** 5 parallel Explore agents covering AuthN/AuthZ, injection/input-validation, endpoint surface, Angular frontend, and source-generators/supply-chain. Findings dedeped and sanity-checked against master HEAD before inclusion.
+
+## 1. How to read this document
+
+Each finding has:
+- **Layer** — `Framework` (bug in MintPlayer.Spark itself), `Application` (developer-facing API works, but easy to misuse), or `Deployment` (config/infra concern).
+- **Testable?** — whether a failing-to-secure e2e test is feasible. `Yes` = we can write a test that asserts the secure expected behavior. `Indirect` = test needs infra setup. `No` = build-time / config / policy concern.
+- **Confidence** — `Confirmed` (code read and verified on master), `Likely` (strong signal, edge case possible), `Needs verification`.
+
+Findings are grouped by severity, not by audit domain. A "Verified secure" section at the end lists surfaces that were audited and found clean.
+
+## 2. Route inventory (master)
+
+For reference when reading the findings. Auth marked with `*` means imperative check inside handler (`SparkAccessDeniedException`), not a route-level `[Authorize]` attribute.
+
+| Verb | Path | Auth | Antiforgery | File |
+|------|------|------|-------------|------|
+| GET | `/spark/` | No | No | `Endpoints/HealthCheck.cs` |
+| GET | `/spark/aliases` | No | No | `Endpoints/Aliases/GetAliases.cs` |
+| GET | `/spark/culture` | No | No | `Endpoints/Culture/Get.cs` |
+| GET | `/spark/types` | **No** | No | `Endpoints/EntityTypes/List.cs` |
+| GET | `/spark/types/{id}` | **No** | No | `Endpoints/EntityTypes/Get.cs` |
+| GET | `/spark/queries` | **No** | No | `Endpoints/Queries/List.cs` |
+| GET | `/spark/queries/{id}` | **No** | No | `Endpoints/Queries/Get.cs` |
+| GET | `/spark/queries/{id}/execute` | Yes* | No | `Endpoints/Queries/Execute.cs` |
+| GET | `/spark/queries/{id}/stream` | Yes* | No | `Endpoints/Queries/StreamExecuteQuery.cs` |
+| GET | `/spark/permissions/{entityTypeId}` | Partial | No | `Endpoints/Permissions/GetPermissions.cs` |
+| GET | `/spark/program-units` | Yes* | No | `Endpoints/ProgramUnits/Get.cs` |
+| GET | `/spark/translations` | No | No | `Endpoints/Translations/Get.cs` |
+| GET | `/spark/po/{objectTypeId}` | Yes* | No | `Endpoints/PersistentObject/List.cs` |
+| GET | `/spark/po/{objectTypeId}/{**id}` | Yes* | No | `Endpoints/PersistentObject/Get.cs` |
+| POST | `/spark/po/{objectTypeId}` | Yes* | Yes | `Endpoints/PersistentObject/Create.cs` |
+| PUT | `/spark/po/{objectTypeId}/{**id}` | Yes* | Yes | `Endpoints/PersistentObject/Update.cs` |
+| DELETE | `/spark/po/{objectTypeId}/{**id}` | Yes* | Yes | `Endpoints/PersistentObject/Delete.cs` |
+| GET | `/spark/actions/{objectTypeId}` | Yes* | No | `Endpoints/Actions/ListCustomActions.cs` |
+| POST | `/spark/actions/{objectTypeId}/{actionName}` | Yes* | Yes | `Endpoints/Actions/ExecuteCustomAction.cs` |
+| GET | `/spark/lookupref/` | No | No | `Endpoints/LookupReferences/List.cs` |
+| GET | `/spark/lookupref/{name}` | No | No | `Endpoints/LookupReferences/Get.cs` |
+| POST | `/spark/lookupref/{name}` | Yes* | Yes | `Endpoints/LookupReferences/AddValue.cs` |
+| PUT | `/spark/lookupref/{name}/{key}` | Yes* | Yes | `Endpoints/LookupReferences/UpdateValue.cs` |
+| DELETE | `/spark/lookupref/{name}/{key}` | Yes* | Yes | `Endpoints/LookupReferences/DeleteValue.cs` |
+
+## 3. Findings
+
+### HIGH
+
+---
+
+#### H-1 — Metadata endpoints leak schema and query definitions without auth
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:**
+- `MintPlayer.Spark/Endpoints/EntityTypes/List.cs:13-17`
+- `MintPlayer.Spark/Endpoints/EntityTypes/Get.cs`
+- `MintPlayer.Spark/Endpoints/Queries/List.cs:13-17`
+- `MintPlayer.Spark/Endpoints/Queries/Get.cs:13-24`
+- `MintPlayer.Spark/Endpoints/Aliases/GetAliases.cs`
+- `MintPlayer.Spark/Endpoints/Translations/Get.cs`
+- `MintPlayer.Spark/Endpoints/LookupReferences/List.cs` and `Get.cs`
+
+**Attack scenario:** Unauthenticated attacker issues `GET /spark/types`, `GET /spark/queries`, `GET /spark/queries/{id}` and harvests the full data model — entity types, attribute definitions, validation rules, query sources (`Database.*` / `Custom.*`), and projection structure. This intel scopes further targeted attacks (IDOR probing, injection against specific queries).
+
+**Expected secure behavior:** Require authentication for all metadata endpoints by default, or expose a public-mode subset (entity names only, no attribute detail) behind an explicit opt-in.
+
+**Test asserts:** Unauthenticated `GET /spark/queries` returns 401 (or empty list when explicit public mode is opted-in).
+
+---
+
+#### H-2 — Broken object-level authorization: entity-type grant implies all instances
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed (design-level)
+
+**Where:**
+- `MintPlayer.Spark/Services/DatabaseAccess.cs:109` (List path)
+- `MintPlayer.Spark/Endpoints/PersistentObject/Get.cs:30`
+- `MintPlayer.Spark/Endpoints/PersistentObject/List.cs:28`
+
+**Attack scenario:** Alice has `Query/Person`. Bob's `Person` record is private to Bob. `GET /spark/po/{personTypeId}` returns all `Person` records including Bob's — there is no row-level filter or ownership check. Same pattern on `GET /spark/po/{type}/{id}`: any authorized user reads any instance.
+
+**Expected secure behavior:** After entity-level authorization succeeds, instance-level authorization must also pass. Today this is a pure application concern (developer writes filtering in custom Actions). Framework should either require an `IObjectAuthorization<T>` hook, or ship a documented pit-of-success pattern so it's impossible to forget.
+
+**Test asserts:** With two demo users and a seeded entity owned by user A, user B's `GET` on that entity returns 404 or 403 — not the record.
+
+**Note:** Could be reframed as "documentation/API shape" rather than a bug. See §5 for triage question.
+
+---
+
+#### H-3 — Query execute accepts arbitrary `parentId` without parent-ownership check
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/Endpoints/Queries/Execute.cs:56-66`
+
+**Attack scenario:** Execute endpoint fetches parent via `GetPersistentObjectAsync(parentEntityType.Id, parentId)`. If entity-level `Read/{parentType}` passes for the caller (see H-2), the parent is returned and scoped-to-parent queries run against it — even if the caller shouldn't see *this specific* parent's children.
+
+**Expected secure behavior:** Parent fetch must enforce instance-level authz (same remediation surface as H-2).
+
+**Test asserts:** User A runs a child query with `parentId=<B's record>`. Response is 403/404, not B's children.
+
+---
+
+#### H-4 — Authorization is runtime-imperative, with no route-level fallback
+
+**Layer:** Framework · **Testable?** Indirect · **Confidence:** Confirmed
+
+**Where:** All `PersistentObject/*`, `Queries/Execute.cs`, `Actions/ExecuteCustomAction.cs` rely on `SparkAccessDeniedException` being thrown from service-layer code. There is no `[Authorize]` attribute, route policy, or DI-time assertion that `AddAuthorization()` was wired.
+
+**Attack scenario:** An app calls `AddSpark()` but forgets `spark.AddAuthorization()` (plausible — authorization is an optional package). If the default `IPermissionService` is a no-op or missing, requests succeed with no identity checking.
+
+**Expected secure behavior:** When the authorization package isn't wired, the framework must fail-closed — either refuse to start, or reject authenticated operations with a clear error.
+
+**Test asserts:** Harder to e2e in a single run — needs a test fixture that builds a host without `AddAuthorization()` and asserts `GET /spark/po/...` is refused. Integration-test-level, not black-box HTTP.
+
+---
+
+#### H-5 — `returnUrl` on login/two-factor is not validated against relative-only allow-list
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Likely (Angular `navigateByUrl` rejects some but not all external URLs)
+
+**Where:**
+- `node_packages/ng-spark-auth/login/src/spark-login.component.ts:52`
+- `node_packages/ng-spark-auth/two-factor/src/spark-two-factor.component.ts:64`
+
+**Attack scenario:** Attacker sends victim `https://app/login?returnUrl=%2F%2Fattacker.example%2Fphish`. After login, Angular router navigates to the attacker URL. Victim sees the app's domain in the pre-login URL, assumes the destination is in-app.
+
+**Expected secure behavior:** Validate `returnUrl.startsWith('/') && !returnUrl.startsWith('//')` — reject otherwise, fall back to `defaultRedirectUrl`.
+
+**Test asserts:** Playwright — login with `?returnUrl=//attacker.test`, assert final URL is `defaultRedirectUrl`, not attacker.
+
+---
+
+### MEDIUM
+
+---
+
+#### M-1 — `GetPermissions` leaks permission matrix to unauthenticated callers
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/Endpoints/Permissions/GetPermissions.cs:15-32`
+
+**Attack scenario:** `GET /spark/permissions/{entityTypeId}` returns `{canRead, canCreate, canEdit, canDelete}` based on the current principal. An unauthenticated request evaluates against the Everyone group. An attacker maps which entity types the anonymous-user tier can operate on without any login. Combined with H-1, the full authorization surface is externally inspectable.
+
+**Expected secure behavior:** Require authentication, OR require the caller to have at least one permission on the entity before returning the matrix.
+
+**Test asserts:** Unauthenticated `GET /spark/permissions/<anyType>` returns 401.
+
+---
+
+#### M-2 — Claim-injection: group names from claims are trusted verbatim
+
+**Layer:** Framework · **Testable?** Indirect · **Confidence:** Needs verification
+
+**Where:**
+- `MintPlayer.Spark.Authorization/Services/ClaimsGroupMembershipProvider.cs:28-44`
+- `MintPlayer.Spark.Authorization/Services/AccessControlService.cs:100-118`
+
+**Attack scenario:** If an external token issuer (social login, federated IdP) can put arbitrary `group` claims into a token, and that group name matches a group defined in `security.json`, the caller gets that group's rights. No check that the issuer is authoritative for that group name.
+
+**Expected secure behavior:** Either (a) map external claims to internal groups through an explicit allow-list, or (b) namespace groups by issuer. Document the threat model for apps using multiple IdPs.
+
+**Test asserts:** Needs a controllable token issuer; probably an integration test, not pure HTTP.
+
+---
+
+#### M-3 — 404 vs 403 differentiation enables existence oracle
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:**
+- `MintPlayer.Spark/Endpoints/PersistentObject/Get.cs:22-24` vs `39-49`
+- `MintPlayer.Spark/Endpoints/PersistentObject/List.cs:20-24` vs `31-41`
+
+**Attack scenario:** Attacker probes IDs. 404 means "no such record"; 403 means "record exists, you can't read it". Combined with H-2 this is less critical (attacker can already read), but absent H-2 it lets an unauthorized user enumerate IDs.
+
+**Expected secure behavior:** Return uniform 404 for both cases when the caller is authenticated but unauthorized. (Keep 401 for unauthenticated.)
+
+**Test asserts:** Authenticated user A asks for non-existent ID and for B's ID — both responses identical.
+
+---
+
+#### M-4 — Custom query method resolution: no explicit attribute gate
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/Services/QueryExecutor.cs:308-333`
+
+**Attack scenario:** `Custom.{MethodName}` resolves to any `public instance` method on the Actions class matching the signature (`IQueryable<T>` or `IEnumerable<T>` return, zero or one `CustomQueryArgs` param). A developer adding a public helper with a matching shape inadvertently exposes it to HTTP callers.
+
+**Expected secure behavior:** Only resolve methods decorated with an explicit `[SparkQuery]` attribute. Reject others at query-definition-load time with a clear error.
+
+**Test asserts:** Author an Actions class with a non-`[SparkQuery]` method matching the signature; assert `Custom.ThatMethod` returns 404/400, not the method's data.
+
+---
+
+#### M-5 — Sort column property name accepted via reflection without allow-list
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Likely
+
+**Where:**
+- `MintPlayer.Spark/Endpoints/Queries/Execute.cs:31-46`
+- `MintPlayer.Spark/Services/QueryExecutor.cs:492`
+
+**Attack scenario:** `?sortColumns=<anyPublicProperty>:asc` uses `GetProperty(name, Public|Instance)` on the result type. If the projection type has a public property not in the attribute schema (e.g., `InternalComment`), the caller can sort by it — which is a side-channel (timing, ordering) even without reading the value. Not as severe as reading the field, but it's leakage.
+
+**Expected secure behavior:** Validate sort columns against the query's declared attribute set.
+
+**Test asserts:** Add a projection with an extra public property not in schema; `?sortColumns=ExtraProp:asc` returns 400.
+
+---
+
+#### M-6 — Exception messages echoed to clients
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:**
+- `MintPlayer.Spark/Endpoints/Actions/ExecuteCustomAction.cs:113` (`ex.Message` → 500 body)
+- `MintPlayer.Spark/Endpoints/LookupReferences/{AddValue,UpdateValue,DeleteValue}.cs` (`ex.Message` → 400 body)
+- `MintPlayer.Spark/Endpoints/Queries/StreamExecuteQuery.cs:89-91` (message over WebSocket)
+
+**Attack scenario:** Server-side errors ("duplicate key 'users/1' in collection Users", "index 'Foo/Bar' not found") are surfaced verbatim. Attacker derives schema/state from error text.
+
+**Expected secure behavior:** Log internally, return generic `"Operation failed"` with a correlation ID.
+
+**Test asserts:** Trigger a duplicate/bad-input on a demo app; assert response body does not contain RavenDB-internal strings.
+
+---
+
+#### M-7 — No optimistic-concurrency / ETag check on updates
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Likely
+
+**Where:** `MintPlayer.Spark/Endpoints/PersistentObject/Update.cs:37-72`
+
+**Attack scenario:** Lost-update race: two clients read v1, both modify, both write. Last write wins silently. Not a classical "security" bug, but in an authorization context it enables authorization-downgrade races (TOCTOU on permission-sensitive fields).
+
+**Expected secure behavior:** Require an ETag / `@change-vector` header on updates; reject on mismatch.
+
+**Test asserts:** Parallel PUT with stale version returns 409 Conflict.
+
+---
+
+### LOW
+
+---
+
+#### L-1 — `AllowedHosts: "*"` in demo apps
+
+**Layer:** Deployment · **Testable?** No · **Confidence:** Confirmed
+
+**Where:** `Demo/*/appsettings.json` all have `"AllowedHosts": "*"`.
+
+**Attack scenario:** Host-header injection against demo deployments, enabling poisoned-link password-reset emails if the demo ever generates absolute URLs. Not exploitable in the current demo scope.
+
+**Expected secure behavior:** Set explicit hosts in production deployments; docs should warn.
+
+---
+
+#### L-2 — XSRF-TOKEN cookie has no `Secure` flag
+
+**Layer:** Framework · **Testable?** Indirect · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/SparkMiddleware.cs:191-196`
+
+**Note:** `HttpOnly=false` is **by design** for Angular's double-submit-cookie pattern — the JS client has to read the cookie and echo it in `X-XSRF-TOKEN`. This is not a bug. What *is* missing is `Secure = true`, which would prevent the token being sent over plain HTTP in production.
+
+**Expected secure behavior:** Add `Secure = context.Request.IsHttps` (or `Secure = true` when not `Development`).
+
+---
+
+#### L-3 — No rate limiting
+
+**Layer:** Framework / Deployment · **Testable?** Indirect · **Confidence:** Confirmed
+
+**Where:** No `AddRateLimiter()` anywhere in the framework or demo configuration.
+
+**Attack scenario:** Brute-force enumeration of IDs (see M-3), credential stuffing against any future login endpoint, DoS against query execute.
+
+**Expected secure behavior:** Ship default rate limits for hot endpoints; document how to tune. Apps on master don't have a login surface yet, so this is mostly about enumeration today.
+
+---
+
+#### L-4 — `CustomActionResolver` auto-discovers `ICustomAction` implementers
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/Services/CustomActionResolver.cs:55-86`
+
+**Attack scenario:** Any class implementing `ICustomAction` anywhere in the loaded assemblies becomes HTTP-exposed. A developer's utility/test class accidentally left in a shipped assembly becomes an endpoint.
+
+**Expected secure behavior:** Require an explicit `[ExposedAsAction]` attribute (matching the `[SparkQuery]` suggestion in M-4).
+
+**Test asserts:** Same shape as M-4.
+
+---
+
+#### L-5 — Frontend `sparkRoutes()` not gated by `sparkAuthGuard` in demo apps
+
+**Layer:** Application (demo-app-level) · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `Demo/Fleet/Fleet/ClientApp/src/app/app.routes.ts` (and peers).
+
+**Note:** Defense-in-depth only — the backend should be the source of truth. A missing frontend guard just means the app briefly renders skeleton before the API rejects. Low priority.
+
+---
+
+#### L-6 — Source generator doesn't validate C# identifier shape in emitted code
+
+**Layer:** Framework (build-time) · **Testable?** No · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark.SourceGenerators/Generators/ActionsRegistrationGenerator.Producer.cs:42`
+
+Not runtime-exploitable (the compiler catches invalid output). Defense-in-depth note only.
+
+---
+
+## 4. Considered-and-dismissed
+
+These came up in the audits but are **not** vulnerabilities given how the framework actually works:
+
+- **ReDoS via validation-rule regex** (injection audit §1). Patterns live in developer-controlled `App_Data/Model/*.json`, not user input. A malicious *developer* can already do worse. Still worth a `RegexOptions.Timeout`, but not a security finding.
+- **Mass-assignment on Create/Update**. Routes override `Id` and `ObjectTypeId` from the path; no `PersistentObject` field is currently authorization-sensitive.
+- **RavenDB raw-query injection**. All query construction uses parameterized LINQ / `.LoadAsync(id)`. No string concatenation into RQL.
+- **XSS in ng-spark-auth**. No `innerHTML`, no `bypassSecurityTrust*`, signals-bound templates — sanitized by Angular default.
+- **`HttpOnly=false` on XSRF-TOKEN**. By-design for double-submit; see L-2 for the real issue.
+- **Supply-chain via pinned packages**. All from nuget.org, no known CVEs in pinned versions (as of audit date).
+- **`pull_request_target` misuse in CI**. Only `push` triggers on master-deploy workflows.
+
+## 5. Triage decisions (resolved 2026-04-20)
+
+1. **H-2 / H-3 framing.** → **API-contract**. Row-level filtering is the application's responsibility, surfaced via a dedicated method on `DefaultPersistentObjectActions<T>` (separate from `OnQueryAsync` so intent is explicit). Framework contract change lands in this PR; demo Actions classes are updated to use it; tests assert the hook is called and enforced.
+2. **Fix scope.** → Single PR, multiple commits. PR addresses findings + adds tests in lockstep.
+3. **Test harness choice.** → Use the existing `MintPlayer.Spark.E2E.Tests` project (Playwright + FleetTestHost). HTTP-level via `page.APIRequest`, browser-level via `page.GotoAsync`. No new test project needed.
+
+## 6. Per-finding disposition
+
+| ID | Decision | Notes |
+|----|----------|-------|
+| H-1 | **Address** | Response is filtered per-caller permission. An anonymous caller gets only the entities/queries for which their effective principal (Everyone group) has at least `Query` rights. E.g., Fleet's `/spark/queries` to an anon user returns `GetCompanies` (Everyone has `QueryRead/Company`) but omits Car/Person/CarBrand/CarStatus. `/spark/types` applies the same filter. Not "opt-in per endpoint" — always on. Confirmed: attributes are **not** filtered per-user today — `IsVisible`/`IsReadOnly` come from schema, not from caller's claims. See new finding H-1b. |
+| H-2 | **Address** | New virtual method on `DefaultPersistentObjectActions<T>` (e.g., `ApplyRowFilter(IRavenQueryable<T>, ClaimsPrincipal)`). Default implementation = no filter. Called by `DatabaseAccess` on List/Get paths. |
+| H-3 | **Address** | Same remediation as H-2 — parent fetch goes through the same filter hook. |
+| H-4 | **Address now** | Framework must fail-closed if `AddAuthorization()` isn't wired. Throw at startup OR ship a `NullPermissionService` that always denies. |
+| H-5 | **Address** | Validate `returnUrl` against a configured allow-list (new `SPARK_AUTH_CONFIG.allowedReturnUrls` or similar). Reject otherwise. |
+| M-1 | **Address with design** | Endpoint stays anonymous-callable (program-unit visibility needs it), but must **only ever** return the anonymous tier's permissions — never leak `canEdit/canDelete=true` that's actually computed against a half-authenticated principal. Test covers both cases. |
+| M-2 | **Address** | JWT signature/issuer validation. Applies to the simple Authentication feature AND the future IdP. Token-tamper tests. |
+| M-3 | **Address** | Uniform 404 for auth'd-but-not-authorized. |
+| M-4 | **Address** | Low-code concern — "implement this interface and it's exposed" violates principle of least surprise. Need explicit opt-in. Related to L-4 and a potential new **endpoint-visibility report** tool (dev-time listing of all exposed HTTP endpoints with auth requirements). |
+| M-5 | **Address** | Allow-list sort columns against the query's declared attributes. |
+| M-6 | **Address** | Generic error responses + server-side logging with correlation ID. |
+| M-7 | **Address** | Generic optimistic-concurrency via RavenDB change-vector / ETag. |
+| L-1 | **Address** | No `docs/Deployment.md` yet (only `guide-docker-deployment.md`). Create one with security-relevant defaults: `AllowedHosts`, HTTPS, rate limits, CORS. |
+| L-2 | **Address** | `Secure = true` flag on XSRF-TOKEN when not Development. |
+| L-3 | **Address (demo-only)** | Framework stays out of rate limiting. Wire `AddRateLimiter()` with sensible defaults into each demo app's `Program.cs`. No changes to `MintPlayer.Spark` or `MintPlayer.Spark.Authorization`. |
+| L-4 | **Address** | Same as M-4 — explicit opt-in. Plus endpoint-visibility report idea. |
+| L-5 | **Try, else defer** | Investigate adding guard to demo `sparkRoutes()`. Flash is cosmetic; defer if non-trivial. |
+| L-6 | **Skip** | Not important. |
+
+## 7. New findings surfaced during triage
+
+### H-1b — Attribute-level access control not implemented
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:**
+- `MintPlayer.Spark/Services/EntityMapper.cs:70-130` — reads all public properties regardless of caller identity
+- `MintPlayer.Spark.Abstractions/EntityAttributeDefinition.cs` — `IsVisible` / `IsReadOnly` are static schema flags, not evaluated per request
+
+**Attack scenario:** `User` entity has a `Salary` attribute marked `IsVisible=true` (public). Bob has role `Employee` which shouldn't see salaries. Framework has no mechanism to hide `Salary` for Bob specifically — schema `IsVisible` is all-or-nothing.
+
+**Expected secure behavior:** Framework exposes a hook (e.g., `IsAttributeVisibleAsync(attrDef, principal, entity)`) so per-caller visibility is possible. Default returns `attrDef.IsVisible`.
+
+---
+
+### L-7a — Read-only attributes are writable on Update
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** `MintPlayer.Spark/Endpoints/PersistentObject/Update.cs:47-71` + `MintPlayer.Spark/Services/EntityMapper.cs`
+
+**Attack scenario:** `Person.CreatedAt` is defined with `IsReadOnly=true`. Client sends a PUT with `CreatedAt` in the body. `EntityMapper.ToEntity<T>` copies the value into the entity. Update succeeds. The read-only contract is advisory-only, not enforced.
+
+**Expected secure behavior:** On update, reject (or silently drop) any attribute whose schema definition has `IsReadOnly=true`. Same for fields invisible to the current user (pairs with H-1b).
+
+---
+
+### L-7b — Invisible attributes are writable on Update
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed
+
+**Where:** Same as L-7a.
+
+**Attack scenario:** `Person.Role` has `IsVisible=false` in the schema (not shown in UI, for admin-only use). A direct PUT with `Role: "Admin"` in the body succeeds anyway — the invisibility contract is UI-only, not write-enforced.
+
+**Expected secure behavior:** Reject writes to attributes marked `IsVisible=false` unless the caller satisfies the condition that would normally make them visible (per-caller evaluation — see H-1b).
+
+---
+
+### L-4b — No developer-visible endpoint inventory
+
+**Layer:** Framework tooling · **Testable?** No · **Confidence:** Confirmed (feature gap, not bug)
+
+**Context:** Many findings (M-4, L-4) trace back to "framework auto-discovers and exposes things". A dev-time endpoint inventory (CLI tool or startup log banner in Development) listing every HTTP endpoint + its auth policy would make these regressions visible.
+
+**Not in test scope** — feature request, not a vulnerability to test.
+
+## 8. Expanded test matrix
+
+User direction: "as many tests as possible. We shouldn't play safe on the number of tests."
+
+Each test asserts the **secure expected behavior**. Tests that fail on current master == vulnerability confirmed.
+
+### HTTP-level (via `page.APIRequest`)
+
+| # | Finding | Test name | Assertion |
+|---|---------|-----------|-----------|
+| 1 | H-1 | `Unauthenticated_GET_queries_is_refused_unless_publicly_opted_in` | `GET /spark/queries` unauth → 401 (or empty list if opt-in is default) |
+| 2 | H-1 | `Unauthenticated_GET_types_is_refused` | `GET /spark/types` unauth → 401 |
+| 3 | H-1 | `Unauthenticated_GET_specific_query_is_refused` | `GET /spark/queries/{id}` unauth → 401 |
+| 4 | H-1 | `Unauthenticated_GET_aliases_is_refused` | `GET /spark/aliases` unauth → 401 |
+| 5 | H-1b | `Attribute_visibility_respects_current_user_claims` | Admin sees `Salary`; Employee doesn't |
+| 6 | H-2 | `User_B_cannot_list_User_As_private_records` | Row filter hides A's records from B's `GET /spark/po/{type}` |
+| 7 | H-2 | `User_B_cannot_read_User_As_private_record_by_id` | `GET /spark/po/{type}/{A-id}` by B → 404 |
+| 8 | H-3 | `Query_execute_with_foreign_parentId_is_refused` | User B's child query against A's parent → 404 |
+| 9 | H-4 | `Framework_fails_closed_when_authorization_not_wired` | Host built without `AddAuthorization()` — `GET /spark/po/...` refused |
+| 10 | M-1 | `Unauthenticated_GET_permissions_returns_anonymous_tier_only` | `canCreate/canEdit/canDelete` all `false` for anon |
+| 11 | M-2 | `JWT_with_tampered_signature_is_rejected` | `GET /spark/auth/me` with tampered JWT → 401 |
+| 12 | M-2 | `JWT_with_foreign_issuer_is_rejected` | Token signed by wrong key → 401 |
+| 13 | M-2 | `JWT_with_injected_group_claim_does_not_grant_rights` | Tampered group claim ignored |
+| 14 | M-3 | `Authorized_NotFound_and_Forbidden_are_indistinguishable` | Responses to non-existent-ID and forbidden-ID are byte-identical |
+| 15 | M-4 | `Custom_query_resolves_only_marked_methods` | Non-`[SparkQuery]` method callable via `Custom.*` → 400/404 |
+| 16 | M-4 | `Custom_query_reflection_does_not_leak_private_methods` | Private method on Actions class not reachable |
+| 17 | M-5 | `Sort_by_unknown_column_returns_400` | `?sortColumns=BogusProp:asc` → 400 |
+| 18 | M-5 | `Sort_by_non_schema_public_property_returns_400` | Public non-attribute property not sortable |
+| 19 | M-6 | `Error_body_does_not_leak_RavenDB_internals` | Duplicate-key / bad-input error body free of Raven-internal strings |
+| 20 | M-6 | `Error_body_does_not_leak_stack_traces` | No `at MintPlayer.Spark.*` in any 4xx/5xx body |
+| 21 | M-7 | `Concurrent_update_with_stale_version_is_rejected` | Two PUTs on same record — second with stale ETag → 409 |
+| 22 | L-2 | `XSRF_TOKEN_cookie_has_Secure_flag_outside_Development` | Set-Cookie header contains `; Secure` |
+| 23 | L-3 | `Rate_limiter_is_configured_on_demo_host` | After N rapid requests, 429 observed |
+| 24 | L-4 | `Custom_action_resolves_only_marked_classes` | `ICustomAction` without opt-in attribute → 404 |
+| 25 | L-7a | `Read_only_attribute_cannot_be_modified_on_update` | PUT with changed `IsReadOnly=true` field — field unchanged OR 400 |
+| 26 | L-7b | `Invisible_attribute_cannot_be_modified_on_update` | PUT with changed `IsVisible=false` field — field unchanged OR 400 |
+| 27 | L-7a | `Create_ignores_read_only_fields_sent_by_client` | POST with client-supplied `IsReadOnly` field — server uses default |
+
+### Browser-level (via Playwright)
+
+| # | Finding | Test name | Assertion |
+|---|---------|-----------|-----------|
+| 28 | H-5 | `Login_with_external_returnUrl_lands_on_default_redirect` | `?returnUrl=//attacker.test` → final URL = default |
+| 29 | H-5 | `Login_with_protocol_relative_returnUrl_is_rejected` | `?returnUrl=\\\\attacker.test` → default |
+| 30 | H-5 | `Login_with_absolute_http_returnUrl_is_rejected` | `?returnUrl=http://attacker.test` → default |
+| 31 | H-5 | `Login_with_allowed_returnUrl_is_honored` | Relative in-app `returnUrl=/dashboard` → `/dashboard` |
+
+**~31 tests total.** Some may be combined if the assertions overlap cleanly.
+
+## 6. Proposed test selection (for user to confirm)
+
+Recommended minimum viable e2e suite — **10 tests covering 9 findings**, each asserting the *secure expected behavior*:
+
+| ID | Finding | Test | Tool |
+|----|---------|------|------|
+| T1 | H-1 | Unauth `GET /spark/queries` → 401 | HTTP |
+| T2 | H-1 | Unauth `GET /spark/types` → 401 | HTTP |
+| T3 | H-2 | User B reads A's record → 404 | HTTP (2 users) |
+| T4 | H-3 | User B query execute with A's `parentId` → 404 | HTTP |
+| T5 | H-5 | Login `?returnUrl=//attacker` → lands on default | Playwright |
+| T6 | M-1 | Unauth `GET /spark/permissions/{id}` → 401 | HTTP |
+| T7 | M-3 | 404 and 403 responses are indistinguishable | HTTP |
+| T8 | M-4 | Non-`[SparkQuery]` method not callable via `Custom.*` | HTTP |
+| T9 | M-5 | Sort by non-schema property → 400 | HTTP |
+| T10 | M-6 | Error response body does not leak Raven internals | HTTP |
+
+H-4, M-2, M-7, L-* are either indirect, need special fixtures, or are deployment concerns — defer unless you want them in scope.
+
+Tests **will fail initially** — that's the point. A failing test == vulnerability confirmed in a reproducible way. Fixes come in separate PRs.

--- a/docs/codecov-pr123-diagnosis.md
+++ b/docs/codecov-pr123-diagnosis.md
@@ -1,0 +1,148 @@
+# CodeCov PR #123 Failure Analysis
+
+## Coverage Metrics
+- **Patch Coverage**: 26.28% (target 40.69%) — FAILING
+- **Project Coverage**: 34.90% (−5.80% vs base ea596e9) — FAILING
+- **No codecov.yml** — default settings apply (line-based coverage, no branch coverage weighting)
+
+---
+
+## Summary
+
+The PR adds **two production fixes** (H-2/H-3 row-level authorization, M-7 optimistic concurrency) plus **extensive E2E test coverage** in a separate test project that **does not run under the CI coverage collection command**. The new production code is exercised by those E2E tests (they pass), but coverage reports don't include `MintPlayer.Spark.E2E.Tests.Security/*`, so the framework changes appear uncovered.
+
+The −5.80% project-wide drop is caused by the new uncovered lines in the production code. The 26.28% patch coverage reflects that the main hit is to framework surface area (new public methods, exception class, reflection helpers) that E2E tests exercise at runtime but coverage tools don't instrument.
+
+---
+
+## Coverage Breakdown
+
+### Files in Diff with Likely Coverage Issues
+
+**High Impact (Framework—no E2E coverage reporting)**:
+
+1. **MintPlayer.Spark/Services/DatabaseAccess.cs** (+88 lines)
+   - `IsAllowedEntityViaActionsAsync()` — reflection helper that loads actions and invokes `IsAllowedAsync()` (H-2)
+   - `FilterByRowLevelAuthAsync()` — filters list results by row-level gate (H-2)
+   - Concurrency check block lines 212–221 — validates Etag before save (M-7)
+   - **Exercised by**: RowLevelAuthzTests + ConcurrencyTests in E2E project
+   - **Not counted**: E2E project not in CI coverage run
+
+2. **MintPlayer.Spark/Actions/DefaultPersistentObjectActions.cs** (+25 lines)
+   - `IsAllowedAsync(string action, T entity)` — new virtual hook on line 75, default returns `Task.FromResult(true)`
+   - Extensive documentation (lines 52–75) explaining the row-level gate
+   - **Exercised by**: E2E tests (Fleet's CarActions overrides it)
+   - **Not counted**: default implementation used via reflection, E2E coverage not collected
+
+3. **MintPlayer.Spark/Exceptions/SparkConcurrencyException.cs** (+19 lines)
+   - New exception class (internal sealed)
+   - Constructor and properties; message formatting
+   - **Exercised by**: ConcurrencyTests.Concurrent_update_with_stale_version_is_rejected
+   - **Not counted**: exception thrown in E2E test, caught in Update.cs endpoint — E2E coverage not reported
+
+4. **MintPlayer.Spark/Endpoints/PersistentObject/Update.cs** (+4 lines)
+   - Catch block for `SparkConcurrencyException` (lines 74–77) — returns 409 Conflict
+   - **Exercised by**: E2E test ConcurrencyTests  
+   - **Not counted**: E2E project not in CI run
+
+5. **MintPlayer.Spark/Endpoints/Queries/Execute.cs** (+38 lines)
+   - Parent fetch block (lines 88–104) — loads parent via `GetPersistentObjectAsync` (which now gates with IsAllowedAsync), returns 404 if null (H-3)
+   - **Exercised by**: RowLevelAuthzTests.User_B_cannot_execute_child_query_with_User_As_parent_id
+   - **Not counted**: E2E test
+
+**Lower Impact (Demo app—excluded from CI)**:
+
+6. **Demo/Fleet/Fleet/Actions/CarActions.cs** (+27 lines)
+   - CarActions.IsAllowedAsync override — enforces "creator sees only their own cars"
+   - OnBeforeSaveAsync stamp CreatedBy field
+   - **Not reported**: Demo/* projects explicitly excluded from CI: `--exclude=@spark-demo/*,Fleet,Fleet.Library`
+
+7. **Demo/Fleet/Fleet.Library/Entities/Car.cs** (+8 lines)
+   - CreatedBy field
+   - **Not reported**: Fleet.Library excluded
+
+**Source Generators (minimal impact)**:
+
+8. **MintPlayer.Spark.AllFeatures.SourceGenerators/Generators/SparkFullGenerator.Producer.cs** (+7 lines)
+9. **MintPlayer.Spark.AllFeatures/SparkFullOptions.cs** (+8 lines)
+   - Minor helper code; not on hot path for these tests
+
+---
+
+## Root Cause of −5.80% Project Drop
+
+The PR **adds production code that the E2E tests fully exercise, but E2E coverage is not collected by CI**.
+
+**Affected LOC** (production, not tests):
+- DatabaseAccess.cs: +88 lines (row-level filter, concurrency check, reflection helper)
+- DefaultPersistentObjectActions.cs: +25 lines (IsAllowedAsync hook)
+- Update.cs, Queries/Execute.cs: +42 lines (409 response, H-3 parent gate)
+- SparkConcurrencyException.cs: +19 lines (new exception)
+- **Total uncovered production LOC**: ~174 lines
+
+This is **new surface area** (framework hooks, internal helpers, exception handling) that is tested behaviorally by E2E tests but not instrumented by coverage tooling.
+
+---
+
+## CI Configuration Analysis
+
+**`.github/workflows/pull-request.yml` line 68**:
+```
+npx nx affected --target=test --exclude=@spark-demo/*,DemoApp,DemoApp.Library,Fleet,Fleet.Library,HR,HR.Library,WebhooksDemo,WebhooksDemo.Library
+```
+
+**What this does**:
+- Runs `dotnet test` on all affected projects *except* Demo/* and Demo.Library/*
+- Projects that WILL run under `dotnet test` with coverage:
+  - `MintPlayer.Spark.Tests` (unit tests, includes Authorization/ folder with AccessControlServiceTests etc.)
+  - `MintPlayer.Spark.SourceGenerators.Tests`
+  - `MintPlayer.Spark.Messaging.Tests` (if affected)
+  - Other non-demo test projects
+
+- Projects that DO NOT RUN:
+  - `MintPlayer.Spark.E2E.Tests` (NOT listed — no glob matches it, it's not a Demo project)
+  - Demo test projects (explicitly excluded)
+
+**Coverage collection** (line 78–80):
+```yaml
+files: |
+  **/coverage/**/coverage.cobertura.xml
+  **/coverage/cobertura-coverage.xml
+```
+Collects Cobertura XML from any test project that ran. If `MintPlayer.Spark.E2E.Tests` doesn't run, its coverage.xml isn't collected.
+
+**Coverlet collector** is in both `MintPlayer.Spark.Tests.csproj` and `MintPlayer.Spark.E2E.Tests.csproj`, but the E2E tests are never invoked because:
+1. Nx affected doesn't know how to test E2E (no `targets: test` defined in E2E project's project.json or equivalent)
+2. OR E2E project is not in the Nx graph (it's .csproj-only, not an Nx project)
+3. Result: its tests don't run, coverage.xml is never generated
+
+---
+
+## Why This Matters
+
+- **RowLevelAuthzTests.cs** (100 lines): 3 facts testing H-2/H-3 behavior — all pass, all exercising IsAllowedAsync hook
+- **ConcurrencyTests.cs** (96 lines): 1 fact testing M-7 — passes, exercises Etag round-trip and 409 response
+- These tests validate the core fix, but codecov sees only:
+  - Test code itself (counted as test coverage, not line coverage)
+  - No instrumentation of the production code paths
+
+---
+
+## Remediation Path (Out of Scope for This Diagnosis)
+
+Uncovered framework code is a code-quality signal, not a functional bug (the tests pass). Options:
+
+1. **Add unit tests to `MintPlayer.Spark.Tests`** covering IsAllowedAsync default path, FilterByRowLevelAuthAsync edge cases (empty list, projection mismatch), SparkConcurrencyException message formatting — ~150 LOC of unit tests to reach 80%+ coverage on the new production lines.
+
+2. **Integrate E2E test coverage into CI** — configure Nx to run `MintPlayer.Spark.E2E.Tests` and collect its coverage.xml, merging it with unit test coverage. Requires:
+   - Nx project configuration for E2E tests
+   - GitHub Actions step to invoke E2E tests separately (or add to affected graph)
+   - Awareness that E2E coverage will be volatile (depends on Fleet demo seeding, Playwright, Raven test instance)
+
+3. **Accept the coverage drop** — the fix is correct (tests pass), and the gap is known and documented. File a follow-up issue to backfill unit tests.
+
+---
+
+## Conclusion
+
+PR #123 adds 174 LOC of uncovered production code. All code is exercised by E2E tests, but those tests run outside the CI coverage collection loop. No bug in the code; a gap in test infrastructure visibility. The −5.80% project drop is the honest cost of adding new framework surface area without parallel unit test coverage.

--- a/docs/codecov-pr123-remediation.md
+++ b/docs/codecov-pr123-remediation.md
@@ -1,0 +1,102 @@
+# CodeCov PR #123 — Remediation Options
+
+Per `docs/codecov-pr123-diagnosis.md`: ~174 LOC of new production code (H-2/H-3 row-level authz, M-7 optimistic concurrency) is exercised only by `MintPlayer.Spark.E2E.Tests/Security/*`. Those tests run Fleet as an **out-of-process** `dotnet run` subprocess (see `MintPlayer.Spark.E2E.Tests/_Infrastructure/FleetTestHost.cs:262`), so coverlet in the test process captures zero coverage of `MintPlayer.Spark.dll`. That — plus the fact that CI's nx filter doesn't invoke the E2E project at all — accounts for both the patch 26.28% and the project −5.80%.
+
+Three options below, then a recommendation.
+
+---
+
+## Option A — Add targeted unit tests in `MintPlayer.Spark.Tests`
+
+The project already exists (xunit + FluentAssertions + NSubstitute + coverlet.collector) and has `InternalsVisibleTo` for `MintPlayer.Spark.Tests` (`MintPlayer.Spark/MintPlayer.Spark.csproj:37`) — so `internal sealed SparkConcurrencyException` is reachable without surface changes.
+
+| File / method to cover | What to test | Effort |
+| --- | --- | --- |
+| `MintPlayer.Spark/Exceptions/SparkConcurrencyException.cs` (new, 19 LOC) | Constructor sets `ExpectedEtag`/`ActualEtag`; message shape with and without `actualEtag`. | small (~15 LOC) |
+| `MintPlayer.Spark/Actions/DefaultPersistentObjectActions.cs` — `IsAllowedAsync(string, T)` default (+25 LOC, mostly doc comments) | Default returns `true` for any action/entity; subclass override is honoured. Parameterize over `"Read"`, `"Query"`, `"Edit"`, `"Delete"`, `"New"`. | small (~20 LOC) |
+| `MintPlayer.Spark/Services/DatabaseAccess.cs` — `IsAllowedEntityViaActionsAsync` + `FilterByRowLevelAuthAsync` (+88 LOC) | Single-load returns null when hook denies; list filter drops denied rows, keeps allowed, handles empty and all-denied lists; projection path loads base entity. Hit via NSubstitute on `IActionsResolver` + in-memory Raven session (`MintPlayer.Spark.Testing` already available). | **medium** (~120 LOC; Raven session setup is the fixed cost) |
+| `MintPlayer.Spark/Endpoints/PersistentObject/Update.cs` — new 409 catch block (+4 LOC) | Unit test would require mocking the endpoint pipeline; NOT worth it — already exercised by `ConcurrencyTests` e2e and effectively covered once Option C lands. | skip |
+| `MintPlayer.Spark/Endpoints/Queries/Execute.cs` — parent-fetch gate (+38 LOC) | Same story as Update.cs: the handler is endpoint-shaped; cheaper under Option C. | skip |
+
+**Total realistic effort**: medium — ~2–4 hours to write, plus CI flake surface from adding Raven-backed unit tests. Would lift patch coverage on the framework-side changes but leaves ~42 LOC in `Update.cs`/`Queries/Execute.cs` uncovered unless the E2E path is also hooked in.
+
+**Tradeoff**: Adds durable regression tests that are faster than e2e, but it's real engineering work mid-security-audit and doesn't address the structural gap (next security PR will hit the same wall).
+
+---
+
+## Option B — Add `codecov.yml` matching current reality
+
+No `codecov.yml` exists today (repo runs on codecov defaults, which derive `target: auto` from the base). Adding one lets us set explicit, defensible thresholds and ignore rules.
+
+```yaml
+# codecov.yml
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%           # allow small regressions without failing CI
+        informational: false
+    patch:
+      default:
+        target: 30%             # realistic floor for this repo's unit-test reach;
+                                # raise to 50% once E2E coverage is wired in (Option C)
+        threshold: 0%
+        informational: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "Demo/**"                            # demo apps, excluded from CI already
+  - "**/obj/**"
+  - "**/bin/**"
+  - "**/*.Generated.cs"
+  - "**/Generated/**"
+  - "MintPlayer.Spark.SourceGenerators/**"   # tested by its own .Tests project;
+                                              # source-gen files are notoriously noisy
+  - "MintPlayer.Spark.E2E.Tests/**"          # test project itself shouldn't count as source
+  - "MintPlayer.Spark.Tests/**"
+  - "MintPlayer.Spark.SourceGenerators.Tests/**"
+  - "node_packages/**"                       # Angular libs measured separately
+  - "**/*.Designer.cs"
+```
+
+**Effort**: small (~15 min). Single new file, no code changes.
+
+**Tradeoff**: Unblocks the PR immediately and sets honest, repo-wide expectations. Does NOT improve actual coverage — if a later PR introduces truly uncovered code, `patch: 30%` still catches it. The `ignore:` list also plugs a real blind spot (today the demo code under `Demo/**` isn't failing codecov only because it happens not to be included in any test project's cobertura output; if that ever changes, coverage tanks). Risk: a floor that's too low becomes permanent — call out in the PR description that this is a staging target, not a final one.
+
+---
+
+## Option C — Wire the E2E project into CI coverage
+
+**Viability check**: the diagnosis got this half right. The e2e tests use Playwright, but more importantly they launch Fleet as a separate subprocess via `dotnet run` (`FleetTestHost.cs:262`). So this is **out-of-process** — coverlet.collector attached to the test process sees test-assembly code only. `WebApplicationFactory` is NOT in use.
+
+Making Option C work therefore requires cross-process instrumentation, roughly:
+
+1. Replace `dotnet run` with `dotnet test --collect:"XPlat Code Coverage"` on a test-harness project that hosts Fleet in-process via `WebApplicationFactory<Program>` — a meaningful refactor of `FleetTestHost`. Or,
+2. Use `coverlet.msbuild` on the Fleet build, pass `/p:CollectCoverage=true /p:CoverletOutputFormat=cobertura` through `dotnet run`, and let Fleet write cobertura on shutdown. Then merge cobertura files from both processes before upload. Moderate wiring + a coverage-merge step in the workflow.
+3. Much simpler sub-option: just include `MintPlayer.Spark.E2E.Tests` in the nx affected test target (so its `coverlet.collector` runs and at minimum contributes **test-assembly** coverage, plus anything reachable in-process — `_Infrastructure/FleetTestHost` itself, `SparkTestDriver`, and any library code the test assertions call directly). This closes some of the patch gap without the cross-process plumbing, but NOT the 174 LOC of framework code running inside the Fleet subprocess.
+
+**Effort**: large for the full solution (#1 or #2). Medium for the partial (#3) — one line change in `pull-request.yml` to drop the implicit E2E exclusion + a `project.json`/nx target for the E2E project.
+
+**Tradeoff**: Full solution is architecturally the right answer but it's a CI infrastructure project in the middle of a security audit. Partial solution helps marginally and risks flaky coverage numbers (E2E flakes on Raven seeding + Playwright). This is the correct long-term fix but the wrong PR for it.
+
+---
+
+## Recommendation: **Option B now, Option C follow-up**
+
+Add `codecov.yml` as described in Option B on this PR. Rationale: the diagnosis establishes that the 174 uncovered LOC is a **measurement gap, not a quality gap** — every added line is behaviourally tested by the new Security/*.cs e2e suite (29 pass / 0 skip / 0 fail). A `patch: 30%` floor with `ignore:` rules matches what CI actually measures today, unblocks the security PR, and doesn't require writing any code. The user is mid-security-audit with more findings to ship; time-to-merge matters more than chasing instrumentation parity on this PR.
+
+**Secondary**: file a follow-up issue for Option C (full E2E coverage wiring — path #1 or #2) and, once it lands, raise the `patch` target from 30% → 50%. Option A is NOT recommended for this PR — 2–4 hours of Raven-backed unit tests duplicates work the e2e suite already does and doesn't scale (the next security PR hits the same 26% wall unless Option C is solved structurally).
+
+---
+
+## Files to change if B is approved
+
+- Add `codecov.yml` at repo root (content above).
+- Add one line to PR #123 description noting the new floor is a staging target pending Option C follow-up.
+
+No code changes. No CI workflow changes.


### PR DESCRIPTION
## Summary

- Audit of master by five parallel review passes (authN/authZ, injection, endpoint surface, Angular frontend, source-generators/supply-chain). Findings triaged with user and documented in `docs/PRD-SecurityAudit.md`.
- 25 active + 3 skipped e2e tests landed in `MintPlayer.Spark.E2E.Tests/Security/`, built on the existing Fleet Playwright fixture plus a CSRF-aware `SparkApi` wrapper. Each test asserts the *secure expected behaviour* — a failing test pins a confirmed vulnerability; a passing test documents existing defence.
- This PR is the **baseline** for the security-remediation effort. Subsequent commits on the branch add the per-finding fixes; each should flip its test(s) green.

## Confirmed from the first run (on master)

**Vulnerabilities reproduced** — tests fail:
- **H-1** metadata leak — `/spark/queries` and `/spark/types` return the full catalogue to anonymous callers. Contract is *filter* (not refuse): Company visible, Car/Person/CarBrand filtered out based on the Everyone group's `Query` rights.
- **L-3** no rate limiter — 200-request burst observed zero 429 responses. Remediation is demo-local (wire `AddRateLimiter()` in each `Program.cs`).

**Already-secure behaviour** — tests pass:
- **M-6** error responses do not echo stack traces or Raven internals.

**Skipped pending row-level filter hook:**
- **H-2 / H-3** cross-user record + parent-id access.

## Triage decisions (see `docs/PRD-SecurityAudit.md` §5–§8)

- Row-level filtering is an *API contract*, surfaced via a new virtual method on `DefaultPersistentObjectActions<T>`.
- Single PR, multiple commits. This PR.
- Harness: existing `MintPlayer.Spark.E2E.Tests` (Playwright) — no new test project.

## Files

- `docs/PRD-SecurityAudit.md` — findings, triage, test matrix
- `docs/PRD-SecurityAudit-TestResults.md` — first-run outcomes, remediation order
- `MintPlayer.Spark.E2E.Tests/Security/*.cs` — 12 files, 28 tests

## Test plan

- [ ] Clean-baseline test run: resolve the 13 outcomes currently hidden by the console logger (run each test class individually or use a TRX logger)
- [ ] Debug admin-POST 500 so L-7/M-7 setup succeeds and the real assertions run
- [ ] Per-finding remediation commits in priority order (H-1 → H-4 → H-5 → H-2/H-3 → M-1…M-7 → L-*), each flipping its test(s) green
- [ ] Remove `[Fact(Skip=…)]` on `RowLevelAuthzTests` once the row-filter hook lands
- [ ] Expand coverage to H-4 (fail-closed host), M-2 (token tampering — when IdP lands), M-4/L-4 (marker attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)