### PR TITLE
feat: PersistentObject factory — Phase 2 (mapper + generic overloads)

### DIFF
--- a/Demo/DemoApp/DemoApp/DemoApp.csproj
+++ b/Demo/DemoApp/DemoApp/DemoApp.csproj
@@ -29,6 +29,7 @@
 
 	<ItemGroup>
 		<AdditionalFiles Include="App_Data\translations.json" />
+		<AdditionalFiles Include="App_Data\Model\*.json" />
 	</ItemGroup>
 
 	<!-- Angular build during publish -->

--- a/Demo/Fleet/Fleet/Fleet.csproj
+++ b/Demo/Fleet/Fleet/Fleet.csproj
@@ -27,6 +27,7 @@
 
 	<ItemGroup>
 		<AdditionalFiles Include="App_Data\translations.json" />
+		<AdditionalFiles Include="App_Data\Model\*.json" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\MintPlayer.Spark.Authorization\Targets\spark-authorization.targets" />

--- a/Demo/HR/HR/HR.csproj
+++ b/Demo/HR/HR/HR.csproj
@@ -29,6 +29,7 @@
 
 	<ItemGroup>
 		<AdditionalFiles Include="App_Data\translations.json" />
+		<AdditionalFiles Include="App_Data\Model\*.json" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\MintPlayer.Spark.Authorization\Targets\spark-authorization.targets" />

--- a/Demo/WebhooksDemo/WebhooksDemo/WebhooksDemo.csproj
+++ b/Demo/WebhooksDemo/WebhooksDemo/WebhooksDemo.csproj
@@ -31,6 +31,7 @@
 
 	<ItemGroup>
 		<AdditionalFiles Include="App_Data\translations.json" />
+		<AdditionalFiles Include="App_Data\Model\*.json" />
 	</ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.Abstractions/IManager.cs
+++ b/MintPlayer.Spark.Abstractions/IManager.cs
@@ -5,10 +5,36 @@ namespace MintPlayer.Spark.Abstractions;
 public interface IManager
 {
     /// <summary>
-    /// Creates a virtual PersistentObject (not backed by a DB entity).
-    /// Useful for building custom dialogs in Retry.Action().
+    /// Scaffolds a blank PersistentObject for the entity type registered under
+    /// <paramref name="name"/>. All declared attributes are created with full
+    /// metadata (DataType, Label, Rules, Renderer, ShowedOn, Order, Group,
+    /// IsRequired/Visible/ReadOnly/Array, Query for References); Value is null.
+    /// Throws <see cref="KeyNotFoundException"/> on unknown or ambiguous name —
+    /// prefer the <see cref="NewPersistentObject(Guid)"/> overload in apps that
+    /// declare entities across multiple database schemas.
     /// </summary>
-    PersistentObject NewPersistentObject(string name, params PersistentObjectAttribute[] attributes);
+    /// <remarks>
+    /// This is the idiomatic way to build a PO for a popup / dialog / form —
+    /// declare the shape as a Virtual PO in <c>App_Data/Model/*.json</c> and
+    /// look it up by name, rather than constructing the PO and its attributes
+    /// by hand.
+    /// </remarks>
+    PersistentObject NewPersistentObject(string name);
+
+    /// <summary>
+    /// Scaffolds a blank PersistentObject by ObjectTypeId. Unambiguous — preferred
+    /// over the name overload whenever the caller already has the Guid
+    /// (e.g. from the source-generated <c>PersistentObjectIds</c> constants).
+    /// </summary>
+    PersistentObject NewPersistentObject(Guid id);
+
+    /// <summary>
+    /// Scaffolds a blank PersistentObject for <typeparamref name="T"/>, resolving the
+    /// ObjectTypeId by looking up <c>typeof(T).FullName</c> against the registered
+    /// EntityTypeDefinitions. The cleanest path when the caller has a typed entity
+    /// class — no Guid plumbing, no string names.
+    /// </summary>
+    PersistentObject NewPersistentObject<T>() where T : class;
 
     /// <summary>
     /// Access to the Retry Action subsystem.

--- a/MintPlayer.Spark.SourceGenerators.Tests/Generators/PersistentObjectIdsGeneratorTests.cs
+++ b/MintPlayer.Spark.SourceGenerators.Tests/Generators/PersistentObjectIdsGeneratorTests.cs
@@ -1,0 +1,155 @@
+using MintPlayer.Spark.SourceGenerators.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.SourceGenerators.Tests.Generators;
+
+/// <summary>
+/// Exercises the PersistentObjectIds emission path of
+/// <c>PersistentObjectNamesGenerator</c>. Unlike <c>PersistentObjectNames</c>
+/// which scans CLR <c>DefaultPersistentObjectActions&lt;T&gt;</c> types, this
+/// path reads <c>App_Data/Model/*.json</c> AdditionalFiles and emits
+/// schema-nested <c>const string</c> Guid values.
+/// </summary>
+public class PersistentObjectIdsGeneratorTests
+{
+    private const string GeneratorName = "PersistentObjectNamesGenerator";
+
+    // A tiny CLR source that makes the generator's "knowsSpark" gate pass.
+    // We reference DefaultPersistentObjectActions via a source stub so the generator
+    // sees a symbol with the expected fully-qualified name.
+    private const string KnowsSparkSource = """
+        namespace MintPlayer.Spark.Actions
+        {
+            public abstract class DefaultPersistentObjectActions<T> { }
+        }
+        namespace TestApp
+        {
+            public class Dummy : MintPlayer.Spark.Actions.DefaultPersistentObjectActions<object> { }
+        }
+        """;
+
+    private static string Model(string id, string name, string? schema = null)
+    {
+        var schemaLine = schema is null ? "" : $"    \"schema\": \"{schema}\",\n";
+        return "{\n"
+             + "  \"persistentObject\": {\n"
+             + $"    \"id\": \"{id}\",\n"
+             + $"    \"name\": \"{name}\",\n"
+             + schemaLine
+             + $"    \"description\": {{ \"en\": \"{name}\" }},\n"
+             + "    \"attributes\": [\n"
+             + "      { \"id\": \"11111111-1111-1111-1111-111111111111\", \"name\": \"Foo\" }\n"
+             + "    ]\n"
+             + "  }\n"
+             + "}\n";
+    }
+
+    [Fact]
+    public void Emits_PersistentObjectIds_Under_Default_Schema_When_Schema_Missing()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/Model/Car.json", Model("27768be5-2ff5-4782-8b22-c0e8d163050e", "Car")),
+                ("App_Data/Model/Person.json", Model("11111111-2222-3333-4444-555555555555", "Person")),
+            ]);
+
+        var ids = result.GeneratedSources.FirstOrDefault(s => s.HintName == "PersistentObjectIds.g.cs");
+        ids.Source.Should().NotBeNull();
+        ids.Source.Should().Contain("public static class PersistentObjectIds");
+        ids.Source.Should().Contain("public static class Default");
+        ids.Source.Should().Contain("public const string Car = \"27768be5-2ff5-4782-8b22-c0e8d163050e\";");
+        ids.Source.Should().Contain("public const string Person = \"11111111-2222-3333-4444-555555555555\";");
+    }
+
+    [Fact]
+    public void Emits_Schema_Nested_Classes_For_Multi_Schema_Input()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/Model/Car.json", Model("27768be5-2ff5-4782-8b22-c0e8d163050e", "Car", "Default")),
+                ("App_Data/Model/AuditLog.json", Model("99999999-8888-7777-6666-555555555555", "AuditLog", "Audit")),
+            ]);
+
+        var ids = result.GeneratedSources.First(s => s.HintName == "PersistentObjectIds.g.cs").Source;
+        ids.Should().Contain("public static class Default");
+        ids.Should().Contain("public static class Audit");
+        ids.Should().Contain("public const string Car = \"27768be5-2ff5-4782-8b22-c0e8d163050e\";");
+        ids.Should().Contain("public const string AuditLog = \"99999999-8888-7777-6666-555555555555\";");
+    }
+
+    [Fact]
+    public void Skips_Files_Outside_Model_Directory()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/translations.json", """{ "hello": "world" }"""),
+                ("App_Data/Model/Car.json", Model("27768be5-2ff5-4782-8b22-c0e8d163050e", "Car")),
+            ]);
+
+        var ids = result.GeneratedSources.First(s => s.HintName == "PersistentObjectIds.g.cs").Source;
+        ids.Should().Contain("Car");
+        ids.Should().NotContain("hello"); // translations.json ignored
+    }
+
+    [Fact]
+    public void Skips_Model_File_That_Is_Not_A_PersistentObject_Wrapper()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/Model/NotAPo.json", """{ "somethingElse": { "id": "27768be5-2ff5-4782-8b22-c0e8d163050e" } }"""),
+                ("App_Data/Model/Car.json", Model("11111111-2222-3333-4444-555555555555", "Car")),
+            ]);
+
+        var ids = result.GeneratedSources.First(s => s.HintName == "PersistentObjectIds.g.cs").Source;
+        ids.Should().Contain("Car");
+        ids.Should().NotContain("somethingElse");
+    }
+
+    [Fact]
+    public void Skips_Model_File_With_Invalid_Guid()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/Model/Invalid.json", Model("not-a-guid", "Invalid")),
+                ("App_Data/Model/Car.json", Model("11111111-2222-3333-4444-555555555555", "Car")),
+            ]);
+
+        var ids = result.GeneratedSources.First(s => s.HintName == "PersistentObjectIds.g.cs").Source;
+        ids.Should().Contain("Car");
+        ids.Should().NotContain("Invalid");
+    }
+
+    [Fact]
+    public void Emits_Nothing_When_No_Model_Files_Present()
+    {
+        var result = GeneratorHarness.Run(
+            GeneratorName,
+            [KnowsSparkSource],
+            rootNamespace: "TestApp",
+            additionalTexts:
+            [
+                ("App_Data/translations.json", """{ "hello": "world" }"""),
+            ]);
+
+        result.GeneratedSources.Should().NotContain(s => s.HintName == "PersistentObjectIds.g.cs");
+    }
+}

--- a/MintPlayer.Spark.SourceGenerators.Tests/Generators/PersistentObjectIdsGeneratorTests.cs
+++ b/MintPlayer.Spark.SourceGenerators.Tests/Generators/PersistentObjectIdsGeneratorTests.cs
@@ -29,18 +29,19 @@ public class PersistentObjectIdsGeneratorTests
 
     private static string Model(string id, string name, string? schema = null)
     {
-        var schemaLine = schema is null ? "" : $"    \"schema\": \"{schema}\",\n";
-        return "{\n"
-             + "  \"persistentObject\": {\n"
-             + $"    \"id\": \"{id}\",\n"
-             + $"    \"name\": \"{name}\",\n"
-             + schemaLine
-             + $"    \"description\": {{ \"en\": \"{name}\" }},\n"
-             + "    \"attributes\": [\n"
-             + "      { \"id\": \"11111111-1111-1111-1111-111111111111\", \"name\": \"Foo\" }\n"
-             + "    ]\n"
-             + "  }\n"
-             + "}\n";
+        var schemaField = schema is null ? "" : $$""", "schema": "{{schema}}" """;
+        return $$"""
+            {
+              "persistentObject": {
+                "id": "{{id}}",
+                "name": "{{name}}"{{schemaField}},
+                "description": { "en": "{{name}}" },
+                "attributes": [
+                  { "id": "11111111-1111-1111-1111-111111111111", "name": "Foo" }
+                ]
+              }
+            }
+            """;
     }
 
     [Fact]

--- a/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.IdsProducer.cs
+++ b/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.IdsProducer.cs
@@ -1,0 +1,93 @@
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using MintPlayer.Spark.SourceGenerators.Models;
+using MintPlayer.SourceGenerators.Tools;
+
+namespace MintPlayer.Spark.SourceGenerators.Generators;
+
+/// <summary>
+/// Emits <c>PersistentObjectIds</c>: nested static classes per database schema,
+/// each holding <c>const string</c> Guid values for every entity declared under
+/// that schema. Source of truth is <c>App_Data/Model/*.json</c> files surfaced
+/// via <c>&lt;AdditionalFiles Include="App_Data\Model\*.json" /&gt;</c> in the
+/// consumer's csproj.
+/// </summary>
+/// <example>
+/// <code>
+/// // Generated output
+/// public static class PersistentObjectIds
+/// {
+///     public static class Default
+///     {
+///         public const string Car    = "27768be5-2ff5-4782-8b22-c0e8d163050e";
+///         public const string Person = "...";
+///     }
+///
+///     public static class Audit
+///     {
+///         public const string AuditLog = "...";
+///     }
+/// }
+///
+/// // Consumer
+/// var po = manager.NewPersistentObject(new Guid(PersistentObjectIds.Default.Car));
+/// </code>
+/// </example>
+public class PersistentObjectIdsProducer : Producer
+{
+    private readonly IReadOnlyList<PersistentObjectIdInfo> ids;
+    private readonly bool knowsSpark;
+
+    public PersistentObjectIdsProducer(
+        IEnumerable<PersistentObjectIdInfo> ids,
+        bool knowsSpark,
+        string rootNamespace)
+        : base(rootNamespace, "PersistentObjectIds.g.cs")
+    {
+        this.ids = ids.ToList();
+        this.knowsSpark = knowsSpark;
+    }
+
+    protected override void ProduceSource(IndentedTextWriter writer, System.Threading.CancellationToken cancellationToken)
+    {
+        if (!knowsSpark || ids.Count == 0)
+            return;
+
+        // Deduplicate by (Schema, Name) — first write wins — then group per schema.
+        var bySchema = ids
+            .GroupBy(i => (i.Schema, i.Name))
+            .Select(g => g.First())
+            .GroupBy(i => i.Schema, System.StringComparer.Ordinal)
+            .OrderBy(g => g.Key, System.StringComparer.Ordinal)
+            .ToList();
+
+        writer.WriteLine(Header);
+        writer.WriteLine();
+
+        using (writer.OpenBlock($"namespace {RootNamespace}"))
+        {
+            using (writer.OpenBlock("public static class PersistentObjectIds"))
+            {
+                for (var i = 0; i < bySchema.Count; i++)
+                {
+                    var schema = bySchema[i];
+                    if (i > 0) writer.WriteLine();
+
+                    using (writer.OpenBlock($"public static class {schema.Key}"))
+                    {
+                        var entries = schema
+                            .OrderBy(e => e.Name, System.StringComparer.Ordinal)
+                            .ToList();
+
+                        foreach (var entry in entries)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            writer.WriteLine($"public const string {entry.Name} = \"{entry.Id}\";");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.cs
+++ b/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.cs
@@ -1,8 +1,10 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using MintPlayer.Spark.SourceGenerators.Json;
 using MintPlayer.Spark.SourceGenerators.Models;
 using MintPlayer.SourceGenerators.Tools;
 using MintPlayer.SourceGenerators.Tools.ValueComparers;
+using System.IO;
 
 namespace MintPlayer.Spark.SourceGenerators.Generators;
 
@@ -115,6 +117,47 @@ public class PersistentObjectNamesGenerator : IncrementalGenerator
                     settings.RootNamespace ?? "GeneratedCode");
             });
 
-        context.ProduceCode(namesProvider, attributeNamesProvider);
+        // Harvest PersistentObjectIdInfo from App_Data/Model/*.json AdditionalFiles.
+        // Files that don't parse as Spark Model JSON (missing "persistentObject" wrapper,
+        // missing id/name, bad Guid) are silently skipped — they may be other auxiliary
+        // JSON files the host includes.
+        var idsProvider = context.AdditionalTextsProvider
+            .Where(static t =>
+            {
+                var file = Path.GetFileName(t.Path);
+                if (!file.EndsWith(".json", System.StringComparison.OrdinalIgnoreCase))
+                    return false;
+                // Path convention: <anything>/App_Data/Model/<EntityName>.json
+                // Accept both absolute paths from csproj globs and relative paths from tests.
+                var normalized = t.Path.Replace('\\', '/');
+                return normalized.Contains("App_Data/Model/");
+            })
+            .Select(static (t, ct) =>
+            {
+                var text = t.GetText(ct)?.ToString();
+                return text is not null && ModelJsonReader.TryRead(text, out var info)
+                    ? info
+                    : null;
+            })
+            .Where(static info => info != null)
+            .WithNullableComparer()
+            .Collect();
+
+        var idsSourceProvider = idsProvider
+            .Combine(knowsSparkProvider)
+            .Combine(settingsProvider)
+            .Select(static (providers, ct) =>
+            {
+                var ids = providers.Left.Left;
+                var knowsSpark = providers.Left.Right;
+                var settings = providers.Right;
+
+                return (Producer)new PersistentObjectIdsProducer(
+                    ids.Where(x => x != null).Cast<PersistentObjectIdInfo>(),
+                    knowsSpark,
+                    settings.RootNamespace ?? "GeneratedCode");
+            });
+
+        context.ProduceCode(namesProvider, attributeNamesProvider, idsSourceProvider);
     }
 }

--- a/MintPlayer.Spark.SourceGenerators/Json/ModelJsonReader.cs
+++ b/MintPlayer.Spark.SourceGenerators/Json/ModelJsonReader.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace MintPlayer.Spark.SourceGenerators.Json;
+
+/// <summary>
+/// Extracts the top-level metadata we need from a Spark Model JSON file
+/// (<c>App_Data/Model/*.json</c>): the <c>persistentObject.id</c>,
+/// <c>persistentObject.name</c>, and the optional <c>persistentObject.schema</c>.
+///
+/// <para>
+/// Deliberately a minimal regex reader instead of a full JSON parser — the only
+/// thing the generator needs is three top-level string values. Model JSON files
+/// are framework-controlled; adversarial shapes aren't a concern.
+/// </para>
+///
+/// <para>
+/// Convention: <c>id</c>, <c>name</c>, and <c>schema</c> appear before any nested
+/// object or array in every Model JSON file. "First match wins" is therefore
+/// safe — a nested <c>attributes[].id</c> never outranks the top-level
+/// <c>persistentObject.id</c>.
+/// </para>
+/// </summary>
+internal static class ModelJsonReader
+{
+    /// <summary>
+    /// Returns <c>null</c> when the file cannot be parsed into a usable
+    /// <see cref="Models.PersistentObjectIdInfo"/> — missing fields, invalid Guid,
+    /// or no <c>persistentObject</c> wrapper at all.
+    /// </summary>
+    public static bool TryRead(string json, out Models.PersistentObjectIdInfo? info)
+    {
+        info = null;
+        if (string.IsNullOrWhiteSpace(json))
+            return false;
+
+        // Must be wrapped in a "persistentObject" root — protects against picking up
+        // unrelated JSON files (translations.json, security.json, etc.) that happen
+        // to share the AdditionalFiles include pattern.
+        if (!PersistentObjectOpen.IsMatch(json))
+            return false;
+
+        var id = FindTopLevelString(json, "id");
+        var name = FindTopLevelString(json, "name");
+        if (id is null || name is null)
+            return false;
+
+        if (!Guid.TryParse(id, out _))
+            return false;
+
+        var schema = FindTopLevelString(json, "schema");
+        info = new Models.PersistentObjectIdInfo
+        {
+            Id = id,
+            Name = name,
+            Schema = string.IsNullOrWhiteSpace(schema) ? "Default" : schema!,
+        };
+        return true;
+    }
+
+    private static readonly Regex PersistentObjectOpen = new(
+        "\"persistentObject\"\\s*:\\s*\\{",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static string? FindTopLevelString(string json, string key)
+    {
+        // Matches: "key" : "value"  — allowing simple backslash escapes in the value.
+        var pattern = "\"" + Regex.Escape(key) + "\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"";
+        var m = Regex.Match(json, pattern);
+        return m.Success ? Unescape(m.Groups[1].Value) : null;
+    }
+
+    private static string Unescape(string s)
+        => s.Replace("\\\"", "\"")
+            .Replace("\\\\", "\\")
+            .Replace("\\n", "\n")
+            .Replace("\\r", "\r")
+            .Replace("\\t", "\t");
+}

--- a/MintPlayer.Spark.SourceGenerators/Models/PersistentObjectIdInfo.cs
+++ b/MintPlayer.Spark.SourceGenerators/Models/PersistentObjectIdInfo.cs
@@ -1,0 +1,31 @@
+using MintPlayer.ValueComparerGenerator.Attributes;
+
+namespace MintPlayer.Spark.SourceGenerators.Models;
+
+/// <summary>
+/// A single entry harvested from a Spark Model JSON file (typically
+/// <c>App_Data/Model/*.json</c>). Feeds the <c>PersistentObjectIds</c> generator
+/// output — nested-by-schema <c>const string</c> Guids that user code can pass to
+/// <c>IManager.NewPersistentObject(Guid)</c>.
+/// </summary>
+[AutoValueComparer]
+public partial class PersistentObjectIdInfo
+{
+    /// <summary>
+    /// The entity's schema (database/module namespace). Defaults to <c>"Default"</c>
+    /// when the JSON file does not declare a schema.
+    /// </summary>
+    public string Schema { get; set; } = "Default";
+
+    /// <summary>
+    /// The entity name. Used as the generated C# member identifier under
+    /// <c>PersistentObjectIds.{Schema}.{Name}</c>.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Guid value (as its canonical string representation) to be emitted
+    /// as a <c>const string</c>. Already validated as parseable when written.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+}

--- a/MintPlayer.Spark.Tests/EntityMapperFactoryTests.cs
+++ b/MintPlayer.Spark.Tests/EntityMapperFactoryTests.cs
@@ -1,0 +1,269 @@
+using System.Drawing;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using NSubstitute;
+
+namespace MintPlayer.Spark.Tests;
+
+/// <summary>
+/// Covers the Phase 2 factory surface on <see cref="IEntityMapper"/>:
+/// NewPersistentObject(string|Guid|T), ToPersistentObject(T), and
+/// PopulateAttributeValues(PersistentObject, object, …) — including the
+/// Vidyano-parity silent-skip and dot-notation-skip rules, value-for-wire
+/// conversions (enum, Color), and Parent-back-reference invariants.
+/// </summary>
+public class EntityMapperFactoryTests
+{
+    private static readonly Guid CarTypeId = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+
+    private readonly IModelLoader _modelLoader = Substitute.For<IModelLoader>();
+    private readonly EntityMapper _mapper;
+
+    public EntityMapperFactoryTests()
+    {
+        var carTypeDef = new EntityTypeDefinition
+        {
+            Id = CarTypeId,
+            Name = "Car",
+            ClrType = typeof(TestCar).FullName!,
+            DisplayAttribute = "LicensePlate",
+            Attributes =
+            [
+                new EntityAttributeDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "LicensePlate",
+                    DataType = "string",
+                    Label = TranslatedString.Create("License plate"),
+                    IsRequired = true,
+                    Order = 1,
+                    Rules = [new ValidationRule { Type = "regex", Value = "^[A-Z]{3}-[0-9]{3}$" }],
+                    Renderer = "plate",
+                    RendererOptions = new Dictionary<string, object> { ["maxLength"] = 7 },
+                    Group = Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222"),
+                    ShowedOn = EShowedOn.PersistentObject,
+                },
+                new EntityAttributeDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Status",
+                    DataType = "string",
+                    Order = 2,
+                },
+                new EntityAttributeDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Color",
+                    DataType = "color",
+                    Order = 3,
+                },
+                new EntityAttributeDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Owner.Name", // dot-notation; populate must skip
+                    DataType = "string",
+                    Order = 4,
+                },
+            ],
+        };
+
+        _modelLoader.GetEntityType(CarTypeId).Returns(carTypeDef);
+        _modelLoader.GetEntityTypeByName("Car").Returns(carTypeDef);
+        _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(carTypeDef);
+
+        _mapper = new EntityMapper(_modelLoader);
+    }
+
+    // --- NewPersistentObject(string) --------------------------------------
+
+    [Fact]
+    public void NewPersistentObject_ByName_CopiesAllMetadataFieldsWithValuesNull()
+    {
+        var po = _mapper.NewPersistentObject("Car");
+
+        po.Name.Should().Be("Car");
+        po.ObjectTypeId.Should().Be(CarTypeId);
+        po.Id.Should().BeNull();
+        po.Attributes.Should().HaveCount(4);
+
+        var plate = po["LicensePlate"];
+        plate.DataType.Should().Be("string");
+        plate.Label!.GetValue("en").Should().Be("License plate");
+        plate.IsRequired.Should().BeTrue();
+        plate.Order.Should().Be(1);
+        plate.Rules.Should().HaveCount(1).And.Contain(r => r.Type == "regex");
+        plate.Renderer.Should().Be("plate");
+        plate.RendererOptions.Should().ContainKey("maxLength");
+        plate.Group.Should().Be(Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222"));
+        plate.ShowedOn.Should().Be(EShowedOn.PersistentObject);
+        plate.Value.Should().BeNull();
+        plate.Parent.Should().BeSameAs(po);
+    }
+
+    [Fact]
+    public void NewPersistentObject_ByName_Throws_WhenNameNotRegistered()
+    {
+        _modelLoader.GetEntityTypeByName("Unknown").Returns((EntityTypeDefinition?)null);
+
+        var act = () => _mapper.NewPersistentObject("Unknown");
+
+        act.Should().Throw<KeyNotFoundException>().WithMessage("*Unknown*");
+    }
+
+    // --- NewPersistentObject(Guid) ----------------------------------------
+
+    [Fact]
+    public void NewPersistentObject_ById_ReturnsEquivalentScaffold()
+    {
+        var byName = _mapper.NewPersistentObject("Car");
+        var byId = _mapper.NewPersistentObject(CarTypeId);
+
+        byId.Name.Should().Be(byName.Name);
+        byId.ObjectTypeId.Should().Be(byName.ObjectTypeId);
+        byId.Attributes.Select(a => a.Name).Should().Equal(byName.Attributes.Select(a => a.Name));
+    }
+
+    [Fact]
+    public void NewPersistentObject_ById_Throws_WhenIdNotRegistered()
+    {
+        var unknown = Guid.NewGuid();
+        _modelLoader.GetEntityType(unknown).Returns((EntityTypeDefinition?)null);
+
+        var act = () => _mapper.NewPersistentObject(unknown);
+
+        act.Should().Throw<KeyNotFoundException>().WithMessage($"*{unknown}*");
+    }
+
+    // --- NewPersistentObject<T>() -----------------------------------------
+
+    [Fact]
+    public void NewPersistentObject_Generic_ResolvesByClrType()
+    {
+        var po = _mapper.NewPersistentObject<TestCar>();
+
+        po.ObjectTypeId.Should().Be(CarTypeId);
+        po.Attributes.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void NewPersistentObject_Generic_Throws_WhenClrTypeNotRegistered()
+    {
+        var act = () => _mapper.NewPersistentObject<UnrelatedClass>();
+
+        act.Should().Throw<KeyNotFoundException>()
+            .WithMessage($"*{typeof(UnrelatedClass).FullName}*");
+    }
+
+    // --- PopulateAttributeValues ------------------------------------------
+
+    [Fact]
+    public void PopulateAttributeValues_FillsValueOnMatchingProperties()
+    {
+        var po = _mapper.NewPersistentObject("Car");
+        var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123", Status = TestCarStatus.Active };
+
+        _mapper.PopulateAttributeValues(po, car);
+
+        po["LicensePlate"].Value.Should().Be("ABC-123");
+        po["Status"].Value.Should().Be("Active", "enums convert to their string name for the wire");
+    }
+
+    [Fact]
+    public void PopulateAttributeValues_SetsIdNameAndBreadcrumb()
+    {
+        var po = _mapper.NewPersistentObject("Car");
+        var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123" };
+
+        _mapper.PopulateAttributeValues(po, car);
+
+        po.Id.Should().Be("cars/1");
+        po.Name.Should().Be("ABC-123", "DisplayAttribute=LicensePlate");
+        po.Breadcrumb.Should().Be("ABC-123");
+    }
+
+    [Fact]
+    public void PopulateAttributeValues_SkipsAttributesWithDotNotation()
+    {
+        var po = _mapper.NewPersistentObject("Car");
+        var car = new TestCar { LicensePlate = "ABC-123" };
+
+        _mapper.PopulateAttributeValues(po, car);
+
+        po["Owner.Name"].Value.Should().BeNull("dot-notation names are reserved for nested PO support (Vidyano parity)");
+    }
+
+    [Fact]
+    public void PopulateAttributeValues_LeavesValueNull_WhenPropertyMissing()
+    {
+        // Attribute "Color" exists on Car def; property exists on TestCar.
+        // Confirms: matching properties DO get populated, non-matching fall through silently.
+        var po = _mapper.NewPersistentObject("Car");
+        var car = new TestCar { LicensePlate = "ABC-123" }; // Color not set → stays default (empty)
+
+        _mapper.PopulateAttributeValues(po, car);
+
+        po["Color"].Value.Should().BeNull(
+            "Color.IsEmpty converts to null on the wire per the Color→hex conversion");
+    }
+
+    [Fact]
+    public void PopulateAttributeValues_ConvertsColorToHex()
+    {
+        var po = _mapper.NewPersistentObject("Car");
+        var car = new TestCar { LicensePlate = "ABC", Color = Color.FromArgb(0x12, 0x34, 0x56) };
+
+        _mapper.PopulateAttributeValues(po, car);
+
+        po["Color"].Value.Should().Be("#123456");
+    }
+
+    // --- ToPersistentObject<T> --------------------------------------------
+
+    [Fact]
+    public void ToPersistentObject_Generic_ResolvesGuidAndPopulates()
+    {
+        var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123", Status = TestCarStatus.Retired };
+
+        var po = _mapper.ToPersistentObject(car);
+
+        po.ObjectTypeId.Should().Be(CarTypeId);
+        po["LicensePlate"].Value.Should().Be("ABC-123");
+        po["Status"].Value.Should().Be("Retired");
+    }
+
+    [Fact]
+    public void ToPersistentObject_Generic_MatchesNonGenericOutput()
+    {
+        var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123" };
+
+        var viaGeneric = _mapper.ToPersistentObject(car);
+        var viaGuid = _mapper.ToPersistentObject(car, CarTypeId);
+
+        viaGeneric.Id.Should().Be(viaGuid.Id);
+        viaGeneric.Name.Should().Be(viaGuid.Name);
+        viaGeneric.ObjectTypeId.Should().Be(viaGuid.ObjectTypeId);
+        viaGeneric.Attributes.Select(a => (a.Name, a.Value?.ToString()))
+            .Should().Equal(viaGuid.Attributes.Select(a => (a.Name, a.Value?.ToString())));
+    }
+
+    // --- fixtures ---------------------------------------------------------
+
+    private sealed class TestCar
+    {
+        public string? Id { get; set; }
+        public string? LicensePlate { get; set; }
+        public TestCarStatus Status { get; set; }
+        public Color Color { get; set; }
+    }
+
+    private enum TestCarStatus
+    {
+        Active,
+        Retired,
+    }
+
+    private sealed class UnrelatedClass
+    {
+        public string? Anything { get; set; }
+    }
+}

--- a/MintPlayer.Spark.Tests/Services/ManagerTests.cs
+++ b/MintPlayer.Spark.Tests/Services/ManagerTests.cs
@@ -2,6 +2,7 @@ using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Retry;
 using MintPlayer.Spark.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace MintPlayer.Spark.Tests.Services;
 
@@ -10,47 +11,47 @@ public class ManagerTests
     private readonly IRetryAccessor _retry = Substitute.For<IRetryAccessor>();
     private readonly ITranslationsLoader _translations = Substitute.For<ITranslationsLoader>();
     private readonly IRequestCultureResolver _culture = Substitute.For<IRequestCultureResolver>();
+    private readonly IEntityMapper _entityMapper = Substitute.For<IEntityMapper>();
 
-    private Manager CreateManager() => new(_retry, _translations, _culture);
+    private Manager CreateManager() => new(_retry, _translations, _culture, _entityMapper);
 
     [Fact]
-    public void NewPersistentObject_Synthetic_ReturnsPoWithSuppliedAttributes()
+    public void NewPersistentObject_ByName_ForwardsToEntityMapper()
     {
+        var expected = new PersistentObject { Name = "Car", ObjectTypeId = Guid.NewGuid() };
+        _entityMapper.NewPersistentObject("Car").Returns(expected);
         var manager = CreateManager();
-        var plate = new PersistentObjectAttribute { Name = "LicensePlate", Value = "ABC-123" };
-        var model = new PersistentObjectAttribute { Name = "Model" };
 
-        var po = manager.NewPersistentObject("ConfirmDelete", plate, model);
+        var actual = manager.NewPersistentObject("Car");
 
-        po.Name.Should().Be("ConfirmDelete");
-        po.ObjectTypeId.Should().Be(Guid.Empty);
-        po.Id.Should().BeNull();
-        po.Attributes.Should().HaveCount(2);
-        po.Attributes.Should().ContainInOrder(plate, model);
+        actual.Should().BeSameAs(expected);
+        _entityMapper.Received(1).NewPersistentObject("Car");
     }
 
     [Fact]
-    public void NewPersistentObject_Synthetic_AttachesParentOnEverySuppliedAttribute()
+    public void NewPersistentObject_ByGuid_ForwardsToEntityMapper()
     {
+        var carId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var expected = new PersistentObject { Name = "Car", ObjectTypeId = carId };
+        _entityMapper.NewPersistentObject(carId).Returns(expected);
         var manager = CreateManager();
-        var plate = new PersistentObjectAttribute { Name = "LicensePlate" };
-        var model = new PersistentObjectAttribute { Name = "Model" };
 
-        var po = manager.NewPersistentObject("ConfirmDelete", plate, model);
+        var actual = manager.NewPersistentObject(carId);
 
-        plate.Parent.Should().BeSameAs(po, "AddAttribute sets Parent on each supplied attribute");
-        model.Parent.Should().BeSameAs(po);
+        actual.Should().BeSameAs(expected);
+        _entityMapper.Received(1).NewPersistentObject(carId);
     }
 
     [Fact]
-    public void NewPersistentObject_Synthetic_WithNoAttributes_ReturnsEmptyPo()
+    public void NewPersistentObject_UnknownName_PropagatesEntityMapperException()
     {
+        _entityMapper.NewPersistentObject("Unknown")
+            .Throws(new KeyNotFoundException("No entity type with Name 'Unknown' is registered."));
         var manager = CreateManager();
 
-        var po = manager.NewPersistentObject("Ping");
+        var act = () => manager.NewPersistentObject("Unknown");
 
-        po.Name.Should().Be("Ping");
-        po.ObjectTypeId.Should().Be(Guid.Empty);
-        po.Attributes.Should().BeEmpty();
+        act.Should().Throw<KeyNotFoundException>()
+            .WithMessage("*Unknown*");
     }
 }

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -28,6 +28,14 @@ public interface IEntityMapper
     PersistentObject NewPersistentObject(Guid id);
 
     /// <summary>
+    /// Scaffolds a blank PersistentObject for <typeparamref name="T"/>, resolving the
+    /// ObjectTypeId via <see cref="IModelLoader.GetEntityTypeByClrType"/>. Throws
+    /// <see cref="KeyNotFoundException"/> when no entity type is registered under
+    /// <c>typeof(T).FullName</c>.
+    /// </summary>
+    PersistentObject NewPersistentObject<T>() where T : class;
+
+    /// <summary>
     /// Fills <paramref name="po"/> with values reflected from <paramref name="entity"/>:
     /// Id / Name / Breadcrumb on the PO itself, and Value on every attribute that has
     /// a matching public readable property. Applies enum→string, <see cref="System.Drawing.Color"/>→
@@ -40,10 +48,25 @@ public interface IEntityMapper
     void PopulateAttributeValues(PersistentObject po, object entity, Dictionary<string, object>? includedDocuments = null);
 
     /// <summary>
+    /// Typed convenience overload of
+    /// <see cref="PopulateAttributeValues(PersistentObject, object, Dictionary{string, object}?)"/>.
+    /// </summary>
+    void PopulateAttributeValues<T>(PersistentObject po, T entity, Dictionary<string, object>? includedDocuments = null) where T : class;
+
+    /// <summary>
     /// Convenience wrapper: <see cref="NewPersistentObject(Guid)"/> + <see cref="PopulateAttributeValues"/>.
     /// Existing call sites (DatabaseAccess, QueryExecutor, StreamingQueryExecutor) keep this signature.
     /// </summary>
     PersistentObject ToPersistentObject(object entity, Guid objectTypeId, Dictionary<string, object>? includedDocuments = null);
+
+    /// <summary>
+    /// Typed convenience overload that derives the ObjectTypeId from
+    /// <c>typeof(T).FullName</c> via <see cref="IModelLoader.GetEntityTypeByClrType"/>.
+    /// Throws <see cref="KeyNotFoundException"/> when no entity type is registered
+    /// for the CLR type. Callers in framework internals that already have a Guid
+    /// (DatabaseAccess, QueryExecutor) continue to use the non-generic overload.
+    /// </summary>
+    PersistentObject ToPersistentObject<T>(T entity, Dictionary<string, object>? includedDocuments = null) where T : class;
 }
 
 [Register(typeof(IEntityMapper), ServiceLifetime.Scoped)]
@@ -97,6 +120,22 @@ internal partial class EntityMapper : IEntityMapper
         var def = modelLoader.GetEntityType(id)
             ?? throw new KeyNotFoundException($"No entity type with ObjectTypeId '{id}' is registered.");
         return ScaffoldFrom(def);
+    }
+
+    public PersistentObject NewPersistentObject<T>() where T : class
+        => ScaffoldFrom(ResolveDefByClrType(typeof(T)));
+
+    public PersistentObject ToPersistentObject<T>(T entity, Dictionary<string, object>? includedDocuments = null) where T : class
+        => ToPersistentObject(entity, ResolveDefByClrType(typeof(T)).Id, includedDocuments);
+
+    public void PopulateAttributeValues<T>(PersistentObject po, T entity, Dictionary<string, object>? includedDocuments = null) where T : class
+        => PopulateAttributeValues(po, (object)entity, includedDocuments);
+
+    private EntityTypeDefinition ResolveDefByClrType(Type clrType)
+    {
+        var name = clrType.FullName ?? clrType.Name;
+        return modelLoader.GetEntityTypeByClrType(name)
+            ?? throw new KeyNotFoundException($"No entity type registered for CLR type '{name}'.");
     }
 
     public PersistentObject ToPersistentObject(object entity, Guid objectTypeId, Dictionary<string, object>? includedDocuments = null)

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -10,6 +10,39 @@ public interface IEntityMapper
 {
     object ToEntity(PersistentObject persistentObject);
     T ToEntity<T>(PersistentObject persistentObject) where T : class;
+
+    /// <summary>
+    /// Scaffolds a blank PersistentObject from the schema named <paramref name="name"/>:
+    /// every declared attribute is created with full metadata (DataType, Label, Rules,
+    /// Renderer, ShowedOn, Order, Group, IsRequired/Visible/ReadOnly/Array, Query),
+    /// Value = null, Parent set. Throws <see cref="KeyNotFoundException"/> on unknown
+    /// or ambiguous name.
+    /// </summary>
+    PersistentObject NewPersistentObject(string name);
+
+    /// <summary>
+    /// Scaffolds a blank PersistentObject by ObjectTypeId. Preferred over the name
+    /// overload for apps that declare entities across multiple database schemas,
+    /// since IDs are unambiguous by construction.
+    /// </summary>
+    PersistentObject NewPersistentObject(Guid id);
+
+    /// <summary>
+    /// Fills <paramref name="po"/> with values reflected from <paramref name="entity"/>:
+    /// Id / Name / Breadcrumb on the PO itself, and Value on every attribute that has
+    /// a matching public readable property. Applies enum→string, <see cref="System.Drawing.Color"/>→
+    /// <c>#RRGGBB</c> hex, and AsDetail→dictionary conversions. When
+    /// <paramref name="includedDocuments"/> is supplied, Reference attributes gain a
+    /// Breadcrumb resolved from the target document. Attributes whose name has no
+    /// matching property on the entity are left with Value = null (Vidyano parity);
+    /// attributes whose name contains '.' are skipped.
+    /// </summary>
+    void PopulateAttributeValues(PersistentObject po, object entity, Dictionary<string, object>? includedDocuments = null);
+
+    /// <summary>
+    /// Convenience wrapper: <see cref="NewPersistentObject(Guid)"/> + <see cref="PopulateAttributeValues"/>.
+    /// Existing call sites (DatabaseAccess, QueryExecutor, StreamingQueryExecutor) keep this signature.
+    /// </summary>
     PersistentObject ToPersistentObject(object entity, Guid objectTypeId, Dictionary<string, object>? includedDocuments = null);
 }
 
@@ -52,109 +85,165 @@ internal partial class EntityMapper : IEntityMapper
         return entity;
     }
 
+    public PersistentObject NewPersistentObject(string name)
+    {
+        var def = modelLoader.GetEntityTypeByName(name)
+            ?? throw new KeyNotFoundException($"No entity type with Name '{name}' is registered.");
+        return ScaffoldFrom(def);
+    }
+
+    public PersistentObject NewPersistentObject(Guid id)
+    {
+        var def = modelLoader.GetEntityType(id)
+            ?? throw new KeyNotFoundException($"No entity type with ObjectTypeId '{id}' is registered.");
+        return ScaffoldFrom(def);
+    }
+
     public PersistentObject ToPersistentObject(object entity, Guid objectTypeId, Dictionary<string, object>? includedDocuments = null)
+    {
+        // `GetEntityType` may legitimately return null for projection / anonymous types
+        // that don't have a declared EntityTypeDefinition. In that case we produce an
+        // empty PO shell and let PopulateAttributeValues fill Id/Name.
+        var def = modelLoader.GetEntityType(objectTypeId);
+        var po = def is not null
+            ? ScaffoldFrom(def)
+            : new PersistentObject
+            {
+                Id = null,
+                Name = entity.GetType().Name,
+                ObjectTypeId = objectTypeId,
+            };
+
+        PopulateAttributeValues(po, entity, includedDocuments);
+        return po;
+    }
+
+    public void PopulateAttributeValues(PersistentObject po, object entity, Dictionary<string, object>? includedDocuments = null)
     {
         var entityType = entity.GetType();
         var idProperty = entityType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        var id = idProperty?.GetValue(entity)?.ToString();
+        po.Id = idProperty?.GetValue(entity)?.ToString();
 
-        // Get the entity type definition for attribute metadata
-        var entityTypeDef = modelLoader.GetEntityType(objectTypeId);
-
+        var entityTypeDef = modelLoader.GetEntityType(po.ObjectTypeId);
         var displayName = GetEntityDisplayName(entity, entityType, entityTypeDef);
+        po.Name = displayName;
+        po.Breadcrumb = displayName;
+
+        foreach (var attribute in po.Attributes)
+        {
+            // Vidyano parity: dot-notation names (nested paths) are not populated
+            // here — reserved for future PersistentObjectAttributeAsDetail support.
+            if (attribute.Name.Contains('.'))
+                continue;
+
+            var property = entityType.GetProperty(attribute.Name, BindingFlags.Public | BindingFlags.Instance);
+            if (property is null || !property.CanRead)
+                continue; // silent skip — attribute may be projection-only
+
+            var raw = property.GetValue(entity);
+            attribute.Value = ConvertValueForWire(raw, property.PropertyType, attribute);
+
+            // Reference attributes: resolve the display name of the referenced entity
+            // from the preloaded includedDocuments dict so the client can render a
+            // breadcrumb without a second round-trip.
+            if (attribute.DataType == "Reference"
+                && attribute.Value is string refId && !string.IsNullOrEmpty(refId)
+                && includedDocuments is not null
+                && includedDocuments.TryGetValue(refId, out var referencedEntity)
+                && referencedEntity is not null)
+            {
+                var referencedEntityType = referencedEntity.GetType();
+                var referencedEntityTypeDef = modelLoader.GetEntityTypeByClrType(
+                    referencedEntityType.FullName ?? referencedEntityType.Name);
+                attribute.Breadcrumb = GetEntityDisplayName(referencedEntity, referencedEntityType, referencedEntityTypeDef);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds a scaffold PO (metadata only, values null) from an entity type definition.
+    /// Shared by <see cref="NewPersistentObject(string)"/>, <see cref="NewPersistentObject(Guid)"/>,
+    /// and <see cref="ToPersistentObject(object, Guid, Dictionary{string, object}?)"/>.
+    /// </summary>
+    private static PersistentObject ScaffoldFrom(EntityTypeDefinition def)
+    {
         var po = new PersistentObject
         {
-            Id = id,
-            Name = displayName,
-            Breadcrumb = displayName,
-            ObjectTypeId = objectTypeId,
+            Id = null,
+            Name = def.Name,
+            ObjectTypeId = def.Id,
         };
 
-        // Iterate over the entity type definition's attributes (merged from collection + projection types)
-        // This ensures all attributes are included even if the entity doesn't have all properties
-        if (entityTypeDef?.Attributes != null)
+        if (def.Attributes is not null)
         {
-            foreach (var attrDef in entityTypeDef.Attributes)
-            {
-                // Try to get the property from the entity (may not exist if entity is a projection type)
-                var property = entityType.GetProperty(attrDef.Name, BindingFlags.Public | BindingFlags.Instance);
-                object? value = null;
-
-                if (property != null && property.CanRead)
-                {
-                    value = property.GetValue(entity);
-
-                    // Convert enum values to their string name for proper serialization
-                    var propType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
-                    if (propType.IsEnum && value != null)
-                    {
-                        value = value.ToString();
-                    }
-
-                    // Convert Color to hex string for frontend compatibility
-                    if (propType == typeof(Color) && value is Color colorValue)
-                    {
-                        value = colorValue.IsEmpty ? null : $"#{colorValue.R:x2}{colorValue.G:x2}{colorValue.B:x2}";
-                    }
-
-                    // For complex types (AsDetail), convert to dictionary for proper JSON serialization
-                    if (attrDef.DataType == "AsDetail" && value != null)
-                    {
-                        if (attrDef.IsArray && value is System.Collections.IEnumerable enumerable && value is not string)
-                        {
-                            var list = new List<Dictionary<string, object?>>();
-                            foreach (var item in enumerable)
-                            {
-                                list.Add(ConvertToSerializableDictionary(item));
-                            }
-                            value = list;
-                        }
-                        else if (!attrDef.IsArray)
-                        {
-                            value = ConvertToSerializableDictionary(value);
-                        }
-                    }
-                }
-
-                var attribute = new PersistentObjectAttribute
-                {
-                    Name = attrDef.Name,
-                    Label = attrDef.Label,
-                    Value = value,
-                    DataType = attrDef.DataType,
-                    IsArray = attrDef.IsArray,
-                    IsRequired = attrDef.IsRequired,
-                    IsVisible = attrDef.IsVisible,
-                    IsReadOnly = attrDef.IsReadOnly,
-                    Order = attrDef.Order,
-                    ShowedOn = attrDef.ShowedOn,
-                    Rules = attrDef.Rules ?? [],
-                    Group = attrDef.Group,
-                    Renderer = attrDef.Renderer,
-                    RendererOptions = attrDef.RendererOptions,
-                };
-
-                // Handle reference attributes - resolve breadcrumb from included documents
-                if (attrDef.DataType == "Reference" && value is string refId && !string.IsNullOrEmpty(refId) && includedDocuments != null)
-                {
-                    if (includedDocuments.TryGetValue(refId, out var referencedEntity) && referencedEntity != null)
-                    {
-                        var referencedEntityType = referencedEntity.GetType();
-                        var referencedEntityTypeDef = modelLoader.GetEntityTypeByClrType(referencedEntityType.FullName ?? referencedEntityType.Name);
-                        attribute.Breadcrumb = GetEntityDisplayName(referencedEntity, referencedEntityType, referencedEntityTypeDef);
-                    }
-                    attribute.Query = attrDef.Query;
-                }
-                else if (attrDef.DataType == "Reference")
-                {
-                    attribute.Query = attrDef.Query;
-                }
-
-                po.AddAttribute(attribute);
-            }
+            foreach (var attrDef in def.Attributes)
+                po.AddAttribute(FromDefinition(attrDef));
         }
 
         return po;
+    }
+
+    /// <summary>
+    /// Pure function: 14-field metadata copy from an <see cref="EntityAttributeDefinition"/>
+    /// into a blank <see cref="PersistentObjectAttribute"/>. Single canonical owner of
+    /// "which fields travel from schema to wire". Value stays null; populate step fills it.
+    /// </summary>
+    private static PersistentObjectAttribute FromDefinition(EntityAttributeDefinition def)
+        => new()
+        {
+            Name = def.Name,
+            Label = def.Label,
+            DataType = def.DataType,
+            IsArray = def.IsArray,
+            IsRequired = def.IsRequired,
+            IsVisible = def.IsVisible,
+            IsReadOnly = def.IsReadOnly,
+            Order = def.Order,
+            ShowedOn = def.ShowedOn,
+            Rules = def.Rules ?? [],
+            Group = def.Group,
+            Renderer = def.Renderer,
+            RendererOptions = def.RendererOptions,
+            Query = def.DataType == "Reference" ? def.Query : null,
+            Value = null,
+        };
+
+    /// <summary>
+    /// Converts a raw property value to its wire representation:
+    /// <list type="bullet">
+    ///   <item>enums → string name</item>
+    ///   <item><see cref="Color"/> → <c>#RRGGBB</c> (or null if Empty)</item>
+    ///   <item>AsDetail single → dictionary</item>
+    ///   <item>AsDetail array → list of dictionaries</item>
+    ///   <item>everything else → passthrough</item>
+    /// </list>
+    /// </summary>
+    private static object? ConvertValueForWire(object? raw, Type propertyType, PersistentObjectAttribute attribute)
+    {
+        if (raw is null) return null;
+
+        var underlying = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+        if (underlying.IsEnum)
+            return raw.ToString();
+
+        if (underlying == typeof(Color) && raw is Color colorValue)
+            return colorValue.IsEmpty ? null : $"#{colorValue.R:x2}{colorValue.G:x2}{colorValue.B:x2}";
+
+        if (attribute.DataType == "AsDetail")
+        {
+            if (attribute.IsArray && raw is System.Collections.IEnumerable enumerable && raw is not string)
+            {
+                var list = new List<Dictionary<string, object?>>();
+                foreach (var item in enumerable)
+                    list.Add(ConvertToSerializableDictionary(item));
+                return list;
+            }
+            if (!attribute.IsArray)
+                return ConvertToSerializableDictionary(raw);
+        }
+
+        return raw;
     }
 
     private void SetPropertyValue(PropertyInfo property, object entity, object? value)

--- a/MintPlayer.Spark/Services/Manager.cs
+++ b/MintPlayer.Spark/Services/Manager.cs
@@ -10,21 +10,18 @@ internal sealed partial class Manager : IManager
     [Inject] private readonly IRetryAccessor retry;
     [Inject] private readonly ITranslationsLoader translationsLoader;
     [Inject] private readonly IRequestCultureResolver requestCultureResolver;
+    [Inject] private readonly IEntityMapper entityMapper;
 
     public IRetryAccessor Retry => retry;
 
-    public PersistentObject NewPersistentObject(string name, params PersistentObjectAttribute[] attributes)
-    {
-        var po = new PersistentObject
-        {
-            Id = null,
-            Name = name,
-            ObjectTypeId = Guid.Empty,
-        };
-        foreach (var attr in attributes)
-            po.AddAttribute(attr);
-        return po;
-    }
+    public PersistentObject NewPersistentObject(string name)
+        => entityMapper.NewPersistentObject(name);
+
+    public PersistentObject NewPersistentObject(Guid id)
+        => entityMapper.NewPersistentObject(id);
+
+    public PersistentObject NewPersistentObject<T>() where T : class
+        => entityMapper.NewPersistentObject<T>();
 
     public string GetTranslatedMessage(string key, params object[] parameters)
     {

--- a/docs/PRD-PersistentObjectFactory.md
+++ b/docs/PRD-PersistentObjectFactory.md
@@ -248,6 +248,11 @@ public interface IManager
     // legally repeat). Throws KeyNotFoundException if the id is unknown.
     PersistentObject NewPersistentObject(Guid id);
 
+    // NEW — typed convenience: derives ObjectTypeId from typeof(T).FullName
+    // via IModelLoader.GetEntityTypeByClrType. Cleanest call site when the
+    // caller has a typed entity class — no Guid plumbing, no string names.
+    PersistentObject NewPersistentObject<T>() where T : class;
+
     // existing
     IRetryAccessor Retry { get; }
     string GetTranslatedMessage(string key, params object[] parameters);
@@ -278,10 +283,21 @@ public interface IEntityMapper
     // NEW — schema-backed factory keyed by ObjectTypeId. Never ambiguous.
     PersistentObject NewPersistentObject(Guid id);
 
+    // NEW — typed overload: resolves ObjectTypeId via
+    // IModelLoader.GetEntityTypeByClrType(typeof(T).FullName).
+    PersistentObject NewPersistentObject<T>() where T : class;
+
     // Existing surface — unchanged signature. Reimplemented internally as
     // NewPersistentObject(objectTypeId) + PopulateAttributeValues.
     PersistentObject ToPersistentObject(object entity, Guid objectTypeId,
         Dictionary<string, object>? includedDocuments = null);
+
+    // NEW — typed convenience that derives ObjectTypeId from typeof(T).FullName.
+    // Eliminates the Guid parameter at typed call sites. Framework internals
+    // (DatabaseAccess, QueryExecutor, StreamingQueryExecutor) continue to use
+    // the non-generic overload because they work with RavenDB-returned `object`.
+    PersistentObject ToPersistentObject<T>(T entity,
+        Dictionary<string, object>? includedDocuments = null) where T : class;
 
     // NEW — populate an already-scaffolded PO from an entity. Handles:
     //   - Id extraction (entity.Id → po.Id)
@@ -294,6 +310,11 @@ public interface IEntityMapper
     // Attributes whose name contains '.' are skipped (Vidyano parity).
     void PopulateAttributeValues(PersistentObject po, object entity,
         Dictionary<string, object>? includedDocuments = null);
+
+    // NEW — typed overload. Thin wrapper; PO already knows its ObjectTypeId,
+    // so <T> is purely call-site ergonomic.
+    void PopulateAttributeValues<T>(PersistentObject po, T entity,
+        Dictionary<string, object>? includedDocuments = null) where T : class;
 }
 ```
 
@@ -319,6 +340,9 @@ internal sealed partial class Manager : IManager
 
     public PersistentObject NewPersistentObject(Guid id)
         => entityMapper.NewPersistentObject(id);
+
+    public PersistentObject NewPersistentObject<T>() where T : class
+        => entityMapper.NewPersistentObject<T>();
 }
 ```
 
@@ -643,17 +667,26 @@ never introduce a second schema — zero migration cost.
    self-call, no `IManager` dependency.
 5. Add `IEntityMapper` injection to `Manager`; drop `IModelLoader` injection
    (no longer needed there).
-6. Implement `Manager.NewPersistentObject(string)` and
-   `Manager.NewPersistentObject(Guid)` as thin forwards.
-7. Tests:
-   - `ManagerTests.NewPersistentObjectTests` — both overloads copy all 14
-     metadata fields; throw on unknown name / id; name overload throws on
-     ambiguity (two schemas, same entity name).
-   - `EntityMapperTests.ToPersistentObject` — enum/Color/AsDetail conversions
-     (currently uncovered in `EntityMapperBreadcrumbTests`); existing 4
-     breadcrumb tests still pass.
-   - `EntityMapperTests.PopulateAttributeValues` — direct unit test of the
-     new method on a scaffold with various property shapes.
+6. Implement `Manager.NewPersistentObject(string)`,
+   `Manager.NewPersistentObject(Guid)`, and `Manager.NewPersistentObject<T>()`
+   as thin forwards to `IEntityMapper`.
+7. **Generic overloads** (added during Phase 2 implementation after a mid-flight
+   design check): `IEntityMapper.NewPersistentObject<T>()`,
+   `IEntityMapper.ToPersistentObject<T>(entity, includedDocuments?)`, and
+   `IEntityMapper.PopulateAttributeValues<T>(po, entity, includedDocuments?)`.
+   Resolve `ObjectTypeId` via `IModelLoader.GetEntityTypeByClrType(typeof(T).FullName)`,
+   with `KeyNotFoundException` on unknown/ambiguous CLR type. Eliminate the
+   Guid plumbing at typed call sites. The non-generic `object` overloads
+   stay for framework internals (`DatabaseAccess`, `QueryExecutor`,
+   `StreamingQueryExecutor`) that work with RavenDB-returned `object`.
+8. Tests:
+   - `ManagerTests` — forwarding to `IEntityMapper` via mock (3 tests).
+   - `EntityMapperFactoryTests` — all three `NewPersistentObject` overloads
+     (name / Guid / generic), `PopulateAttributeValues` happy/edge paths
+     (silent skip, dot-notation skip, enum→string, Color→hex), and
+     `ToPersistentObject<T>` parity with the Guid overload (13 tests).
+   - Existing `EntityMapperBreadcrumbTests` (4) still pass — the refactor
+     preserves byte-identical output for the 6 existing callers.
 
 **Phase 2b — `PersistentObjectIds` generator**
 
@@ -675,13 +708,13 @@ never introduce a second schema — zero migration cost.
    `entityMapper.NewPersistentObject(entityTypeDef.Id)` + value loop
    (inject `IEntityMapper` directly; no need to go through `IManager`).
    Keep CLR-fallback as a separate method.
-2. `PersistentObjectExtensions.ToPersistentObject<T>` — delete.
-3. `PersistentObjectExtensions.PopulateAttributeValues<T>` — delete (or
-   rewrite as a sugar wrapper that DI-resolves `IEntityMapper`; prefer
-   delete given preview-mode project state).
-4. Update any caller of the deleted extensions (grep first — the
-   call-site inventory agent found none inside the framework, but public
-   API may have external Demo-app callers).
+2. ~~`PersistentObjectExtensions.ToPersistentObject<T>` — delete.~~
+   **Done in PR #125** (pulled forward from Phase 3 to bump patch coverage
+   on the Phase 1 PR).
+3. ~~`PersistentObjectExtensions.PopulateAttributeValues<T>` — delete.~~
+   **Done in PR #125.**
+4. ~~Update any caller of the deleted extensions.~~ **Done in PR #125** —
+   grep confirmed zero framework callers before deletion.
 
 **Phase 4 — Test migration**
 


### PR DESCRIPTION
## Summary

Second slice of [`docs/PRD-PersistentObjectFactory.md`](./docs/PRD-PersistentObjectFactory.md). Promotes scaffold-then-populate to the framework's canonical entity→PO path and layers generic convenience overloads on top.

**Two commits:**

1. `5eaa399` — `EntityMapper.ToPersistentObject`'s 104-line inline body split into `FromDefinition` (private static, the single 14-field metadata copy) → `ScaffoldFrom` (blank PO + loop) → `NewPersistentObject(string|Guid)` + `PopulateAttributeValues(po, entity, …)`. `ToPersistentObject(entity, objectTypeId)` becomes a 3-line wrapper. All 6 existing callers unchanged. Vidyano parity: silent skip on non-matching property names, dot-notation-skip for future `PersistentObjectAttributeAsDetail`.

2. `7bfd7fa` — Generic overloads that derive `ObjectTypeId` from CLR type:
   - `mapper.NewPersistentObject<Car>()` — no Guid plumbing
   - `mapper.ToPersistentObject(car)` — no Guid plumbing
   - `mapper.PopulateAttributeValues(po, car)` — typed convenience
   - `IManager.NewPersistentObject<T>()` same story at the user-facing surface
   - `IManager` drops the old `NewPersistentObject(name, params attrs)` synthetic overload — popup POs are Virtual POs in JSON going forward
   - `Manager` thin-forwards; drops `IModelLoader` dep, injects `IEntityMapper`

## Test plan

- [x] 324 unit tests green (was 311; +13 net)
  - 13 new `EntityMapperFactoryTests` covering all three `NewPersistentObject` overloads, `PopulateAttributeValues` happy/edge paths (dot-notation skip, silent skip, enum→string, Color→hex), `ToPersistentObject<T>` parity with the Guid overload
  - `ManagerTests` rewritten to mock `IEntityMapper` and assert forwarding (3 tests)
  - Existing `EntityMapperBreadcrumbTests` (4) still green — the refactor preserves byte-identical output for the 6 existing `ToPersistentObject` callers
- [x] E2E tests build green — wire format unchanged
- [ ] E2E tests run green (pending CI)

## Phase roadmap

- [x] **Phase 1** — DTO + ownership plumbing (merged in #125)
- [x] **Phase 2** — mapper factory + populate + generics (this PR)
- [ ] **Phase 2b** — `PersistentObjectIds` generator (follow-up commit on this branch)
- [ ] **Phase 3** — `SyncActionHandler.BuildPersistentObject` schema-branch migration
- [ ] **Phase 4** — E2E test migration (shared builders using `PersistentObjectNames.*` / `AttributeNames.*`)
- [ ] **Phase 5** — Demo apps (opportunity-based)

Draft — Phase 2b will land on this branch before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)