### PR TITLE
feat: PersistentObject factory — Phase 3 (SyncActionHandler migration)

### DIFF
--- a/MintPlayer.Spark.Tests/Services/SyncActionHandlerBuildPersistentObjectTests.cs
+++ b/MintPlayer.Spark.Tests/Services/SyncActionHandlerBuildPersistentObjectTests.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using NSubstitute;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="SyncActionHandler.BuildPersistentObject"/> after the Phase 3
+/// migration: the schema branch routes through <see cref="IEntityMapper.NewPersistentObject(Guid)"/>
+/// so attributes get the full 14-field metadata scaffold, and the CLR-reflection
+/// fallback stays inline for entity types without a registered definition.
+/// </summary>
+public class SyncActionHandlerBuildPersistentObjectTests
+{
+    private static readonly Guid CarTypeId = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+
+    private readonly IDocumentStore _documentStore = Substitute.For<IDocumentStore>();
+    private readonly IActionsResolver _actionsResolver = Substitute.For<IActionsResolver>();
+    private readonly IModelLoader _modelLoader = Substitute.For<IModelLoader>();
+    private readonly IEntityMapper _entityMapper = Substitute.For<IEntityMapper>();
+    private readonly ILogger<SyncActionHandler> _logger = Substitute.For<ILogger<SyncActionHandler>>();
+
+    private SyncActionHandler CreateHandler()
+        => new(_documentStore, _actionsResolver, _modelLoader, _entityMapper, _logger);
+
+    private sealed class TestCar { public string? Id { get; set; } public string? LicensePlate { get; set; } public int Year { get; set; } }
+    private sealed class UnregisteredEntity { public string? Id { get; set; } public string? Name { get; set; } }
+
+    // --- Schema path: via IEntityMapper.NewPersistentObject ----------------
+
+    [Fact]
+    public void BuildPersistentObject_Schema_UsesEntityMapperScaffold()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = CarTypeId,
+            Name = "Car",
+            ClrType = typeof(TestCar).FullName!,
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LicensePlate", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Year", DataType = "number" },
+            ],
+        };
+        _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
+
+        var scaffold = new PersistentObject
+        {
+            Name = "Car",
+            ObjectTypeId = CarTypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = "LicensePlate", DataType = "string", Label = TranslatedString.Create("License plate") },
+                new PersistentObjectAttribute { Name = "Year", DataType = "number" },
+            ],
+        };
+        _entityMapper.NewPersistentObject(CarTypeId).Returns(scaffold);
+
+        var data = new Dictionary<string, object?> { ["LicensePlate"] = "ABC-123", ["Year"] = 2024 };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(TestCar), "cars/1", data, properties: null);
+
+        po.Should().BeSameAs(scaffold);
+        po.Id.Should().Be("cars/1");
+        po["LicensePlate"].Value.Should().Be("ABC-123");
+        po["Year"].Value.Should().Be(2024);
+        po["LicensePlate"].Label!.GetValue("en").Should().Be("License plate",
+            "schema metadata from the mapper scaffold must survive the value overlay");
+    }
+
+    [Fact]
+    public void BuildPersistentObject_Schema_IsValueChanged_FromPropertySet()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = CarTypeId,
+            Name = "Car",
+            ClrType = typeof(TestCar).FullName!,
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LicensePlate", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Year", DataType = "number" },
+            ],
+        };
+        _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
+        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        {
+            Name = "Car",
+            ObjectTypeId = CarTypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = "LicensePlate" },
+                new PersistentObjectAttribute { Name = "Year" },
+            ],
+        });
+
+        var data = new Dictionary<string, object?> { ["LicensePlate"] = "ABC-123", ["Year"] = 2024 };
+        var properties = new[] { "LicensePlate" };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(TestCar), "cars/1", data, properties);
+
+        po["LicensePlate"].IsValueChanged.Should().BeTrue("explicitly listed in properties[]");
+        po["Year"].IsValueChanged.Should().BeFalse("not listed in properties[] — partial update");
+    }
+
+    [Fact]
+    public void BuildPersistentObject_Schema_IsValueChanged_FallsBackToHasValue_WhenNoProperties()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = CarTypeId,
+            Name = "Car",
+            ClrType = typeof(TestCar).FullName!,
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LicensePlate", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Year", DataType = "number" },
+            ],
+        };
+        _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
+        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        {
+            Name = "Car",
+            ObjectTypeId = CarTypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = "LicensePlate" },
+                new PersistentObjectAttribute { Name = "Year" },
+            ],
+        });
+
+        var data = new Dictionary<string, object?> { ["LicensePlate"] = "ABC-123" };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(TestCar), "cars/1", data, properties: null);
+
+        po["LicensePlate"].IsValueChanged.Should().BeTrue("full sync — present keys are changed");
+        po["Year"].IsValueChanged.Should().BeFalse("not present in incoming data");
+        po["Year"].Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildPersistentObject_Schema_NormalizesJsonElementValues()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = CarTypeId,
+            Name = "Car",
+            ClrType = typeof(TestCar).FullName!,
+            Attributes = [new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LicensePlate", DataType = "string" }],
+        };
+        _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
+        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        {
+            Name = "Car",
+            ObjectTypeId = CarTypeId,
+            Attributes = [new PersistentObjectAttribute { Name = "LicensePlate" }],
+        });
+
+        // HTTP path delivers JsonElement values
+        var json = """{"LicensePlate": "ABC-123"}""";
+        var element = JsonDocument.Parse(json).RootElement.GetProperty("LicensePlate");
+        var data = new Dictionary<string, object?> { ["LicensePlate"] = element };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(TestCar), "cars/1", data, properties: null);
+
+        po["LicensePlate"].Value.Should().Be("ABC-123",
+            "JsonElement → string normalization happens before value is stored");
+    }
+
+    // --- CLR-reflection fallback ------------------------------------------
+
+    [Fact]
+    public void BuildPersistentObject_UnregisteredType_UsesClrReflectionFallback()
+    {
+        _modelLoader.GetEntityTypeByClrType(typeof(UnregisteredEntity).FullName!)
+            .Returns((EntityTypeDefinition?)null);
+
+        var data = new Dictionary<string, object?> { ["Name"] = "Alice" };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(UnregisteredEntity), "x/1", data, properties: null);
+
+        po.Id.Should().Be("x/1");
+        po.ObjectTypeId.Should().Be(Guid.Empty, "no schema → no canonical ObjectTypeId");
+        po.Name.Should().Be("UnregisteredEntity");
+        po.Attributes.Should().ContainSingle(a => a.Name == "Name")
+            .Which.Value.Should().Be("Alice");
+
+        // The fallback must not reach the entity mapper — schema is unavailable.
+        _entityMapper.DidNotReceiveWithAnyArgs().NewPersistentObject(Arg.Any<Guid>());
+    }
+
+    [Fact]
+    public void BuildPersistentObject_UnregisteredType_SkipsIdProperty()
+    {
+        _modelLoader.GetEntityTypeByClrType(typeof(UnregisteredEntity).FullName!)
+            .Returns((EntityTypeDefinition?)null);
+
+        var data = new Dictionary<string, object?> { ["Id"] = "should-not-appear", ["Name"] = "Alice" };
+
+        var po = CreateHandler().BuildPersistentObject(typeof(UnregisteredEntity), "x/1", data, properties: null);
+
+        po.Attributes.Should().NotContain(a => a.Name == "Id",
+            "Id is the document identifier, not an attribute");
+    }
+}

--- a/MintPlayer.Spark/Services/SyncActionHandler.cs
+++ b/MintPlayer.Spark/Services/SyncActionHandler.cs
@@ -21,6 +21,7 @@ internal partial class SyncActionHandler : ISyncActionHandler
     [Inject] private readonly IDocumentStore documentStore;
     [Inject] private readonly IActionsResolver actionsResolver;
     [Inject] private readonly IModelLoader modelLoader;
+    [Inject] private readonly IEntityMapper entityMapper;
     [Inject] private readonly ILogger<SyncActionHandler> logger;
 
     // Cache: collection name → CLR entity type
@@ -60,72 +61,69 @@ internal partial class SyncActionHandler : ISyncActionHandler
     }
 
     /// <summary>
-    /// Builds a PersistentObject from the incoming sync action data dictionary.
-    /// Marks attributes as IsValueChanged based on the Properties array.
-    /// Uses the EntityTypeDefinition to construct proper attribute metadata.
+    /// Builds a PersistentObject from the incoming sync action data dictionary,
+    /// marking attributes as <c>IsValueChanged</c> based on the <paramref name="properties"/> list.
+    /// When an <see cref="EntityTypeDefinition"/> is registered for the entity type the
+    /// schema path runs through <see cref="IEntityMapper.NewPersistentObject(Guid)"/>, so
+    /// every attribute gets the canonical 14-field metadata; otherwise the CLR-reflection
+    /// fallback inventories the entity's public read/write properties (no schema available).
     /// </summary>
-    private PersistentObject BuildPersistentObject(Type entityType, string? documentId, Dictionary<string, object?> data, string[]? properties)
+    internal PersistentObject BuildPersistentObject(Type entityType, string? documentId, Dictionary<string, object?> data, string[]? properties)
     {
-        // Find the entity type definition for attribute metadata
         var entityTypeDef = FindEntityTypeDefinition(entityType);
         var propertySet = properties != null
             ? new HashSet<string>(properties, StringComparer.OrdinalIgnoreCase)
             : null;
 
+        if (entityTypeDef is null)
+            return BuildFromClrReflection(entityType, documentId, data, propertySet);
+
+        // Schema path — full metadata scaffolded by IEntityMapper, values overlaid from data dict.
+        var po = entityMapper.NewPersistentObject(entityTypeDef.Id);
+        po.Id = documentId;
+
+        foreach (var attribute in po.Attributes)
+        {
+            var hasValue = TryGetValue(data, attribute.Name, out var value);
+            attribute.Value = hasValue ? NormalizeValue(value) : null;
+            attribute.IsValueChanged = propertySet != null
+                ? propertySet.Contains(attribute.Name)
+                : hasValue;
+        }
+
+        return po;
+    }
+
+    /// <summary>
+    /// CLR-reflection fallback for entity types that have no registered
+    /// <see cref="EntityTypeDefinition"/>. No schema metadata is available, so attributes
+    /// carry only <c>Name</c>, <c>Value</c>, and <c>IsValueChanged</c>.
+    /// </summary>
+    private static PersistentObject BuildFromClrReflection(Type entityType, string? documentId, Dictionary<string, object?> data, HashSet<string>? propertySet)
+    {
         var po = new PersistentObject
         {
             Id = documentId,
-            ObjectTypeId = entityTypeDef?.Id ?? Guid.Empty,
-            Name = entityTypeDef?.Name ?? entityType.Name,
+            ObjectTypeId = Guid.Empty,
+            Name = entityType.Name,
         };
 
-        if (entityTypeDef?.Attributes != null)
+        foreach (var prop in entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
-            foreach (var attrDef in entityTypeDef.Attributes)
+            if (string.Equals(prop.Name, "Id", StringComparison.Ordinal)) continue;
+            if (!prop.CanRead || !prop.CanWrite) continue;
+
+            var hasValue = TryGetValue(data, prop.Name, out var value);
+            var isChanged = propertySet != null
+                ? propertySet.Contains(prop.Name)
+                : hasValue;
+
+            po.AddAttribute(new PersistentObjectAttribute
             {
-                var hasValue = TryGetValue(data, attrDef.Name, out var value);
-
-                var isChanged = propertySet != null
-                    ? propertySet.Contains(attrDef.Name)
-                    : hasValue;
-
-                po.AddAttribute(new PersistentObjectAttribute
-                {
-                    Name = attrDef.Name,
-                    Label = attrDef.Label,
-                    Value = hasValue ? NormalizeValue(value) : null,
-                    IsValueChanged = isChanged,
-                    DataType = attrDef.DataType,
-                    IsRequired = attrDef.IsRequired,
-                    IsVisible = attrDef.IsVisible,
-                    IsReadOnly = attrDef.IsReadOnly,
-                    Order = attrDef.Order,
-                    ShowedOn = attrDef.ShowedOn,
-                    Rules = attrDef.Rules ?? [],
-                });
-            }
-        }
-        else
-        {
-            // Fallback: build attributes from entity type's CLR properties
-            foreach (var prop in entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (string.Equals(prop.Name, "Id", StringComparison.Ordinal)) continue;
-                if (!prop.CanRead || !prop.CanWrite) continue;
-
-                var hasValue = TryGetValue(data, prop.Name, out var value);
-
-                var isChanged = propertySet != null
-                    ? propertySet.Contains(prop.Name)
-                    : hasValue;
-
-                po.AddAttribute(new PersistentObjectAttribute
-                {
-                    Name = prop.Name,
-                    Value = hasValue ? NormalizeValue(value) : null,
-                    IsValueChanged = isChanged,
-                });
-            }
+                Name = prop.Name,
+                Value = hasValue ? NormalizeValue(value) : null,
+                IsValueChanged = isChanged,
+            });
         }
 
         return po;


### PR DESCRIPTION
## Summary

Third slice of [`docs/PRD-PersistentObjectFactory.md`](./docs/PRD-PersistentObjectFactory.md). Routes `SyncActionHandler.BuildPersistentObject`'s schema branch through the canonical `IEntityMapper.NewPersistentObject(Guid)` scaffold.

**What changes**
- `SyncActionHandler` injects `IEntityMapper` and replaces its hand-rolled attribute-construction loop (which copied only 9 of the 14 schema metadata fields) with a call to `entityMapper.NewPersistentObject(def.Id)` + a value/IsValueChanged overlay pass. Attributes now consistently carry `Group`, `Renderer`, `RendererOptions`, `Query`, and `IsArray` that the old code silently dropped.
- CLR-reflection fallback extracted to `BuildFromClrReflection` for readability — unchanged behavior, just a method boundary so the schema path reads linearly.
- `BuildPersistentObject` goes private → internal (MintPlayer.Spark already has `InternalsVisibleTo` for the tests assembly) so unit tests can drive it without mocking RavenDB session plumbing.

## Test plan
- [x] 330 / 330 unit tests green (was 324; +6 new `SyncActionHandlerBuildPersistentObjectTests`)
- [x] Full-solution build clean
- [ ] E2E tests green — pending CI
- [ ] Sync action flow smoke-tested against demo app — verified only that the refactor compiles + unit tests pass; no actual sync runs here

## Phase roadmap
- [x] Phase 1 — DTO ownership plumbing (#125)
- [x] Phase 2 + 2b — mapper + generic overloads + PersistentObjectIds generator (#126)
- [x] **Phase 3 — SyncActionHandler migration (this PR)**
- [ ] Phase 4 — E2E Security test migration (shared builders using `PersistentObjectNames.*` / `AttributeNames.*` / `PersistentObjectIds.Default.Car`)
- [ ] Phase 5 — Demo apps (opportunity-based)
- [ ] Out-of-scope deferrals (popup modal rendering, richer `PopulateObjectValues`, CustomAction builder, nested `PersistentObjectAttributeAsDetail`, Vidyano naming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)