### PR TITLE
feat: PersistentObject factory — Phase 4 (E2E test migration)

### DIFF
--- a/MintPlayer.Spark.E2E.Tests/MintPlayer.Spark.E2E.Tests.csproj
+++ b/MintPlayer.Spark.E2E.Tests/MintPlayer.Spark.E2E.Tests.csproj
@@ -36,6 +36,14 @@
     <ProjectReference Include="..\MintPlayer.Spark.Client\MintPlayer.Spark.Client.csproj" />
     <!-- Auth extensions (LoginAsync/LogoutAsync/RegisterAsync/GetCurrentUserAsync). -->
     <ProjectReference Include="..\MintPlayer.Spark.Client.Authorization\MintPlayer.Spark.Client.Authorization.csproj" />
+    <!-- Runs the PersistentObjectIds generator against Fleet's Model JSONs so Security
+         tests can reference `PersistentObjectIds.Default.Car` instead of hardcoding the Guid. -->
+    <ProjectReference Include="..\MintPlayer.Spark.SourceGenerators\MintPlayer.Spark.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Feeds the PersistentObjectIds generator. E2E tests target Fleet, so we surface its schemas. -->
+    <AdditionalFiles Include="..\Demo\Fleet\Fleet\App_Data\Model\*.json" />
   </ItemGroup>
 
 </Project>

--- a/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs
@@ -13,8 +13,6 @@ namespace MintPlayer.Spark.E2E.Tests.Security;
 [Collection(FleetE2ECollection.Name)]
 public class AttributeWriteProtectionTests
 {
-    private static readonly Guid CarTypeId = Guid.Parse("facb6829-f2a1-4ae2-a046-6ba506e8c0ce");
-
     private readonly FleetE2ECollectionFixture _fixture;
     public AttributeWriteProtectionTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
 
@@ -23,18 +21,8 @@ public class AttributeWriteProtectionTests
         var client = await SparkClientFactory.ForFleetAsAdminAsync(_fixture.Host);
         try
         {
-            var plate = $"RO{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
-            var created = await client.CreatePersistentObjectAsync(new PersistentObject
-            {
-                Name = "Car",
-                ObjectTypeId = CarTypeId,
-                Attributes =
-                [
-                    new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
-                    new PersistentObjectAttribute { Name = "Model",        Value = "X1" },
-                    new PersistentObjectAttribute { Name = "Year",         Value = 2024 },
-                ],
-            });
+            var created = await client.CreatePersistentObjectAsync(
+                CarFixture.New(CarFixture.RandomLicensePlate(), model: "X1"));
             created.Id.Should().NotBeNullOrEmpty($"admin car create must return id\n--- Fleet log ---\n{_fixture.Host.RecentLog()}");
             return (client, created.Id!);
         }
@@ -54,12 +42,12 @@ public class AttributeWriteProtectionTests
             // Fleet's default Car schema has no IsReadOnly=true attribute. This test pins
             // shape: the server must never 500 on such a request. Success (2xx, silently
             // ignoring the field) or 4xx (explicit rejection) are both acceptable per PRD.
-            var po = await client.GetPersistentObjectAsync(CarTypeId, id);
+            var po = await client.GetPersistentObjectAsync(CarFixture.TypeId, id);
             po.Should().NotBeNull();
-            SetAttribute(po!, "LicensePlate", "ROMOD123");
+            po![CarFixture.AttributeNames.LicensePlate].Value = "ROMOD123";
 
             // Update succeeds (no read-only field on schema today) → no throw.
-            var saved = await client.UpdatePersistentObjectAsync(po!);
+            var saved = await client.UpdatePersistentObjectAsync(po);
             saved.Should().NotBeNull();
         }
     }
@@ -70,7 +58,7 @@ public class AttributeWriteProtectionTests
         var (client, id) = await LoginAndCreateCarAsync();
         using (client)
         {
-            var po = await client.GetPersistentObjectAsync(CarTypeId, id);
+            var po = await client.GetPersistentObjectAsync(CarFixture.TypeId, id);
             po.Should().NotBeNull();
 
             // Smuggle in an attribute that isn't in the Car schema. The framework must
@@ -91,16 +79,9 @@ public class AttributeWriteProtectionTests
             }
 
             // No throw → 2xx path. Re-fetch and assert the rogue field isn't echoed back.
-            var reread = await client.GetPersistentObjectAsync(CarTypeId, id);
+            var reread = await client.GetPersistentObjectAsync(CarFixture.TypeId, id);
             reread!.Attributes.Should().NotContain(a => a.Name == "IsAdmin",
                 "server must not echo back unknown client-supplied attributes");
         }
-    }
-
-    private static void SetAttribute(PersistentObject po, string name, object value)
-    {
-        var attr = po.Attributes.FirstOrDefault(a => a.Name == name)
-            ?? throw new InvalidOperationException($"Attribute '{name}' not on PO '{po.Id}'.");
-        attr.Value = value;
     }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs
@@ -23,60 +23,31 @@ public class ConcurrencyTests
     {
         using var client = await SparkClientFactory.ForFleetAsAdminAsync(_fixture.Host);
 
-        var carTypeId = Guid.Parse("facb6829-f2a1-4ae2-a046-6ba506e8c0ce");
-        var plate = $"CC{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
+        var plate = CarFixture.RandomLicensePlate("CC");
 
         // Create a car. Id is assigned server-side and returned on the created PO.
-        var newCar = new PersistentObject
-        {
-            Name = "Car",
-            ObjectTypeId = carTypeId,
-            Attributes =
-            [
-                new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
-                new PersistentObjectAttribute { Name = "Model", Value = "CC1" },
-                new PersistentObjectAttribute { Name = "Year", Value = 2024 },
-            ],
-        };
-        var created = await client.CreatePersistentObjectAsync(newCar);
+        var created = await client.CreatePersistentObjectAsync(CarFixture.New(plate, model: "CC1"));
         created.Id.Should().NotBeNullOrEmpty(
             $"create must return the server-assigned id\n--- Fleet log tail ---\n{_fixture.Host.RecentLog()}");
 
         // Read v1 and capture its etag — the stale snapshot both clients will be working from.
-        var v1 = await client.GetPersistentObjectAsync(carTypeId, created.Id!);
+        var v1 = await client.GetPersistentObjectAsync(CarFixture.TypeId, created.Id!);
         v1.Should().NotBeNull();
         var etagV1 = v1!.Etag;
         etagV1.Should().NotBeNullOrEmpty("server must surface the change vector as Etag for optimistic concurrency");
 
         // Client A writes first with the v1 etag → succeeds, server moves to v2.
-        SetAttribute(v1, "Year", 2025);
+        v1[CarFixture.AttributeNames.Year].Value = 2025;
         var v2 = await client.UpdatePersistentObjectAsync(v1);
         v2.Etag.Should().NotBe(etagV1);
 
         // Client B writes based on the stale v1 snapshot with the v1 etag — 409 expected.
-        var stale = new PersistentObject
-        {
-            Id = created.Id,
-            Etag = etagV1,
-            Name = "Car",
-            ObjectTypeId = carTypeId,
-            Attributes =
-            [
-                new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
-                new PersistentObjectAttribute { Name = "Model", Value = "CC1" },
-                new PersistentObjectAttribute { Name = "Year", Value = 2026 },
-            ],
-        };
+        var stale = CarFixture.New(plate, model: "CC1", year: 2026);
+        stale.Id = created.Id;
+        stale.Etag = etagV1;
 
         var ex = await Assert.ThrowsAsync<SparkClientException>(() => client.UpdatePersistentObjectAsync(stale));
         ex.StatusCode.Should().Be(HttpStatusCode.Conflict,
             "the second writer's request is based on a stale version and must be rejected with 409 Conflict");
-    }
-
-    private static void SetAttribute(PersistentObject po, string name, object value)
-    {
-        var attr = po.Attributes.FirstOrDefault(a => a.Name == name)
-            ?? throw new InvalidOperationException($"Attribute '{name}' not on PO '{po.Id}'.");
-        attr.Value = value;
     }
 }

--- a/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/NotFoundVsForbiddenTests.cs
@@ -19,8 +19,6 @@ namespace MintPlayer.Spark.E2E.Tests.Security;
 [Collection(FleetE2ECollection.Name)]
 public class NotFoundVsForbiddenTests
 {
-    private static readonly Guid CarTypeId = Guid.Parse("facb6829-f2a1-4ae2-a046-6ba506e8c0ce");
-
     private readonly FleetE2ECollectionFixture _fixture;
     public NotFoundVsForbiddenTests(FleetE2ECollectionFixture fixture) => _fixture = fixture;
 
@@ -31,18 +29,8 @@ public class NotFoundVsForbiddenTests
         string adminCarId;
         using (var adminClient = await SparkClientFactory.ForFleetAsAdminAsync(_fixture.Host))
         {
-            var plate = $"NF{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
-            var created = await adminClient.CreatePersistentObjectAsync(new PersistentObject
-            {
-                Name = "Car",
-                ObjectTypeId = CarTypeId,
-                Attributes =
-                [
-                    new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
-                    new PersistentObjectAttribute { Name = "Model",        Value = "M3" },
-                    new PersistentObjectAttribute { Name = "Year",         Value = 2024 },
-                ],
-            });
+            var created = await adminClient.CreatePersistentObjectAsync(
+                CarFixture.New(CarFixture.RandomLicensePlate("NF"), model: "M3"));
             adminCarId = created.Id
                 ?? throw new InvalidOperationException(
                     $"admin create returned no id\n--- Fleet log ---\n{_fixture.Host.RecentLog()}");
@@ -61,9 +49,9 @@ public class NotFoundVsForbiddenTests
         catch (SparkClientException) { /* email-confirmation gate is out of scope for this test */ }
 
         var nonExistent = await CaptureOutcomeAsync(() =>
-            plainClient.GetPersistentObjectAsync(CarTypeId, $"cars/definitely-does-not-exist-{Guid.NewGuid():N}"));
+            plainClient.GetPersistentObjectAsync(CarFixture.TypeId, $"cars/definitely-does-not-exist-{Guid.NewGuid():N}"));
         var forbidden = await CaptureOutcomeAsync(() =>
-            plainClient.GetPersistentObjectAsync(CarTypeId, adminCarId));
+            plainClient.GetPersistentObjectAsync(CarFixture.TypeId, adminCarId));
 
         forbidden.Should().Be(nonExistent,
             "the real-but-forbidden id and the nonexistent id must produce identical client outcomes — " +

--- a/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
+++ b/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs
@@ -16,7 +16,6 @@ namespace MintPlayer.Spark.E2E.Tests.Security;
 [Collection(FleetE2ECollection.Name)]
 public class RowLevelAuthzTests
 {
-    private static readonly Guid CarTypeId = Guid.Parse("facb6829-f2a1-4ae2-a046-6ba506e8c0ce");
     private static readonly Guid GetCarsQueryId = Guid.Parse("a20e8400-e29b-41d4-a716-446655440001");
 
     private readonly FleetE2ECollectionFixture _fixture;
@@ -34,19 +33,8 @@ public class RowLevelAuthzTests
         // Admin creates a car — CarActions stamps CreatedBy with the admin's id.
         using (var adminClient = await SparkClientFactory.ForFleetAsAdminAsync(_fixture.Host))
         {
-            var plate = $"RL{Guid.NewGuid():N}".Substring(0, 8).ToUpperInvariant();
-            var newCar = new PersistentObject
-            {
-                Name = "Car",
-                ObjectTypeId = CarTypeId,
-                Attributes =
-                [
-                    new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
-                    new PersistentObjectAttribute { Name = "Model", Value = "RL1" },
-                    new PersistentObjectAttribute { Name = "Year", Value = 2024 },
-                ],
-            };
-            var created = await adminClient.CreatePersistentObjectAsync(newCar);
+            var created = await adminClient.CreatePersistentObjectAsync(
+                CarFixture.New(CarFixture.RandomLicensePlate("RL"), model: "RL1"));
             created.Id.Should().NotBeNullOrEmpty(
                 $"admin car create must return id\n--- Fleet log tail ---\n{_fixture.Host.RecentLog()}");
 
@@ -74,7 +62,7 @@ public class RowLevelAuthzTests
             // User B has QueryReadEditNew/Car (entity-type check passes) but is not the
             // creator → row-level filter returns null (surfaced as 404 on the endpoint,
             // surfaced as null PO on the client — both shapes mean "invisible" per M-3).
-            var po = await userBClient.GetPersistentObjectAsync(CarTypeId, adminCarId);
+            var po = await userBClient.GetPersistentObjectAsync(CarFixture.TypeId, adminCarId);
             po.Should().BeNull("user B is not the creator and must not be able to load admin's car by id");
         }
     }
@@ -85,7 +73,7 @@ public class RowLevelAuthzTests
         var (userBClient, adminCarId) = await SeedTwoUsersAndAdminCarAsync();
         using (userBClient)
         {
-            var cars = await userBClient.ListPersistentObjectsAsync(CarTypeId);
+            var cars = await userBClient.ListPersistentObjectsAsync(CarFixture.TypeId);
 
             cars.Should().NotContain(po => po.Id == adminCarId,
                 "admin's car must be absent from user B's list response");
@@ -101,7 +89,7 @@ public class RowLevelAuthzTests
             // GetCars scoped to admin's car as the parent — the parent fetch must fail the
             // row-level gate and surface as 404 rather than silently run the query unscoped.
             var ex = await Assert.ThrowsAsync<SparkClientException>(
-                () => userBClient.ExecuteQueryAsync(GetCarsQueryId, parentId: adminCarId, parentType: "Car"));
+                () => userBClient.ExecuteQueryAsync(GetCarsQueryId, parentId: adminCarId, parentType: CarFixture.TypeName));
             ex.StatusCode.Should().Be(HttpStatusCode.NotFound,
                 "parent fetch must apply the row-level gate — cannot scope a query to an inaccessible parent");
         }

--- a/MintPlayer.Spark.E2E.Tests/_Infrastructure/CarFixture.cs
+++ b/MintPlayer.Spark.E2E.Tests/_Infrastructure/CarFixture.cs
@@ -1,0 +1,54 @@
+using MintPlayer.Spark.Abstractions;
+
+namespace MintPlayer.Spark.E2E.Tests._Infrastructure;
+
+/// <summary>
+/// Shared factory for the Fleet <c>Car</c> PersistentObject payloads used by the
+/// <c>Security/*Tests</c>. Collapses ~4 hand-built object initializers with magic
+/// strings into one constructor call, and pulls the Guid from the source-generated
+/// <see cref="PersistentObjectIds"/> constants (fed by
+/// <c>Demo/Fleet/Fleet/App_Data/Model/Car.json</c> via <c>&lt;AdditionalFiles&gt;</c>
+/// in the csproj), so schema drift in the Fleet model file flows through to the
+/// tests at compile time rather than failing mysteriously on the wire.
+/// </summary>
+internal static class CarFixture
+{
+    public const string TypeName = "Car";
+
+    /// <summary>Canonical <c>ObjectTypeId</c> for Fleet's Car. Resolved at compile time.</summary>
+    public static readonly Guid TypeId = Guid.Parse(PersistentObjectIds.Default.Car);
+
+    /// <summary>Attribute names exposed on Car. Keep in sync with Car.json.</summary>
+    public static class AttributeNames
+    {
+        public const string LicensePlate = "LicensePlate";
+        public const string Model = "Model";
+        public const string Year = "Year";
+    }
+
+    /// <summary>
+    /// Builds a fresh Car PO suitable for <c>CreatePersistentObjectAsync</c>. Callers
+    /// supply the license plate (usually a random one to avoid collisions across runs);
+    /// <paramref name="model"/> and <paramref name="year"/> take reasonable defaults
+    /// since most Security tests don't care about those values beyond "valid Car".
+    /// </summary>
+    public static PersistentObject New(string licensePlate, string model = "M1", int year = 2024)
+        => new()
+        {
+            Name = TypeName,
+            ObjectTypeId = TypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = AttributeNames.LicensePlate, Value = licensePlate },
+                new PersistentObjectAttribute { Name = AttributeNames.Model,        Value = model },
+                new PersistentObjectAttribute { Name = AttributeNames.Year,         Value = year },
+            ],
+        };
+
+    /// <summary>
+    /// Generates a unique 8-char uppercase license plate. Useful for create flows where
+    /// every test run needs a plate that won't collide with an existing document.
+    /// </summary>
+    public static string RandomLicensePlate(string prefix = "RO")
+        => $"{prefix}{Guid.NewGuid():N}"[..8].ToUpperInvariant();
+}


### PR DESCRIPTION
## Summary

Fourth slice of [`docs/PRD-PersistentObjectFactory.md`](./docs/PRD-PersistentObjectFactory.md). Migrates the four Security E2E tests off hand-built Car PO payloads onto a shared `CarFixture` builder that pulls its `ObjectTypeId` from the source-generated `PersistentObjectIds.Default.Car` constant.

**Diff shape**
- `MintPlayer.Spark.E2E.Tests/_Infrastructure/CarFixture.cs` — new. Single factory for the Car PO shape (type name / ObjectTypeId / attribute names) that the 4 Security tests share.
- Wired `MintPlayer.Spark.SourceGenerators` as an analyzer on `E2E.Tests` and added `..\Demo\Fleet\Fleet\App_Data\Model\*.json` as `<AdditionalFiles>`, so the `PersistentObjectIds` generator runs against Fleet's schemas and emits `PersistentObjectIds.Default.Car = "facb6829-..."` into the test assembly.
- Migrated `AttributeWriteProtectionTests`, `ConcurrencyTests`, `NotFoundVsForbiddenTests`, `RowLevelAuthzTests` — each loses its duplicated `CarTypeId` constant + 15-line object-initializer block + local `SetAttribute` helper. Tests now read as domain operations (`CarFixture.New(plate)`, `po[CarFixture.AttributeNames.Year].Value = 2025`).
- Net: **+85 / −95 lines** across 6 files; schema drift in `Fleet/App_Data/Model/Car.json` now surfaces at compile time rather than mysteriously on the wire.

**Before** (every Security test had this 15-line block):
```csharp
private static readonly Guid CarTypeId = Guid.Parse("facb6829-f2a1-4ae2-a046-6ba506e8c0ce");
// ...
var created = await client.CreatePersistentObjectAsync(new PersistentObject
{
    Name = "Car",
    ObjectTypeId = CarTypeId,
    Attributes =
    [
        new PersistentObjectAttribute { Name = "LicensePlate", Value = plate },
        new PersistentObjectAttribute { Name = "Model",        Value = "X1" },
        new PersistentObjectAttribute { Name = "Year",         Value = 2024 },
    ],
});
```

**After**:
```csharp
var created = await client.CreatePersistentObjectAsync(
    CarFixture.New(CarFixture.RandomLicensePlate(), model: "X1"));
```

## Test plan

- [x] 330 unit tests green (no change — this PR touches E2E.Tests only)
- [x] Solution build clean (Spark + Demo apps + all test assemblies)
- [x] `grep` for magic strings in migrated files returns zero hits
- [ ] E2E Security tests green — pending CI (`pull-request` workflow)

## Phase roadmap

- [x] Phase 1 — DTO ownership + CloneAndAdd (#125)
- [x] Phase 2 + 2b — mapper + generic overloads + PersistentObjectIds generator (#126)
- [x] Phase 3 — SyncActionHandler migration (#127)
- [x] **Phase 4 — E2E test migration (this PR)**
- [ ] Phase 5 — Demo apps (opportunity-based)
- [ ] Out-of-scope deferrals (popup modal rendering, richer `PopulateObjectValues`, CustomAction builder, nested `PersistentObjectAttributeAsDetail`, Vidyano naming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)