### PR TITLE
fix(ci): carryforward coverage flags so codecov/project stops misfiring on partial runs

### DIFF
--- a/.github/workflows/dotnet-build-master.yml
+++ b/.github/workflows/dotnet-build-master.yml
@@ -70,22 +70,74 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-playwright-
 
+    # Per-project test invocation so each coverage file lands at
+    # `{ProjectName}/coverage/{guid}/coverage.cobertura.xml` — matches the layout
+    # nx produces on PRs, and matches the glob pattern each flagged codecov
+    # upload step below uses.
     - name: Test
-      run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage" --results-directory coverage
+      run: |
+        set -e
+        for proj in \
+          MintPlayer.Spark.Tests \
+          MintPlayer.Spark.SourceGenerators.Tests \
+          MintPlayer.Spark.Client.Tests \
+          MintPlayer.Spark.E2E.Tests; do
+          echo "::group::dotnet test ${proj}"
+          dotnet test "${proj}" \
+            --no-restore \
+            --configuration Release \
+            --verbosity normal \
+            --collect:"XPlat Code Coverage" \
+            --results-directory "${proj}/coverage"
+          echo "::endgroup::"
+        done
       env:
         RAVENDB_LICENSE: ${{ secrets.RAVENDB_LICENSE }}
 
     - name: Test Angular libraries
       run: npx nx run-many --target=test --projects=@mintplayer/ng-spark,@mintplayer/ng-spark-auth
 
-    - name: Upload coverage to Codecov
-      if: always()
+    # Master runs every test project unconditionally — all four coverage files
+    # are present. Each uploads under its own flag so codecov's carryforward
+    # logic has a full, fresh baseline to serve to PRs where `nx affected`
+    # skipped one or more projects. See codecov.yml `flag_management`.
+    - name: Upload coverage (unit)
+      if: always() && hashFiles('MintPlayer.Spark.Tests/coverage/**/coverage.cobertura.xml') != ''
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: |
-          **/coverage/**/coverage.cobertura.xml
-          **/coverage/cobertura-coverage.xml
+        files: MintPlayer.Spark.Tests/coverage/**/coverage.cobertura.xml
+        flags: unit
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (sourcegen)
+      if: always() && hashFiles('MintPlayer.Spark.SourceGenerators.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.SourceGenerators.Tests/coverage/**/coverage.cobertura.xml
+        flags: sourcegen
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (client)
+      if: always() && hashFiles('MintPlayer.Spark.Client.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.Client.Tests/coverage/**/coverage.cobertura.xml
+        flags: client
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (e2e)
+      if: always() && hashFiles('MintPlayer.Spark.E2E.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.E2E.Tests/coverage/**/coverage.cobertura.xml
+        flags: e2e
         fail_ci_if_error: false
         verbose: true
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,13 +70,50 @@ jobs:
         NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
         RAVENDB_LICENSE: ${{ secrets.RAVENDB_LICENSE }}
 
-    - name: Upload coverage to Codecov
-      if: always()
+    # One codecov upload per test project, each tagged with its own flag.
+    # codecov.yml has `carryforward: true` on every flag — when nx affected
+    # skips a project on a given PR, codecov reuses that flag's last-known
+    # coverage instead of treating the missing lines as uncovered. That
+    # keeps `codecov/project` accurate on test-only / single-suite PRs.
+    # Each step gates on the presence of the corresponding coverage file
+    # (nx affected may have skipped the project, leaving no file) so a
+    # missing file is a no-op rather than a failure.
+    - name: Upload coverage (unit)
+      if: always() && hashFiles('MintPlayer.Spark.Tests/coverage/**/coverage.cobertura.xml') != ''
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: |
-          **/coverage/**/coverage.cobertura.xml
-          **/coverage/cobertura-coverage.xml
+        files: MintPlayer.Spark.Tests/coverage/**/coverage.cobertura.xml
+        flags: unit
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (sourcegen)
+      if: always() && hashFiles('MintPlayer.Spark.SourceGenerators.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.SourceGenerators.Tests/coverage/**/coverage.cobertura.xml
+        flags: sourcegen
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (client)
+      if: always() && hashFiles('MintPlayer.Spark.Client.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.Client.Tests/coverage/**/coverage.cobertura.xml
+        flags: client
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Upload coverage (e2e)
+      if: always() && hashFiles('MintPlayer.Spark.E2E.Tests/coverage/**/coverage.cobertura.xml') != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: MintPlayer.Spark.E2E.Tests/coverage/**/coverage.cobertura.xml
+        flags: e2e
         fail_ci_if_error: false
         verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,11 +10,39 @@ coverage:
         target: auto
         threshold: 2%
         informational: false
+        # Each flag below has carryforward: true. If a PR's CI run only covers
+        # a subset of flags (nx affected skipped the others), codecov reuses
+        # those flags' last-known coverage when computing the project total.
+        # Without this, project coverage tanks whenever nx skips any test
+        # project, even though no production code regressed.
+        carryforward_behavior: include
     patch:
       default:
         target: 40%
         threshold: 0%
         informational: false
+
+# Each test project uploads its coverage tagged with one of these flags.
+# The `pull-request.yml` workflow maps:
+#   MintPlayer.Spark.Tests                  → unit
+#   MintPlayer.Spark.SourceGenerators.Tests → sourcegen
+#   MintPlayer.Spark.Client.Tests           → client
+#   MintPlayer.Spark.E2E.Tests              → e2e
+# `carryforward: true` means "when this flag isn't uploaded on a given commit,
+# reuse the last commit's coverage under this flag" — which is exactly what's
+# needed to keep project coverage stable across nx-affected partial runs.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit
+      carryforward: true
+    - name: sourcegen
+      carryforward: true
+    - name: client
+      carryforward: true
+    - name: e2e
+      carryforward: true
 
 comment:
   layout: "reach, diff, flags, files"
@@ -33,5 +61,6 @@ ignore:
   - "MintPlayer.Spark.Testing/**"             # test helper library, not production
   - "MintPlayer.Spark.Tests/**"
   - "MintPlayer.Spark.SourceGenerators.Tests/**"
+  - "MintPlayer.Spark.Client.Tests/**"
   - "MintPlayer.Spark.E2E.Tests/**"
   - "node_packages/**"                        # Angular libs measured separately


### PR DESCRIPTION
## Summary

`codecov/project` has been failing with `-33%` on PRs that don't touch production code (#128 being the latest example). Root cause: `nx affected --target=test` runs only the affected test projects, producing a **partial** coverage report that codecov compares against master's **full-suite** baseline. No production code regressed — just different sample sizes — but the gate fires all the same.

This PR fixes it with codecov carryforward flags.

## How it works

- **`codecov.yml`** — each test project gets its own flag (`unit`, `sourcegen`, `client`, `e2e`) with `carryforward: true`. When a PR's CI doesn't upload a given flag, codecov uses that flag's last-known coverage from master. `carryforward_behavior: include` on the project status makes the project total pull those carryforward numbers in.
- **`.github/workflows/pull-request.yml`** — split the one `**/coverage/**` upload step into four flagged steps, each gated by `hashFiles()` so skipped projects are no-ops. The nx-affected runner already produces per-project coverage files at `{Project}/coverage/{guid}/coverage.cobertura.xml`, so the globs match without further changes.
- **`.github/workflows/dotnet-build-master.yml`** — the old single `dotnet test --results-directory coverage` dumped everything into a shared root dir with no way to tell which project each file came from. Split it into a per-project loop matching nx's layout. Master uploads all four flags on every run → keeps the carryforward baseline fresh.

## Test plan

Can't smoke-test the codecov-side logic locally, but:
- [x] `node -e 'yaml.load(...)'` parses all three files
- [x] Per-project coverage file layout verified locally: `dotnet test MintPlayer.Spark.Tests --results-directory MintPlayer.Spark.Tests/coverage` writes to `MintPlayer.Spark.Tests/coverage/{guid}/coverage.cobertura.xml` — matches the upload glob
- [x] Existing CI logs from PR #128 confirm nx invokes `dotnet test {proj} --results-directory=coverage` per-project; coverage lands under `{proj}/coverage/` — matches the upload glob
- [ ] `pull-request` workflow result on this PR itself will be the real proof (this PR touches only YAML, so patch coverage → N/A, and project coverage should hold steady)

## Impact

- **Test-only PRs** (fixtures, helpers, workflow tweaks) stop failing `codecov/project` with meaningless drops
- **Real regressions** still surface through the unchanged `threshold: 2%` project gate — carryforward fills in *missing* flags; it doesn't mask lowered coverage on flags that *did* upload
- **First master run after merge** re-seeds all four flags with fresh coverage, so carryforward has a correct baseline from the next PR onward

🤖 Generated with [Claude Code](https://claude.com/claude-code)