### PR TITLE
refactor: PersistentObject factory Followups-II — PRD + NewPersistentObject → GetPersistentObject

### DIFF
--- a/Demo/Fleet/Fleet.Library/VirtualObjects/ConfirmDeleteCar.cs
+++ b/Demo/Fleet/Fleet.Library/VirtualObjects/ConfirmDeleteCar.cs
@@ -4,7 +4,7 @@ namespace Fleet.VirtualObjects;
 /// Marker class for the <c>ConfirmDeleteCar</c> Virtual PO. Spark's
 /// <c>EntityTypeDefinition.ClrType</c> is required, so every schema registration needs a
 /// CLR type to resolve against — this class exists only to satisfy that shape. No
-/// persistence; instances are scaffolded via <c>manager.NewPersistentObject</c> and live
+/// persistence; instances are scaffolded via <c>manager.GetPersistentObject</c> and live
 /// for the duration of one retry-action round-trip in <c>CarActions.OnBeforeDeleteAsync</c>.
 /// </summary>
 public sealed class ConfirmDeleteCar

--- a/Demo/Fleet/Fleet/Actions/CarActions.cs
+++ b/Demo/Fleet/Fleet/Actions/CarActions.cs
@@ -78,7 +78,7 @@ public partial class CarActions : DefaultPersistentObjectActions<Car>
         // Virtual PO confirmation form — user must retype the plate. The Virtual PO is
         // scaffolded from Demo/Fleet/Fleet/App_Data/Model/ConfirmDeleteCar.json; the
         // populated values come back through manager.Retry.Result.PersistentObject.
-        var popup = manager.NewPersistentObject(Guid.Parse(PersistentObjectIds.Default.ConfirmDeleteCar));
+        var popup = manager.GetPersistentObject(Guid.Parse(PersistentObjectIds.Default.ConfirmDeleteCar));
         popup["LicensePlate"].Value = entity.LicensePlate;
 
         manager.Retry.Action(

--- a/MintPlayer.Spark.Abstractions/IManager.cs
+++ b/MintPlayer.Spark.Abstractions/IManager.cs
@@ -10,7 +10,7 @@ public interface IManager
     /// metadata (DataType, Label, Rules, Renderer, ShowedOn, Order, Group,
     /// IsRequired/Visible/ReadOnly/Array, Query for References); Value is null.
     /// Throws <see cref="KeyNotFoundException"/> on unknown or ambiguous name —
-    /// prefer the <see cref="NewPersistentObject(Guid)"/> overload in apps that
+    /// prefer the <see cref="GetPersistentObject(Guid)"/> overload in apps that
     /// declare entities across multiple database schemas.
     /// </summary>
     /// <remarks>
@@ -19,14 +19,14 @@ public interface IManager
     /// look it up by name, rather than constructing the PO and its attributes
     /// by hand.
     /// </remarks>
-    PersistentObject NewPersistentObject(string name);
+    PersistentObject GetPersistentObject(string name);
 
     /// <summary>
     /// Scaffolds a blank PersistentObject by ObjectTypeId. Unambiguous — preferred
     /// over the name overload whenever the caller already has the Guid
     /// (e.g. from the source-generated <c>PersistentObjectIds</c> constants).
     /// </summary>
-    PersistentObject NewPersistentObject(Guid id);
+    PersistentObject GetPersistentObject(Guid id);
 
     /// <summary>
     /// Scaffolds a blank PersistentObject for <typeparamref name="T"/>, resolving the
@@ -34,7 +34,7 @@ public interface IManager
     /// EntityTypeDefinitions. The cleanest path when the caller has a typed entity
     /// class — no Guid plumbing, no string names.
     /// </summary>
-    PersistentObject NewPersistentObject<T>() where T : class;
+    PersistentObject GetPersistentObject<T>() where T : class;
 
     /// <summary>
     /// Access to the Retry Action subsystem.

--- a/MintPlayer.Spark.Abstractions/PersistentObject.cs
+++ b/MintPlayer.Spark.Abstractions/PersistentObject.cs
@@ -150,7 +150,7 @@ public sealed class PersistentObjectAttributeAsDetail : PersistentObjectAttribut
     /// <summary>
     /// For <see cref="PersistentObjectAttribute.IsArray"/> = <c>false</c>: the single nested
     /// PO (or <c>null</c> when the CLR field is null). The mapper always scaffolds this on
-    /// <c>NewPersistentObject</c> so UIs can start from an empty-but-structured form.
+    /// <c>GetPersistentObject</c> so UIs can start from an empty-but-structured form.
     /// </summary>
     public PersistentObject? Object { get; set; }
 

--- a/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.IdsProducer.cs
+++ b/MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.IdsProducer.cs
@@ -31,7 +31,7 @@ namespace MintPlayer.Spark.SourceGenerators.Generators;
 /// }
 ///
 /// // Consumer
-/// var po = manager.NewPersistentObject(new Guid(PersistentObjectIds.Default.Car));
+/// var po = manager.GetPersistentObject(new Guid(PersistentObjectIds.Default.Car));
 /// </code>
 /// </example>
 public class PersistentObjectIdsProducer : Producer

--- a/MintPlayer.Spark.SourceGenerators/Models/PersistentObjectIdInfo.cs
+++ b/MintPlayer.Spark.SourceGenerators/Models/PersistentObjectIdInfo.cs
@@ -6,7 +6,7 @@ namespace MintPlayer.Spark.SourceGenerators.Models;
 /// A single entry harvested from a Spark Model JSON file (typically
 /// <c>App_Data/Model/*.json</c>). Feeds the <c>PersistentObjectIds</c> generator
 /// output — nested-by-schema <c>const string</c> Guids that user code can pass to
-/// <c>IManager.NewPersistentObject(Guid)</c>.
+/// <c>IManager.GetPersistentObject(Guid)</c>.
 /// </summary>
 [AutoValueComparer]
 public partial class PersistentObjectIdInfo

--- a/MintPlayer.Spark.Tests/EntityMapperAsDetailTests.cs
+++ b/MintPlayer.Spark.Tests/EntityMapperAsDetailTests.cs
@@ -117,9 +117,9 @@ public class EntityMapperAsDetailTests
     // --- Scaffold -------------------------------------------------------
 
     [Fact]
-    public void NewPersistentObject_SingleAsDetail_PreScaffoldsNestedPO()
+    public void GetPersistentObject_SingleAsDetail_PreScaffoldsNestedPO()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
 
         var addressAttr = po["Address"];
         addressAttr.Should().BeOfType<PersistentObjectAttributeAsDetail>();
@@ -133,9 +133,9 @@ public class EntityMapperAsDetailTests
     }
 
     [Fact]
-    public void NewPersistentObject_ArrayAsDetail_StartsWithEmptyList()
+    public void GetPersistentObject_ArrayAsDetail_StartsWithEmptyList()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
 
         var jobsAttr = (PersistentObjectAttributeAsDetail)po["Jobs"];
         jobsAttr.IsArray.Should().BeTrue();
@@ -149,7 +149,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateAttributeValues_SingleAsDetail_FillsNestedPO()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         var person = new TestPerson
         {
             FirstName = "Alice",
@@ -166,7 +166,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateAttributeValues_ArrayAsDetail_ScaffoldsOneChildPerItem()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         var person = new TestPerson
         {
             FirstName = "Alice",
@@ -190,7 +190,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateAttributeValues_NullSingleAsDetail_ClearsObject()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         var person = new TestPerson { FirstName = "Alice", Address = null };
 
         _mapper.PopulateAttributeValues(po, person);
@@ -201,7 +201,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateAttributeValues_EmptyArrayAsDetail_YieldsEmptyObjects()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         var person = new TestPerson { FirstName = "Alice", Jobs = [] };
 
         _mapper.PopulateAttributeValues(po, person);
@@ -214,7 +214,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateObjectValues_SingleAsDetail_InstantiatesAndFillsEntity()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object!["Street"].Value = "Rue 42";
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object!["City"].Value = "Ghent";
         po["FirstName"].Value = "Alice";
@@ -231,12 +231,12 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateObjectValues_ArrayAsDetail_BuildsListOfInstantiatedChildren()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         po["FirstName"].Value = "Alice";
 
-        var job1 = _mapper.NewPersistentObject<TestJob>();
+        var job1 = _mapper.GetPersistentObject<TestJob>();
         job1["Title"].Value = "Intern"; job1["Year"].Value = 2020;
-        var job2 = _mapper.NewPersistentObject<TestJob>();
+        var job2 = _mapper.GetPersistentObject<TestJob>();
         job2["Title"].Value = "Dev";    job2["Year"].Value = 2024;
         ((PersistentObjectAttributeAsDetail)po["Jobs"]).Objects = [job1, job2];
 
@@ -253,7 +253,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void PopulateObjectValues_NullSingleAsDetail_SetsPropertyNull()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object = null;
 
         var person = new TestPerson { Address = new TestAddress { Street = "stale" } };
@@ -342,7 +342,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void JsonConverter_SerializesAsDetailSubclassFields()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object!["Street"].Value = "Main 1";
 
         var json = JsonSerializer.Serialize(po);
@@ -354,7 +354,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void JsonConverter_DeserializesAsDetailBasedOnDataType()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object!["Street"].Value = "Main 1";
         ((PersistentObjectAttributeAsDetail)po["Address"]).Object!["City"].Value = "Brussels";
         var json = JsonSerializer.Serialize(po);
@@ -369,7 +369,7 @@ public class EntityMapperAsDetailTests
     [Fact]
     public void JsonConverter_NonAsDetailAttributeUsesBaseClass()
     {
-        var po = _mapper.NewPersistentObject<TestPerson>();
+        var po = _mapper.GetPersistentObject<TestPerson>();
         po["FirstName"].Value = "Alice";
         var json = JsonSerializer.Serialize(po);
 

--- a/MintPlayer.Spark.Tests/EntityMapperFactoryTests.cs
+++ b/MintPlayer.Spark.Tests/EntityMapperFactoryTests.cs
@@ -7,7 +7,7 @@ namespace MintPlayer.Spark.Tests;
 
 /// <summary>
 /// Covers the Phase 2 factory surface on <see cref="IEntityMapper"/>:
-/// NewPersistentObject(string|Guid|T), ToPersistentObject(T), and
+/// GetPersistentObject(string|Guid|T), ToPersistentObject(T), and
 /// PopulateAttributeValues(PersistentObject, object, …) — including the
 /// Vidyano-parity silent-skip and dot-notation-skip rules, value-for-wire
 /// conversions (enum, Color), and Parent-back-reference invariants.
@@ -74,12 +74,12 @@ public class EntityMapperFactoryTests
         _mapper = new EntityMapper(_modelLoader);
     }
 
-    // --- NewPersistentObject(string) --------------------------------------
+    // --- GetPersistentObject(string) --------------------------------------
 
     [Fact]
-    public void NewPersistentObject_ByName_CopiesAllMetadataFieldsWithValuesNull()
+    public void GetPersistentObject_ByName_CopiesAllMetadataFieldsWithValuesNull()
     {
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
 
         po.Name.Should().Be("Car");
         po.ObjectTypeId.Should().Be(CarTypeId);
@@ -101,22 +101,22 @@ public class EntityMapperFactoryTests
     }
 
     [Fact]
-    public void NewPersistentObject_ByName_Throws_WhenNameNotRegistered()
+    public void GetPersistentObject_ByName_Throws_WhenNameNotRegistered()
     {
         _modelLoader.GetEntityTypeByName("Unknown").Returns((EntityTypeDefinition?)null);
 
-        var act = () => _mapper.NewPersistentObject("Unknown");
+        var act = () => _mapper.GetPersistentObject("Unknown");
 
         act.Should().Throw<KeyNotFoundException>().WithMessage("*Unknown*");
     }
 
-    // --- NewPersistentObject(Guid) ----------------------------------------
+    // --- GetPersistentObject(Guid) ----------------------------------------
 
     [Fact]
-    public void NewPersistentObject_ById_ReturnsEquivalentScaffold()
+    public void GetPersistentObject_ById_ReturnsEquivalentScaffold()
     {
-        var byName = _mapper.NewPersistentObject("Car");
-        var byId = _mapper.NewPersistentObject(CarTypeId);
+        var byName = _mapper.GetPersistentObject("Car");
+        var byId = _mapper.GetPersistentObject(CarTypeId);
 
         byId.Name.Should().Be(byName.Name);
         byId.ObjectTypeId.Should().Be(byName.ObjectTypeId);
@@ -124,31 +124,31 @@ public class EntityMapperFactoryTests
     }
 
     [Fact]
-    public void NewPersistentObject_ById_Throws_WhenIdNotRegistered()
+    public void GetPersistentObject_ById_Throws_WhenIdNotRegistered()
     {
         var unknown = Guid.NewGuid();
         _modelLoader.GetEntityType(unknown).Returns((EntityTypeDefinition?)null);
 
-        var act = () => _mapper.NewPersistentObject(unknown);
+        var act = () => _mapper.GetPersistentObject(unknown);
 
         act.Should().Throw<KeyNotFoundException>().WithMessage($"*{unknown}*");
     }
 
-    // --- NewPersistentObject<T>() -----------------------------------------
+    // --- GetPersistentObject<T>() -----------------------------------------
 
     [Fact]
-    public void NewPersistentObject_Generic_ResolvesByClrType()
+    public void GetPersistentObject_Generic_ResolvesByClrType()
     {
-        var po = _mapper.NewPersistentObject<TestCar>();
+        var po = _mapper.GetPersistentObject<TestCar>();
 
         po.ObjectTypeId.Should().Be(CarTypeId);
         po.Attributes.Should().HaveCount(4);
     }
 
     [Fact]
-    public void NewPersistentObject_Generic_Throws_WhenClrTypeNotRegistered()
+    public void GetPersistentObject_Generic_Throws_WhenClrTypeNotRegistered()
     {
-        var act = () => _mapper.NewPersistentObject<UnrelatedClass>();
+        var act = () => _mapper.GetPersistentObject<UnrelatedClass>();
 
         act.Should().Throw<KeyNotFoundException>()
             .WithMessage($"*{typeof(UnrelatedClass).FullName}*");
@@ -159,7 +159,7 @@ public class EntityMapperFactoryTests
     [Fact]
     public void PopulateAttributeValues_FillsValueOnMatchingProperties()
     {
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
         var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123", Status = TestCarStatus.Active };
 
         _mapper.PopulateAttributeValues(po, car);
@@ -171,7 +171,7 @@ public class EntityMapperFactoryTests
     [Fact]
     public void PopulateAttributeValues_SetsIdNameAndBreadcrumb()
     {
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
         var car = new TestCar { Id = "cars/1", LicensePlate = "ABC-123" };
 
         _mapper.PopulateAttributeValues(po, car);
@@ -184,7 +184,7 @@ public class EntityMapperFactoryTests
     [Fact]
     public void PopulateAttributeValues_SkipsAttributesWithDotNotation()
     {
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
         var car = new TestCar { LicensePlate = "ABC-123" };
 
         _mapper.PopulateAttributeValues(po, car);
@@ -197,7 +197,7 @@ public class EntityMapperFactoryTests
     {
         // Attribute "Color" exists on Car def; property exists on TestCar.
         // Confirms: matching properties DO get populated, non-matching fall through silently.
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
         var car = new TestCar { LicensePlate = "ABC-123" }; // Color not set → stays default (empty)
 
         _mapper.PopulateAttributeValues(po, car);
@@ -209,7 +209,7 @@ public class EntityMapperFactoryTests
     [Fact]
     public void PopulateAttributeValues_ConvertsColorToHex()
     {
-        var po = _mapper.NewPersistentObject("Car");
+        var po = _mapper.GetPersistentObject("Car");
         var car = new TestCar { LicensePlate = "ABC", Color = Color.FromArgb(0x12, 0x34, 0x56) };
 
         _mapper.PopulateAttributeValues(po, car);

--- a/MintPlayer.Spark.Tests/Services/ManagerTests.cs
+++ b/MintPlayer.Spark.Tests/Services/ManagerTests.cs
@@ -16,40 +16,40 @@ public class ManagerTests
     private Manager CreateManager() => new(_retry, _translations, _culture, _entityMapper);
 
     [Fact]
-    public void NewPersistentObject_ByName_ForwardsToEntityMapper()
+    public void GetPersistentObject_ByName_ForwardsToEntityMapper()
     {
         var expected = new PersistentObject { Name = "Car", ObjectTypeId = Guid.NewGuid() };
-        _entityMapper.NewPersistentObject("Car").Returns(expected);
+        _entityMapper.GetPersistentObject("Car").Returns(expected);
         var manager = CreateManager();
 
-        var actual = manager.NewPersistentObject("Car");
+        var actual = manager.GetPersistentObject("Car");
 
         actual.Should().BeSameAs(expected);
-        _entityMapper.Received(1).NewPersistentObject("Car");
+        _entityMapper.Received(1).GetPersistentObject("Car");
     }
 
     [Fact]
-    public void NewPersistentObject_ByGuid_ForwardsToEntityMapper()
+    public void GetPersistentObject_ByGuid_ForwardsToEntityMapper()
     {
         var carId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var expected = new PersistentObject { Name = "Car", ObjectTypeId = carId };
-        _entityMapper.NewPersistentObject(carId).Returns(expected);
+        _entityMapper.GetPersistentObject(carId).Returns(expected);
         var manager = CreateManager();
 
-        var actual = manager.NewPersistentObject(carId);
+        var actual = manager.GetPersistentObject(carId);
 
         actual.Should().BeSameAs(expected);
-        _entityMapper.Received(1).NewPersistentObject(carId);
+        _entityMapper.Received(1).GetPersistentObject(carId);
     }
 
     [Fact]
-    public void NewPersistentObject_UnknownName_PropagatesEntityMapperException()
+    public void GetPersistentObject_UnknownName_PropagatesEntityMapperException()
     {
-        _entityMapper.NewPersistentObject("Unknown")
+        _entityMapper.GetPersistentObject("Unknown")
             .Throws(new KeyNotFoundException("No entity type with Name 'Unknown' is registered."));
         var manager = CreateManager();
 
-        var act = () => manager.NewPersistentObject("Unknown");
+        var act = () => manager.GetPersistentObject("Unknown");
 
         act.Should().Throw<KeyNotFoundException>()
             .WithMessage("*Unknown*");

--- a/MintPlayer.Spark.Tests/Services/SyncActionHandlerBuildPersistentObjectTests.cs
+++ b/MintPlayer.Spark.Tests/Services/SyncActionHandlerBuildPersistentObjectTests.cs
@@ -9,7 +9,7 @@ namespace MintPlayer.Spark.Tests.Services;
 
 /// <summary>
 /// Covers <see cref="SyncActionHandler.BuildPersistentObject"/> after the Phase 3
-/// migration: the schema branch routes through <see cref="IEntityMapper.NewPersistentObject(Guid)"/>
+/// migration: the schema branch routes through <see cref="IEntityMapper.GetPersistentObject(Guid)"/>
 /// so attributes get the full 14-field metadata scaffold, and the CLR-reflection
 /// fallback stays inline for entity types without a registered definition.
 /// </summary>
@@ -29,7 +29,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
     private sealed class TestCar { public string? Id { get; set; } public string? LicensePlate { get; set; } public int Year { get; set; } }
     private sealed class UnregisteredEntity { public string? Id { get; set; } public string? Name { get; set; } }
 
-    // --- Schema path: via IEntityMapper.NewPersistentObject ----------------
+    // --- Schema path: via IEntityMapper.GetPersistentObject ----------------
 
     [Fact]
     public void BuildPersistentObject_Schema_UsesEntityMapperScaffold()
@@ -57,7 +57,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
                 new PersistentObjectAttribute { Name = "Year", DataType = "number" },
             ],
         };
-        _entityMapper.NewPersistentObject(CarTypeId).Returns(scaffold);
+        _entityMapper.GetPersistentObject(CarTypeId).Returns(scaffold);
 
         var data = new Dictionary<string, object?> { ["LicensePlate"] = "ABC-123", ["Year"] = 2024 };
 
@@ -86,7 +86,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
             ],
         };
         _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
-        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        _entityMapper.GetPersistentObject(CarTypeId).Returns(new PersistentObject
         {
             Name = "Car",
             ObjectTypeId = CarTypeId,
@@ -121,7 +121,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
             ],
         };
         _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
-        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        _entityMapper.GetPersistentObject(CarTypeId).Returns(new PersistentObject
         {
             Name = "Car",
             ObjectTypeId = CarTypeId,
@@ -152,7 +152,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
             Attributes = [new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LicensePlate", DataType = "string" }],
         };
         _modelLoader.GetEntityTypeByClrType(typeof(TestCar).FullName!).Returns(def);
-        _entityMapper.NewPersistentObject(CarTypeId).Returns(new PersistentObject
+        _entityMapper.GetPersistentObject(CarTypeId).Returns(new PersistentObject
         {
             Name = "Car",
             ObjectTypeId = CarTypeId,
@@ -189,7 +189,7 @@ public class SyncActionHandlerBuildPersistentObjectTests
             .Which.Value.Should().Be("Alice");
 
         // The fallback must not reach the entity mapper — schema is unavailable.
-        _entityMapper.DidNotReceiveWithAnyArgs().NewPersistentObject(Arg.Any<Guid>());
+        _entityMapper.DidNotReceiveWithAnyArgs().GetPersistentObject(Arg.Any<Guid>());
     }
 
     [Fact]

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -19,14 +19,14 @@ public interface IEntityMapper
     /// Value = null, Parent set. Throws <see cref="KeyNotFoundException"/> on unknown
     /// or ambiguous name.
     /// </summary>
-    PersistentObject NewPersistentObject(string name);
+    PersistentObject GetPersistentObject(string name);
 
     /// <summary>
     /// Scaffolds a blank PersistentObject by ObjectTypeId. Preferred over the name
     /// overload for apps that declare entities across multiple database schemas,
     /// since IDs are unambiguous by construction.
     /// </summary>
-    PersistentObject NewPersistentObject(Guid id);
+    PersistentObject GetPersistentObject(Guid id);
 
     /// <summary>
     /// Scaffolds a blank PersistentObject for <typeparamref name="T"/>, resolving the
@@ -34,7 +34,7 @@ public interface IEntityMapper
     /// <see cref="KeyNotFoundException"/> when no entity type is registered under
     /// <c>typeof(T).FullName</c>.
     /// </summary>
-    PersistentObject NewPersistentObject<T>() where T : class;
+    PersistentObject GetPersistentObject<T>() where T : class;
 
     /// <summary>
     /// Fills <paramref name="po"/> with values reflected from <paramref name="entity"/>:
@@ -55,7 +55,7 @@ public interface IEntityMapper
     void PopulateAttributeValues<T>(PersistentObject po, T entity, Dictionary<string, object>? includedDocuments = null) where T : class;
 
     /// <summary>
-    /// Convenience wrapper: <see cref="NewPersistentObject(Guid)"/> + <see cref="PopulateAttributeValues"/>.
+    /// Convenience wrapper: <see cref="GetPersistentObject(Guid)"/> + <see cref="PopulateAttributeValues"/>.
     /// Existing call sites (DatabaseAccess, QueryExecutor, StreamingQueryExecutor) keep this signature.
     /// </summary>
     PersistentObject ToPersistentObject(object entity, Guid objectTypeId, Dictionary<string, object>? includedDocuments = null);
@@ -126,21 +126,21 @@ internal partial class EntityMapper : IEntityMapper
         return entity;
     }
 
-    public PersistentObject NewPersistentObject(string name)
+    public PersistentObject GetPersistentObject(string name)
     {
         var def = modelLoader.GetEntityTypeByName(name)
             ?? throw new KeyNotFoundException($"No entity type with Name '{name}' is registered.");
         return ScaffoldFrom(def);
     }
 
-    public PersistentObject NewPersistentObject(Guid id)
+    public PersistentObject GetPersistentObject(Guid id)
     {
         var def = modelLoader.GetEntityType(id)
             ?? throw new KeyNotFoundException($"No entity type with ObjectTypeId '{id}' is registered.");
         return ScaffoldFrom(def);
     }
 
-    public PersistentObject NewPersistentObject<T>() where T : class
+    public PersistentObject GetPersistentObject<T>() where T : class
         => ScaffoldFrom(ResolveDefByClrType(typeof(T)));
 
     public PersistentObject ToPersistentObject<T>(T entity, Dictionary<string, object>? includedDocuments = null) where T : class
@@ -315,7 +315,7 @@ internal partial class EntityMapper : IEntityMapper
 
     /// <summary>
     /// Builds a scaffold PO (metadata only, values null) from an entity type definition.
-    /// Shared by <see cref="NewPersistentObject(string)"/>, <see cref="NewPersistentObject(Guid)"/>,
+    /// Shared by <see cref="GetPersistentObject(string)"/>, <see cref="GetPersistentObject(Guid)"/>,
     /// and <see cref="ToPersistentObject(object, Guid, Dictionary{string, object}?)"/>.
     /// Recurses through AsDetail attributes: for single AsDetail, the nested child PO is
     /// pre-scaffolded so UIs render an empty-but-structured form; for array AsDetail,

--- a/MintPlayer.Spark/Services/Manager.cs
+++ b/MintPlayer.Spark/Services/Manager.cs
@@ -14,14 +14,14 @@ internal sealed partial class Manager : IManager
 
     public IRetryAccessor Retry => retry;
 
-    public PersistentObject NewPersistentObject(string name)
-        => entityMapper.NewPersistentObject(name);
+    public PersistentObject GetPersistentObject(string name)
+        => entityMapper.GetPersistentObject(name);
 
-    public PersistentObject NewPersistentObject(Guid id)
-        => entityMapper.NewPersistentObject(id);
+    public PersistentObject GetPersistentObject(Guid id)
+        => entityMapper.GetPersistentObject(id);
 
-    public PersistentObject NewPersistentObject<T>() where T : class
-        => entityMapper.NewPersistentObject<T>();
+    public PersistentObject GetPersistentObject<T>() where T : class
+        => entityMapper.GetPersistentObject<T>();
 
     public string GetTranslatedMessage(string key, params object[] parameters)
     {

--- a/MintPlayer.Spark/Services/SyncActionHandler.cs
+++ b/MintPlayer.Spark/Services/SyncActionHandler.cs
@@ -64,7 +64,7 @@ internal partial class SyncActionHandler : ISyncActionHandler
     /// Builds a PersistentObject from the incoming sync action data dictionary,
     /// marking attributes as <c>IsValueChanged</c> based on the <paramref name="properties"/> list.
     /// When an <see cref="EntityTypeDefinition"/> is registered for the entity type the
-    /// schema path runs through <see cref="IEntityMapper.NewPersistentObject(Guid)"/>, so
+    /// schema path runs through <see cref="IEntityMapper.GetPersistentObject(Guid)"/>, so
     /// every attribute gets the canonical 14-field metadata; otherwise the CLR-reflection
     /// fallback inventories the entity's public read/write properties (no schema available).
     /// </summary>
@@ -79,7 +79,7 @@ internal partial class SyncActionHandler : ISyncActionHandler
             return BuildFromClrReflection(entityType, documentId, data, propertySet);
 
         // Schema path — full metadata scaffolded by IEntityMapper, values overlaid from data dict.
-        var po = entityMapper.NewPersistentObject(entityTypeDef.Id);
+        var po = entityMapper.GetPersistentObject(entityTypeDef.Id);
         po.Id = documentId;
 
         foreach (var attribute in po.Attributes)

--- a/docs/PRD-PersistentObjectFactory-Followups-II.md
+++ b/docs/PRD-PersistentObjectFactory-Followups-II.md
@@ -1,0 +1,158 @@
+# PRD: PersistentObject Factory Follow-ups — Part II
+
+## Status
+
+Continuation of [`docs/PRD-PersistentObjectFactory-Followups.md`](./PRD-PersistentObjectFactory-Followups.md). Items §1–§3 of that PRD shipped via **PR #130**:
+
+- §1 Richer `PopulateObjectValues` (PO → entity inverse path) ✅
+- §2 First-class `PersistentObjectAttributeAsDetail` + polymorphic JSON converter ✅
+- §3 Frontend popup-form rendering in retry modal ✅
+
+This PRD covers the two remaining items (§4 and §5 of the predecessor), renumbered here as §1 and §2. The two items are unrelated in scope but share the same context (factory work stream) and similar "small, scoped, doable without new architecture" size, so they live in a single PRD.
+
+## Recommended order
+
+1. **§2 Rename `NewPersistentObject` → `GetPersistentObject`** first — mechanical, unblocked, fast. Doing this before §1 means §1's design doesn't need to mention the old name.
+2. **§1 `CustomAction` return-value builder** — currently **blocked** on the Custom Actions PRD (`docs/custom-actions-prd.md`) committing to a return-value shape. Revisit when that PRD's §8 ("Future Phase: Navigate & Notify via IManager") is closed out.
+
+---
+
+## 1. `CustomAction` return-value builder
+
+### Why deferred (from predecessor PRD §4)
+
+> A `CustomAction` return-value builder that uses the factory (separate PRD
+> once CustomActions land broadly).
+
+### Current state
+
+- **`docs/custom-actions-prd.md`** defines Custom Actions v1. Key quote from §4.1:
+  ```csharp
+  public interface ICustomAction
+  {
+      Task ExecuteAsync(CustomActionArgs args, CancellationToken cancellationToken = default);
+  }
+  ```
+  v1 deliberately has **no return type** — `Task`, not `Task<T>`. A "return-value builder" with no return value to build is premature.
+- **`docs/custom-actions-prd.md` §8** — "Future Phase: Navigate & Notify via IManager" — is the hook where return-shape lands. Until that phase commits to a `CustomActionResult` (or equivalent), this item has nothing concrete to design against.
+- **`IEntityMapper.NewPersistentObject<T>()`** et al. are available (shipped in PR #126) for CustomAction implementations to use directly. A builder is ergonomic sugar on top; it is not load-bearing.
+
+### Blocker
+
+**Custom Actions PRD must commit to `CustomActionResult` first.** Expected shape (per predecessor PRD §4 sketch):
+
+```csharp
+return CustomActionResult
+    .Ok(manager.NewPersistentObject<Car>())   // or GetPersistentObject<Car>() post-rename
+    .WithNotification("Car created", NotificationKind.Success);
+```
+
+But this sketch is **not yet design** — it's a placeholder. The actual shape (navigate? notify? error? follow-up action? PO payload vs query refresh?) is a Custom Actions design decision that belongs in `docs/custom-actions-prd.md`, not here.
+
+### Design (when unblocked)
+
+Once `CustomActionResult` is defined by the Custom Actions PRD, this item becomes: "wire the factory into `CustomActionResult`'s PO-producing factory methods so callers can't hand-build POs." Specifically:
+
+- Any `CustomActionResult` method that takes a PO — `.Ok(po)`, `.WithContent(po)`, etc. — gets a generic overload `.Ok<T>()` / `.WithContent<T>()` that calls `IEntityMapper.GetPersistentObject<T>()` internally.
+- Documentation pass on `docs/guide-custom-actions.md` to show the builder as the one-true-way to construct action results; mark hand-built POs as an anti-pattern.
+
+### Acceptance criteria (when unblocked)
+
+- [ ] Custom Actions PRD §8 is closed with a concrete `CustomActionResult` definition.
+- [ ] `CustomActionResult` exposes generic factory overloads that route through `IEntityMapper` — unit tests verify the PO payload has correct `ObjectTypeId`, `Attributes`, etc.
+- [ ] At least one demo app ships a worked CustomAction using the builder (Fleet "Merge duplicate Cars" or HR "Promote Employee" are natural candidates) with a Playwright test invoking it from the UI.
+- [ ] `docs/guide-custom-actions.md` updated — builder-first, mentions the hand-built-PO anti-pattern.
+
+### Estimated size
+
+**Blocked — unknown until §8 of the Custom Actions PRD is closed.** Expect small once unblocked: the factory work is done, this is an ergonomic wrapper + docs pass + one demo exercise.
+
+### Files that will touch (when unblocked)
+
+- `MintPlayer.Spark.Abstractions/Actions/CustomActionResult.cs` (new, ~80 lines)
+- `MintPlayer.Spark.Abstractions/Actions/ICustomAction.cs` (return type change)
+- `MintPlayer.Spark/Actions/SparkCustomAction.cs` (abstract signature change)
+- Endpoint dispatcher (wherever `ExecuteAsync` is awaited — result gets serialized to wire)
+- `docs/custom-actions-prd.md` + `docs/guide-custom-actions.md`
+- One demo app's `Actions/*CustomAction.cs` + corresponding `customActions.json` + Playwright test
+
+### Tracking
+
+Open a **GitHub issue linked to Custom Actions PRD §8** with this PRD's item as the descendant. Do not open a PR for this item until the blocker lifts.
+
+---
+
+## 2. Rename `NewPersistentObject` → `GetPersistentObject`
+
+### Why deferred (from predecessor PRD §5)
+
+> Renaming `NewPersistentObject` to `GetPersistentObject` à la Vidyano — the
+> Spark naming is already established in `prd-manager-retry-action.md`.
+
+Left for last in the original sequence because a mechanical rename breaks every call site — rebasing new work over a rename is cheaper than rebasing a rename over new work. With §1–§3 shipped and §1-here (CustomAction builder) blocked, **now is the quiet window** to do the rename.
+
+### Current state (post-PR #130)
+
+Call-site snapshot (excluding docs/markdown and `.claude/worktrees/`):
+
+| File | Occurrences | Role |
+|---|---|---|
+| `MintPlayer.Spark.Abstractions/IManager.cs` | 4 | interface declaration |
+| `MintPlayer.Spark.Abstractions/PersistentObject.cs` | 1 | xml-doc reference |
+| `MintPlayer.Spark/Services/EntityMapper.cs` | 8 | implementation + internal call sites |
+| `MintPlayer.Spark/Services/Manager.cs` | 6 | thin forwarders |
+| `MintPlayer.Spark/Services/SyncActionHandler.cs` | 2 | schema-branch call |
+| `MintPlayer.Spark.SourceGenerators/Generators/PersistentObjectNamesGenerator.IdsProducer.cs` | 1 | xml-doc reference |
+| `MintPlayer.Spark.SourceGenerators/Models/PersistentObjectIdInfo.cs` | 1 | xml-doc reference |
+| `Demo/Fleet/Fleet/Actions/CarActions.cs` | 1 | **new in PR #130** |
+| `Demo/Fleet/Fleet.Library/VirtualObjects/ConfirmDeleteCar.cs` | 1 | **new in PR #130** |
+| `MintPlayer.Spark.Tests/EntityMapperFactoryTests.cs` | 22 | test usage |
+| `MintPlayer.Spark.Tests/EntityMapperAsDetailTests.cs` | 16 | test usage (includes multi-level test added post-PR #130) |
+| `MintPlayer.Spark.Tests/Services/SyncActionHandlerBuildPersistentObjectTests.cs` | 7 | test usage |
+| `MintPlayer.Spark.Tests/Services/ManagerTests.cs` | 11 | test usage |
+
+Total: **9 production files + 4 test files + 2 PRDs**. The predecessor PRD said "Demo apps have zero call sites today" — that's no longer true, Fleet picked up 2 during PR #130. Scope grew marginally.
+
+### Design
+
+Straight rename. No semantic change.
+
+- `IManager.NewPersistentObject(string)` → `GetPersistentObject(string)`
+- `IManager.NewPersistentObject(Guid)` → `GetPersistentObject(Guid)`
+- `IManager.NewPersistentObject<T>()` → `GetPersistentObject<T>()`
+- `IEntityMapper.NewPersistentObject(...)` (same three overloads) → `GetPersistentObject(...)`
+- All internal callers (Manager thin-forwards, EntityMapper self-calls, SyncActionHandler, Fleet Actions/VirtualObjects) updated in the same commit.
+- All test call sites updated in the same commit.
+- `docs/PRD-PersistentObjectFactory.md` (parent) and `docs/PRD-PersistentObjectFactory-Followups.md` (predecessor) updated to use the new name.
+
+**`ToPersistentObject(...)` and `PopulateAttributeValues(...)` names stay** — those are not part of the Vidyano rename.
+
+Because this is a preview-mode project (NuGet `10.0.0-preview.*`), **no deprecation path** — just rename and bump the preview version.
+
+### Acceptance criteria
+
+- [ ] `grep -rn "NewPersistentObject" MintPlayer.Spark*/ Demo/ --include='*.cs'` returns **zero hits** post-rename.
+- [ ] All unit tests pass (≥330 expected).
+- [ ] All E2E tests pass.
+- [ ] Demo apps (`DemoApp`, `HR`, `Fleet`, `WebhooksDemo`) still build and run — smoke-test Fleet (the only demo with call sites) by exercising `ConfirmDeleteCar` flow end-to-end.
+- [ ] `docs/PRD-PersistentObjectFactory.md` + `docs/PRD-PersistentObjectFactory-Followups.md` updated to use the new name.
+- [ ] NuGet preview version bumped.
+- [ ] CHANGELOG / preview-version notes mention the breaking rename if such a file exists.
+
+### Estimated size
+
+**Small — ~80 lines of diff** (up from the predecessor PRD's ~50-line estimate, because Fleet now has call sites). Single-commit PR, single reviewer, no design discussion needed.
+
+### Suggested branch name
+
+`refactor/get-persistent-object-rename` (per predecessor PRD's naming convention).
+
+---
+
+## Cross-cutting notes
+
+- **Ordering is load-bearing.** §2 (rename) must land before §1 (builder) — the §1 design examples reference `GetPersistentObject<T>()`, and shipping them in reverse order means a mini-rebase on the builder PR.
+- **§1 is genuinely blocked, not "deferred for planning".** If Custom Actions §8 stays open for months, this PRD should be revisited — either by folding §1 into `docs/custom-actions-prd.md` directly (it's really a CustomActions design note, not a factory follow-up), or by closing §1 here and leaving the CustomActions PRD owner to pick it up when they design §8.
+- **No live-test scenarios for §2** beyond the existing demo-app smoke tests. Unlike §1–§3 of the predecessor PRD (which each added demo-app + Playwright coverage), a rename doesn't change observable behavior — unit + E2E passing + one demo smoke run is sufficient.
+- **PR size discipline** — parent PRD + predecessor PRD phases averaged +300/-100 diffs. §2 here is even smaller. Don't bundle §1 and §2 into one PR even when §1 unblocks — different review scopes, different risk profiles.
+- **Test count** — 344 unit tests green on master at time of writing (330 parent + 14 AsDetail from PR #130). §2 must hold or grow this number.

--- a/docs/PRD-PersistentObjectFactory-Followups.md
+++ b/docs/PRD-PersistentObjectFactory-Followups.md
@@ -317,6 +317,8 @@ Unknown until scope is locked with the CustomActions PRD.
 
 ## 5. Rename `NewPersistentObject` → `GetPersistentObject`
 
+> **Status: Shipped.** Executed via `refactor/get-persistent-object-rename`; scoped in [`docs/PRD-PersistentObjectFactory-Followups-II.md`](./PRD-PersistentObjectFactory-Followups-II.md) §2. The section below is preserved as a historical record of the planned scope — the codebase now uses `GetPersistentObject` everywhere.
+
 ### Why deferred
 
 Parent PRD's "Out of scope":

--- a/docs/PRD-PersistentObjectFactory.md
+++ b/docs/PRD-PersistentObjectFactory.md
@@ -46,7 +46,7 @@ Vidyano solved (1)–(3) with `Manager.Current.GetPersistentObject(Types.Foo)`,
 scaffold the PO (metadata only) via `GetPersistentObject`, then fill values
 via `po.PopulateAttributeValues(entity)`. Spark already has the
 `PersistentObjectNames.Foo` generator output, a stub
-`IManager.NewPersistentObject(...)` method with zero callers, and a weak
+`IManager.GetPersistentObject(...)` method with zero callers, and a weak
 `PopulateAttributeValues<T>` extension method. This PRD wires them together
 and promotes the scaffold-then-populate model to the framework's canonical
 entity→PO conversion path — replacing `EntityMapper.ToPersistentObject`,
@@ -55,7 +55,7 @@ entity→PO conversion path — replacing `EntityMapper.ToPersistentObject`,
 
 ## Goals
 
-- `manager.NewPersistentObject(PersistentObjectNames.Foo)` returns a fully
+- `manager.GetPersistentObject(PersistentObjectNames.Foo)` returns a fully
   schema-backed, blank PersistentObject — `ObjectTypeId`, every declared
   attribute with correct `DataType` / `Label` / `Rules` / `Renderer` /
   `ShowedOn` / `Order` / `Group` / `IsRequired` / `IsVisible` / `IsReadOnly` /
@@ -65,7 +65,7 @@ entity→PO conversion path — replacing `EntityMapper.ToPersistentObject`,
   (enum→string, `Color`→hex, `AsDetail`→dictionary), resolves Reference
   breadcrumbs, and sets `Id` / `Name` / `Breadcrumb` on the PO. Schema-aware.
 - `EntityMapper.ToPersistentObject` becomes a thin wrapper: scaffold via
-  `NewPersistentObject`, populate via `PopulateAttributeValues`. Its call sites
+  `GetPersistentObject`, populate via `PopulateAttributeValues`. Its call sites
   stop changing.
 - `SyncActionHandler.BuildPersistentObject` migrates to the same pattern with
   an extra `IsValueChanged` overlay from the incoming `properties[]` array.
@@ -79,13 +79,13 @@ entity→PO conversion path — replacing `EntityMapper.ToPersistentObject`,
   `Parent` back-reference.
 - Popup / dialog POs that don't correspond to a CLR entity are declared as
   **Virtual POs** in JSON — no separate code path, no
-  `ObjectTypeId == Guid.Empty` fallback. The same `NewPersistentObject(name)`
-  / `NewPersistentObject(Guid)` factory handles entity-backed and virtual
+  `ObjectTypeId == Guid.Empty` fallback. The same `GetPersistentObject(name)`
+  / `GetPersistentObject(Guid)` factory handles entity-backed and virtual
   POs identically.
 - The source generator emits a sibling `PersistentObjectIds` class —
   nested static classes per database schema, each holding
   `const string` Guid values — so apps with cross-schema name collisions
-  can disambiguate via `manager.NewPersistentObject(Guid)`.
+  can disambiguate via `manager.GetPersistentObject(Guid)`.
 - The three half-baked extension methods (`ToPersistentObject<T>`,
   `PopulateAttributeValues<T>`, `PopulateObjectValues<T>`) in
   `PersistentObjectExtensions.cs` are either deleted or rewritten to delegate
@@ -116,8 +116,8 @@ entity→PO conversion path — replacing `EntityMapper.ToPersistentObject`,
 
 | Piece | Location | Status |
 |---|---|---|
-| `IManager.NewPersistentObject(name, params attrs)` | `MintPlayer.Spark.Abstractions/IManager.cs` | Exists, trivial wrapper, zero callers |
-| `Manager.NewPersistentObject` impl | `MintPlayer.Spark/Services/Manager.cs:16` | Returns `new PersistentObject { ObjectTypeId = Guid.Empty, Attributes = attributes }` — not schema aware |
+| `IManager.GetPersistentObject(name, params attrs)` | `MintPlayer.Spark.Abstractions/IManager.cs` | Exists, trivial wrapper, zero callers |
+| `Manager.GetPersistentObject` impl | `MintPlayer.Spark/Services/Manager.cs:16` | Returns `new PersistentObject { ObjectTypeId = Guid.Empty, Attributes = attributes }` — not schema aware |
 | `IModelLoader` singleton with `GetEntityTypeByName` / `GetEntityTypeByClrType` / `ResolveEntityType` | `MintPlayer.Spark/Services/ModelLoader.cs` | Already loads every `App_Data/Model/*.json` lazily |
 | `EntityTypeDefinition.Attributes` (`EntityAttributeDefinition[]`) | `MintPlayer.Spark.Abstractions/EntityTypeDefinition.cs` | Full attribute schema, loaded from JSON |
 | `EntityMapper.ToPersistentObject` (schema-aware entity→PO) | `MintPlayer.Spark/Services/EntityMapper.cs:55-158` | Copies 14 metadata fields inline per attribute, does enum/Color/AsDetail value conversions, resolves Reference breadcrumbs. 6 callers (DatabaseAccess×2, QueryExecutor×2, StreamingQueryExecutor×1, PersistentObjectExtensions×1). |
@@ -164,7 +164,7 @@ actual conversions baked in.
 Both types remain sealed and wire-compatible. Key invariant: **every
 attribute belongs to exactly one PO for its entire lifetime**. No public
 `Attach` / `Detach` surface — attributes are constructed already-owned, via
-scaffold (`NewPersistentObject`), clone (`attribute.CloneAndAdd`), or
+scaffold (`GetPersistentObject`), clone (`attribute.CloneAndAdd`), or
 deserialization.
 
 ```csharp
@@ -210,7 +210,7 @@ public sealed class PersistentObjectAttribute
 
 **How `Parent` gets set** — three paths, all framework-internal:
 
-- `EntityMapper.NewPersistentObject(name)` — per-schema-attribute
+- `EntityMapper.GetPersistentObject(name)` — per-schema-attribute
   construction calls `po.AddAttribute(attr)`.
 - `attribute.CloneAndAdd(name, label?)` — reads `this.Parent`, builds the
   clone, calls `Parent.AddAttribute(clone)`.
@@ -241,17 +241,17 @@ public interface IManager
     // if the name is unknown OR ambiguous (more than one entity with this
     // name across schemas). Recommend the Guid overload for cross-schema
     // apps to avoid ambiguity.
-    PersistentObject NewPersistentObject(string name);
+    PersistentObject GetPersistentObject(string name);
 
     // NEW — schema-backed factory keyed by ObjectTypeId. Preferred when the
     // app declares entities in multiple database schemas (same name can
     // legally repeat). Throws KeyNotFoundException if the id is unknown.
-    PersistentObject NewPersistentObject(Guid id);
+    PersistentObject GetPersistentObject(Guid id);
 
     // NEW — typed convenience: derives ObjectTypeId from typeof(T).FullName
     // via IModelLoader.GetEntityTypeByClrType. Cleanest call site when the
     // caller has a typed entity class — no Guid plumbing, no string names.
-    PersistentObject NewPersistentObject<T>() where T : class;
+    PersistentObject GetPersistentObject<T>() where T : class;
 
     // existing
     IRetryAccessor Retry { get; }
@@ -263,14 +263,14 @@ public interface IManager
 There is **no "synthetic" overload**. Popup POs that don't correspond to a
 CLR entity are defined as **Virtual POs** in JSON (existing Spark concept —
 PO schema with `IsVirtual: true` and no `ClrType`). That gives them a real
-`ObjectTypeId`, real declared attributes, and lets `NewPersistentObject`
+`ObjectTypeId`, real declared attributes, and lets `GetPersistentObject`
 treat them identically to entity-backed POs. No separate code path, no
 `Guid.Empty` fallback.
 
 ### 3. `IEntityMapper` surface (extended)
 
 `IEntityMapper` owns the entire entity ↔ PO machinery. `Manager` injects it
-and thinly forwards the schema-backed `NewPersistentObject(name)` overload so
+and thinly forwards the schema-backed `GetPersistentObject(name)` overload so
 the user-facing ergonomic stays on `IManager`.
 
 ```csharp
@@ -278,17 +278,17 @@ public interface IEntityMapper
 {
     // NEW — schema-backed factory (scaffold only, values null). Keyed by
     // name. Throws on unknown / ambiguous name.
-    PersistentObject NewPersistentObject(string name);
+    PersistentObject GetPersistentObject(string name);
 
     // NEW — schema-backed factory keyed by ObjectTypeId. Never ambiguous.
-    PersistentObject NewPersistentObject(Guid id);
+    PersistentObject GetPersistentObject(Guid id);
 
     // NEW — typed overload: resolves ObjectTypeId via
     // IModelLoader.GetEntityTypeByClrType(typeof(T).FullName).
-    PersistentObject NewPersistentObject<T>() where T : class;
+    PersistentObject GetPersistentObject<T>() where T : class;
 
     // Existing surface — unchanged signature. Reimplemented internally as
-    // NewPersistentObject(objectTypeId) + PopulateAttributeValues.
+    // GetPersistentObject(objectTypeId) + PopulateAttributeValues.
     PersistentObject ToPersistentObject(object entity, Guid objectTypeId,
         Dictionary<string, object>? includedDocuments = null);
 
@@ -335,14 +335,14 @@ internal sealed partial class Manager : IManager
     [Inject] private readonly IRequestCultureResolver requestCultureResolver;
     [Inject] private readonly IEntityMapper entityMapper;            // NEW
 
-    public PersistentObject NewPersistentObject(string name)
-        => entityMapper.NewPersistentObject(name);
+    public PersistentObject GetPersistentObject(string name)
+        => entityMapper.GetPersistentObject(name);
 
-    public PersistentObject NewPersistentObject(Guid id)
-        => entityMapper.NewPersistentObject(id);
+    public PersistentObject GetPersistentObject(Guid id)
+        => entityMapper.GetPersistentObject(id);
 
-    public PersistentObject NewPersistentObject<T>() where T : class
-        => entityMapper.NewPersistentObject<T>();
+    public PersistentObject GetPersistentObject<T>() where T : class
+        => entityMapper.GetPersistentObject<T>();
 }
 ```
 
@@ -354,7 +354,7 @@ ModelLoader`, acyclic.
 
 Owns scaffold, populate, and the per-attribute metadata copy. No `IManager`
 dependency — the factory body and `ToPersistentObject` both self-call
-`NewPersistentObject`.
+`GetPersistentObject`.
 
 ```csharp
 [Register(typeof(IEntityMapper), ServiceLifetime.Scoped)]
@@ -363,14 +363,14 @@ internal partial class EntityMapper : IEntityMapper
     [Inject] private readonly IModelLoader modelLoader;
     // NO IManager dependency.
 
-    public PersistentObject NewPersistentObject(string name)
+    public PersistentObject GetPersistentObject(string name)
     {
         var def = modelLoader.GetEntityTypeByName(name)
             ?? throw new KeyNotFoundException($"Unknown entity type '{name}'");
         return ScaffoldFrom(def);
     }
 
-    public PersistentObject NewPersistentObject(Guid id)
+    public PersistentObject GetPersistentObject(Guid id)
     {
         var def = modelLoader.GetEntityType(id)
             ?? throw new KeyNotFoundException($"Unknown ObjectTypeId '{id}'");
@@ -380,7 +380,7 @@ internal partial class EntityMapper : IEntityMapper
     public PersistentObject ToPersistentObject(object entity, Guid objectTypeId,
         Dictionary<string, object>? includedDocuments = null)
     {
-        var po = NewPersistentObject(objectTypeId);   // self-call, no DI
+        var po = GetPersistentObject(objectTypeId);   // self-call, no DI
         PopulateAttributeValues(po, entity, includedDocuments);
         return po;
     }
@@ -489,7 +489,7 @@ private PersistentObject BuildPersistentObject(Type entityType, string? document
     // inline (it's a genuinely different beast — no PersistentObjectNames
     // constant exists, we're inventing attributes on the fly).
     var po = entityTypeDef is not null
-        ? entityMapper.NewPersistentObject(entityTypeDef.Id)
+        ? entityMapper.GetPersistentObject(entityTypeDef.Id)
         : BuildPoFromClrTypeFallback(entityType, documentId);
 
     po.Id = documentId;
@@ -534,7 +534,7 @@ path" claim is a lie the moment someone calls the extension.
 ### 8. RetryAction popup pattern
 
 Popup POs are Virtual POs — regular schema entries with no CLR entity.
-They go through the same `NewPersistentObject` factory as entity-backed POs.
+They go through the same `GetPersistentObject` factory as entity-backed POs.
 
 ```json
 // App_Data/Model/ConfirmDeleteCar.json — a Virtual PO definition
@@ -554,7 +554,7 @@ They go through the same `NewPersistentObject` factory as entity-backed POs.
 public override async Task OnBeforeDeleteAsync(Car car)
 {
     // Same API as any other PO. No "synthetic" concept.
-    var popup = manager.NewPersistentObject(
+    var popup = manager.GetPersistentObject(
         PersistentObjectNames.ConfirmDeleteCar);
     popup[AttributeNames.ConfirmDeleteCar.LicensePlate].Value = car.LicensePlate;
 
@@ -618,7 +618,7 @@ public static class PersistentObjectIds
 Consumer code that needs disambiguation:
 
 ```csharp
-var po = manager.NewPersistentObject(new Guid(PersistentObjectIds.Audit.AuditLog));
+var po = manager.GetPersistentObject(new Guid(PersistentObjectIds.Audit.AuditLog));
 ```
 
 `const string` (not `static readonly Guid`) per the user's directive — lets
@@ -658,20 +658,20 @@ never introduce a second schema — zero migration cost.
 
 1. Add `private static EntityMapper.FromDefinition(EntityAttributeDefinition)`
    and `private static EntityMapper.ScaffoldFrom(EntityTypeDefinition)`.
-2. Add `IEntityMapper.NewPersistentObject(string name)` and
-   `IEntityMapper.NewPersistentObject(Guid id)` — both delegate to
+2. Add `IEntityMapper.GetPersistentObject(string name)` and
+   `IEntityMapper.GetPersistentObject(Guid id)` — both delegate to
    `ScaffoldFrom`.
 3. Add `IEntityMapper.PopulateAttributeValues(po, entity, includedDocuments?)`.
 4. Rewrite `EntityMapper.ToPersistentObject` body as
-   `NewPersistentObject(objectTypeId)` + `PopulateAttributeValues` — one
+   `GetPersistentObject(objectTypeId)` + `PopulateAttributeValues` — one
    self-call, no `IManager` dependency.
 5. Add `IEntityMapper` injection to `Manager`; drop `IModelLoader` injection
    (no longer needed there).
-6. Implement `Manager.NewPersistentObject(string)`,
-   `Manager.NewPersistentObject(Guid)`, and `Manager.NewPersistentObject<T>()`
+6. Implement `Manager.GetPersistentObject(string)`,
+   `Manager.GetPersistentObject(Guid)`, and `Manager.GetPersistentObject<T>()`
    as thin forwards to `IEntityMapper`.
 7. **Generic overloads** (added during Phase 2 implementation after a mid-flight
-   design check): `IEntityMapper.NewPersistentObject<T>()`,
+   design check): `IEntityMapper.GetPersistentObject<T>()`,
    `IEntityMapper.ToPersistentObject<T>(entity, includedDocuments?)`, and
    `IEntityMapper.PopulateAttributeValues<T>(po, entity, includedDocuments?)`.
    Resolve `ObjectTypeId` via `IModelLoader.GetEntityTypeByClrType(typeof(T).FullName)`,
@@ -681,7 +681,7 @@ never introduce a second schema — zero migration cost.
    `StreamingQueryExecutor`) that work with RavenDB-returned `object`.
 8. Tests:
    - `ManagerTests` — forwarding to `IEntityMapper` via mock (3 tests).
-   - `EntityMapperFactoryTests` — all three `NewPersistentObject` overloads
+   - `EntityMapperFactoryTests` — all three `GetPersistentObject` overloads
      (name / Guid / generic), `PopulateAttributeValues` happy/edge paths
      (silent skip, dot-notation skip, enum→string, Color→hex), and
      `ToPersistentObject<T>` parity with the Guid overload (13 tests).
@@ -705,7 +705,7 @@ never introduce a second schema — zero migration cost.
 **Phase 3 — Framework internals migration**
 
 1. `SyncActionHandler.BuildPersistentObject` — migrate schema branch to
-   `entityMapper.NewPersistentObject(entityTypeDef.Id)` + value loop
+   `entityMapper.GetPersistentObject(entityTypeDef.Id)` + value loop
    (inject `IEntityMapper` directly; no need to go through `IManager`).
    Keep CLR-fallback as a separate method.
 2. ~~`PersistentObjectExtensions.ToPersistentObject<T>` — delete.~~
@@ -749,16 +749,16 @@ test helper that uses the internal `AddAttribute` path (exposed via
 Zero direct PO construction in demo apps today. Migration here is
 **opportunity-based**: when a demo Actions class grows a retry-action popup
 or a `CustomAction` return value, use `PersistentObjectNames.*` +
-`NewPersistentObject` from day one. A worked example (e.g. a `MergeWith`-style
+`GetPersistentObject` from day one. A worked example (e.g. a `MergeWith`-style
 CustomAction in DemoApp) is the best documentation.
 
 ## Acceptance criteria
 
-- [ ] `manager.NewPersistentObject(PersistentObjectNames.Person)` on DemoApp
+- [ ] `manager.GetPersistentObject(PersistentObjectNames.Person)` on DemoApp
   returns a PO with `ObjectTypeId == Person.Id`, `Attributes.Count ==
   entityDef.Attributes.Length`, each attribute has the full 14-field metadata
   matching the schema JSON, `Value == null`, and `Parent == returnedPO`.
-- [ ] `manager.NewPersistentObject(new Guid(PersistentObjectIds.Default.Person))`
+- [ ] `manager.GetPersistentObject(new Guid(PersistentObjectIds.Default.Person))`
   returns an equivalent PO. Both overloads behave identically for
   unambiguous names.
 - [ ] `po.PopulateAttributeValues(entity)` (via `IEntityMapper`) on that same
@@ -786,7 +786,7 @@ CustomAction in DemoApp) is the best documentation.
   pre-change byte output, and after deserialization every
   `PersistentObjectAttribute.Parent` is correctly set.
 - [ ] Virtual PO defined in `App_Data/Model/ConfirmDeleteCar.json` flows
-  through `NewPersistentObject` identically to an entity-backed PO
+  through `GetPersistentObject` identically to an entity-backed PO
   (same return-shape assertions, no special-case code path).
 - [ ] `PersistentObjectExtensions.ToPersistentObject<T>` and
   `PopulateAttributeValues<T>` are removed (or rewritten as delegating
@@ -803,7 +803,7 @@ CustomAction in DemoApp) is the best documentation.
    `TranslatedString?`, so mirror Vidyano. A `string` overload is trivial to
    add later if ergonomic.
 
-2. **Ambiguous name throw vs. silent-pick in `NewPersistentObject(string)`.**
+2. **Ambiguous name throw vs. silent-pick in `GetPersistentObject(string)`.**
    When two schemas declare an entity with the same name, should the name
    overload throw (`AmbiguousMatchException`) or fall back to the first
    match? Proposal: throw — forces the caller to switch to the Guid
@@ -841,8 +841,9 @@ CustomAction in DemoApp) is the best documentation.
   is a follow-up PRD.
 - A `CustomAction` return-value builder that uses the factory (separate PRD
   once CustomActions land broadly).
-- Renaming `NewPersistentObject` to `GetPersistentObject` à la Vidyano — the
-  Spark naming is already established in `prd-manager-retry-action.md`.
+- ~~Renaming `NewPersistentObject` to `GetPersistentObject` à la Vidyano — the
+  Spark naming is already established in `prd-manager-retry-action.md`.~~
+  **Shipped** — tracked in `docs/PRD-PersistentObjectFactory-Followups-II.md` §2.
 - **First-class `PersistentObjectAttributeAsDetail` (nested PO arrays) in
   the mapper.** Today `EntityMapper` converts `AsDetail`-typed values to a
   plain `Dictionary<string, object?>` for serialization; a richer port

--- a/docs/guide-manager-retry-actions.md
+++ b/docs/guide-manager-retry-actions.md
@@ -9,7 +9,7 @@ The `IManager` interface exposes:
 | Member | Purpose |
 |---|---|
 | `Retry` | Access to the Retry Action subsystem (`IRetryAccessor`) |
-| `NewPersistentObject()` | Create a virtual PersistentObject for custom dialog forms |
+| `GetPersistentObject()` | Create a virtual PersistentObject for custom dialog forms |
 | `GetTranslatedMessage()` | Get a translated string for the current request culture |
 | `GetMessage()` | Get a translated string for a specific language |
 
@@ -154,13 +154,13 @@ void Action(
 
 ## Custom Dialog Forms
 
-You can display a form inside the retry modal by passing a `PersistentObject` with attributes. Use `manager.NewPersistentObject()` to create one:
+You can display a form inside the retry modal by passing a `PersistentObject` with attributes. Use `manager.GetPersistentObject()` to create one:
 
 ```csharp
 manager.Retry.Action(
     title: "Enter reason",
     options: ["Submit"],
-    persistentObject: manager.NewPersistentObject("ReasonForm",
+    persistentObject: manager.GetPersistentObject("ReasonForm",
         new PersistentObjectAttribute
         {
             Name = "Reason",

--- a/docs/prd-manager-retry-action.md
+++ b/docs/prd-manager-retry-action.md
@@ -4,7 +4,7 @@
 
 Introduce an `IManager` interface (abstractions) and `internal Manager` class (core) that developers can inject into their Actions classes. The Manager provides two key capabilities:
 
-1. **`NewPersistentObject()`** — Create virtual/temporary PersistentObjects with custom attributes (not backed by a database entity).
+1. **`GetPersistentObject()`** — Create virtual/temporary PersistentObjects with custom attributes (not backed by a database entity).
 2. **`Retry.Action()` / `Retry.Result`** — An exception-driven confirmation/dialog pattern that lets action methods pause execution, present a modal to the user, and resume with the user's response.
 
 ## Motivation
@@ -43,7 +43,7 @@ Developer's Actions Class (CRUD hooks or future Custom Actions)
     │
     ├── Injects IManager
     │       │
-    │       ├── .NewPersistentObject(name, attributes[])
+    │       ├── .GetPersistentObject(name, attributes[])
     │       │       → Returns a virtual PersistentObject (no DB backing)
     │       │
     │       └── .Retry
@@ -85,7 +85,7 @@ public interface IManager
     /// Creates a virtual PersistentObject (not backed by a DB entity).
     /// Useful for building custom dialogs in Retry.Action().
     /// </summary>
-    PersistentObject NewPersistentObject(string name, params PersistentObjectAttribute[] attributes);
+    PersistentObject GetPersistentObject(string name, params PersistentObjectAttribute[] attributes);
 
     /// <summary>
     /// Access to the Retry Action subsystem.
@@ -165,7 +165,7 @@ internal sealed partial class Manager : IManager
 
     public IRetryAccessor Retry => retry;
 
-    public PersistentObject NewPersistentObject(string name, params PersistentObjectAttribute[] attributes)
+    public PersistentObject GetPersistentObject(string name, params PersistentObjectAttribute[] attributes)
     {
         return new PersistentObject
         {
@@ -425,7 +425,7 @@ public partial class InvoiceActions : DefaultPersistentObjectActions<Invoice>
 
     public override async Task OnBeforeSaveAsync(PersistentObject obj, Invoice entity)
     {
-        var dialog = manager.NewPersistentObject("Confirm Changes",
+        var dialog = manager.GetPersistentObject("Confirm Changes",
             new PersistentObjectAttribute { Name = "Reason", DataType = "string", IsRequired = true },
             new PersistentObjectAttribute { Name = "NotifyCustomer", DataType = "boolean", Value = true }
         );


### PR DESCRIPTION
## Summary

Ships the **Followups-II PRD** (`docs/PRD-PersistentObjectFactory-Followups-II.md`) together with the item §2 it covers — the `NewPersistentObject` → `GetPersistentObject` rename.

Continuation of the factory follow-ups series: the predecessor PRD's §1–§3 shipped via PR #130; this PR covers §5 (rename) and documents §4 (CustomAction return-value builder) as explicitly blocked on the Custom Actions PRD.

## What lands

### Followups-II PRD (`docs/PRD-PersistentObjectFactory-Followups-II.md`)

Two items, renumbered here as §1 and §2:

| Item | Status |
|---|---|
| §1 CustomAction return-value builder | ❌ **blocked** on Custom Actions PRD §8 committing to a return-value shape |
| §2 Rename `NewPersistentObject` → `GetPersistentObject` | ✅ **shipped in this PR** |

**Key design call-out on §1**: Custom Actions PRD §8 as currently written uses `IManager.Navigate(po)` / `IManager.Notify(msg)` side-effects — not a `CustomActionResult` object. If §8 lands as specified, §1 becomes **obsolete**, not unblocked. Calling this out so the next CustomActions design pass makes the choice deliberately.

### Rename (Vidyano parity)

Mechanical rename — no semantic change, no deprecation path (preview-mode project, NuGet `10.0.0-preview.*`).

**Production** (9 files):
- `IManager` — 3 overloads (`string` / `Guid` / `<T>`)
- `IEntityMapper` — same 3 overloads + internal self-calls
- `Manager` thin forwarders
- `EntityMapper` impl (including xml-doc cross-refs)
- `SyncActionHandler.BuildPersistentObject` schema branch
- `PersistentObject.cs` xml-doc reference
- Two source-generator xml-doc references
- Fleet demo: `CarActions.OnDeleteAsync` + `ConfirmDeleteCar` xml-doc

**Tests** (4 files, 56 call sites):
- `EntityMapperFactoryTests` (22), `EntityMapperAsDetailTests` (16)
- `SyncActionHandlerBuildPersistentObjectTests` (7), `ManagerTests` (11)

**Docs**:
- `guide-manager-retry-actions.md` — user-facing, all refs updated
- `prd-manager-retry-action.md` — design doc, all API refs updated
- `PRD-PersistentObjectFactory.md` — all API refs updated; "Out of Scope" bullet struck through with a "Shipped" note pointing to Followups-II §2
- `PRD-PersistentObjectFactory-Followups.md` — §5 gets a **"Status: Shipped"** banner at the top; the body stays as historical record of the planned scope

## Verification

- [x] `grep -rn "NewPersistentObject" --include='*.cs'` returns **zero hits** across production, demos, and tests.
- [x] Unit tests: **360 passed, 0 failed** locally.
- [x] Demo apps compile.
- [ ] E2E tests pass (CI).
- [ ] Fleet smoke test — exercise `ConfirmDeleteCar` flow end-to-end (manual check before merge, per PRD §2 acceptance criteria).

## Rollout notes

- **No deprecation path.** Preview-mode project. Consumers must re-build against the new API name.
- **Preview version bump** — not done in this PR; bump in the release-prep commit.

## Supersedes

- Closes #132 (PRD moved into this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)