### PR TITLE
feat(webhooks-demo): install-app link + auto-delete branch on PR close

### DIFF
--- a/Demo/WebhooksDemo/WebhooksDemo/App_Data/translations.json
+++ b/Demo/WebhooksDemo/WebhooksDemo/App_Data/translations.json
@@ -47,6 +47,21 @@
     "enabled":    { "en": "Enabled",    "fr": "Activé",        "nl": "Ingeschakeld" },
     "enable":     { "en": "Enable",     "fr": "Activer",       "nl": "Inschakelen" },
     "configure":  { "en": "Configure",  "fr": "Configurer",    "nl": "Configureren" },
-    "failedToLoadProjects": { "en": "Failed to load projects", "fr": "Impossible de charger les projets", "nl": "Projecten laden mislukt" }
+    "failedToLoadProjects": { "en": "Failed to load projects", "fr": "Impossible de charger les projets", "nl": "Projecten laden mislukt" },
+    "installAppHintBefore": {
+      "en": "If your project doesn't appear, you need to install",
+      "fr": "Si votre projet n'apparaît pas, vous devez installer",
+      "nl": "Als je project niet verschijnt, moet je"
+    },
+    "installAppHintLink": {
+      "en": "this app",
+      "fr": "cette application",
+      "nl": "deze app"
+    },
+    "installAppHintAfter": {
+      "en": "on your organization.",
+      "fr": "sur votre organisation.",
+      "nl": "op je organisatie installeren."
+    }
   }
 }

--- a/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/models/github-project.ts
+++ b/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/models/github-project.ts
@@ -11,3 +11,7 @@ export interface ProjectColumn {
   optionId: string;
   name: string;
 }
+
+export interface GitHubAppInfo {
+  productionAppSlug: string | null;
+}

--- a/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/pages/github-projects/github-projects.component.html
+++ b/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/pages/github-projects/github-projects.component.html
@@ -66,6 +66,13 @@
           }
         </div>
       </bs-card>
+      @if (installAppUrl(); as url) {
+        <p class="text-muted small mt-3 mb-0">
+          {{ 'app.installAppHintBefore' | t }}
+          <a [href]="url" target="_blank" rel="noopener">{{ 'app.installAppHintLink' | t }}</a>
+          {{ 'app.installAppHintAfter' | t }}
+        </p>
+      }
     </div>
   </div>
 </bs-grid>

--- a/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/pages/github-projects/github-projects.component.ts
+++ b/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/pages/github-projects/github-projects.component.ts
@@ -36,9 +36,21 @@ export default class GitHubProjectsComponent implements OnInit {
   projects = signal<ProjectRow[]>([]);
   loading = signal(true);
   error = signal<string | null>(null);
+  installAppUrl = signal<string | null>(null);
 
   async ngOnInit(): Promise<void> {
-    await this.loadProjects();
+    await Promise.all([this.loadProjects(), this.loadAppInfo()]);
+  }
+
+  private async loadAppInfo(): Promise<void> {
+    try {
+      const info = await this.ghService.getAppInfo();
+      const slug = info.productionAppSlug;
+      this.installAppUrl.set(slug ? `https://github.com/apps/${slug}/installations/new` : null);
+    } catch {
+      // Soft-fail: link just stays hidden if the backend can't tell us the slug.
+      this.installAppUrl.set(null);
+    }
   }
 
   private async loadProjects(): Promise<void> {

--- a/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/services/github-projects.service.ts
+++ b/Demo/WebhooksDemo/WebhooksDemo/ClientApp/src/app/services/github-projects.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-import { GitHubProjectInfo, ProjectColumn } from '../models/github-project';
+import { GitHubAppInfo, GitHubProjectInfo, ProjectColumn } from '../models/github-project';
 
 @Injectable({ providedIn: 'root' })
 export class GitHubProjectsService {
@@ -9,6 +9,10 @@ export class GitHubProjectsService {
 
   listProjects(): Promise<GitHubProjectInfo[]> {
     return firstValueFrom(this.http.get<GitHubProjectInfo[]>('/api/github/projects'));
+  }
+
+  getAppInfo(): Promise<GitHubAppInfo> {
+    return firstValueFrom(this.http.get<GitHubAppInfo>('/api/github/app-info'));
   }
 
   getColumns(nodeId: string, installationId: number): Promise<{ statusFieldId: string; columns: ProjectColumn[] }> {

--- a/Demo/WebhooksDemo/WebhooksDemo/Controllers/GitHubAppInfoController.cs
+++ b/Demo/WebhooksDemo/WebhooksDemo/Controllers/GitHubAppInfoController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MintPlayer.SourceGenerators.Attributes;
+
+namespace WebhooksDemo.Controllers;
+
+/// <summary>
+/// Surfaces non-secret metadata about the GitHub App so the frontend can build a
+/// deep-link to the app's install page. The slug is a short, public, human-readable
+/// identifier (URL bar shows <c>https://github.com/apps/&lt;slug&gt;</c>).
+/// </summary>
+[ApiController]
+[Route("api/github/app-info")]
+[AllowAnonymous]
+public partial class GitHubAppInfoController : ControllerBase
+{
+    [Inject] private readonly IConfiguration _configuration;
+
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var slug = _configuration["GitHub:Production:AppSlug"];
+        return Ok(new AppInfo { ProductionAppSlug = slug });
+    }
+
+    public sealed class AppInfo
+    {
+        public string? ProductionAppSlug { get; init; }
+    }
+}

--- a/Demo/WebhooksDemo/WebhooksDemo/Recipients/DeleteBranchOnPullRequestClose.cs
+++ b/Demo/WebhooksDemo/WebhooksDemo/Recipients/DeleteBranchOnPullRequestClose.cs
@@ -1,0 +1,68 @@
+using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Messaging.Abstractions;
+using MintPlayer.Spark.Webhooks.GitHub.Messages;
+using MintPlayer.Spark.Webhooks.GitHub.Services;
+using Octokit;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.PullRequest;
+
+namespace WebhooksDemo.Recipients;
+
+/// <summary>
+/// Bot-wide policy: when a pull request closes (merged or not), delete its head
+/// branch via the GitHub API. Mirrors the per-repo "Automatically delete head
+/// branches" setting at organization scope, so installing the app makes it the
+/// default for every repository it sees webhooks from.
+/// </summary>
+public partial class DeleteBranchOnPullRequestClose : IRecipient<GitHubWebhookMessage<PullRequestEvent>>
+{
+    [Inject] private readonly IGitHubInstallationService _installationService;
+    [Inject] private readonly ILogger<DeleteBranchOnPullRequestClose> _logger;
+
+    public async Task HandleAsync(GitHubWebhookMessage<PullRequestEvent> message, CancellationToken cancellationToken = default)
+    {
+        if (message.Event.Action != PullRequestActionValue.Closed)
+            return;
+
+        var pr = message.Event.PullRequest;
+        var headRef = pr.Head.Ref;
+        var headRepo = pr.Head.Repo;
+        var baseRepo = pr.Base.Repo;
+
+        // Cross-repo PR (fork): the head branch lives in a repo we don't control.
+        if (headRepo is null || baseRepo is null || headRepo.Id != baseRepo.Id)
+        {
+            _logger.LogDebug("Skipping branch delete for PR #{Number}: head is on a different repo (fork).", pr.Number);
+            return;
+        }
+
+        var owner = baseRepo.Owner.Login;
+        var name = baseRepo.Name;
+
+        try
+        {
+            var client = await _installationService.CreateInstallationClientAsync(message.InstallationId);
+            await client.Git.Reference.Delete(owner, name, $"heads/{headRef}");
+            _logger.LogInformation("Deleted branch {Owner}/{Repo}:{Ref} after PR #{Number} closed.",
+                owner, name, headRef, pr.Number);
+        }
+        catch (NotFoundException)
+        {
+            // Race with GitHub's own auto-delete (delete_branch_on_merge), or the branch
+            // was already removed manually. Either way, our intended state is reached.
+            _logger.LogInformation("Branch {Owner}/{Repo}:{Ref} was already gone for PR #{Number}.",
+                owner, name, headRef, pr.Number);
+        }
+        catch (ApiValidationException ex)
+        {
+            // 422 typically means the branch is protected — skip rather than retry.
+            _logger.LogWarning(ex, "Refused to delete branch {Owner}/{Repo}:{Ref} for PR #{Number} (likely protected).",
+                owner, name, headRef, pr.Number);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete branch {Owner}/{Repo}:{Ref} for PR #{Number}.",
+                owner, name, headRef, pr.Number);
+        }
+    }
+}

--- a/Demo/WebhooksDemo/WebhooksDemo/appsettings.json
+++ b/Demo/WebhooksDemo/WebhooksDemo/appsettings.json
@@ -14,6 +14,9 @@
   },
   "GitHub": {
     "WebhookSecret": "",
-    "SmeeChannelUrl": ""
+    "SmeeChannelUrl": "",
+    "Production": {
+      "AppSlug": "testappspark"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two related additions for org-wide GitHub App ergonomics in WebhooksDemo:

1. **Install-app hint** below the Card on `/github-projects` — "If your project doesn't appear, you need to install this app on your organization." links to `https://github.com/apps/<slug>/installations/new`. Slug source: `GitHub:Production:AppSlug` in configuration, surfaced via a new `GET /api/github/app-info` endpoint.
2. **Org-wide branch cleanup** via a new `DeleteBranchOnPullRequestClose` recipient — mirrors GitHub's per-repo "Automatically delete head branches" setting at organization scope. Triggers on every `PullRequestEvent` with `action=Closed` (merged or not) and deletes the head ref via the installation client.

## Behavior — branch cleanup

- Skips cross-repo PRs (forks): head and base repo IDs differ → fork → branch lives somewhere we don't control.
- Idempotent on the delete:
  - `404 NotFoundException` → branch already gone (race with GitHub's own auto-delete or manual removal). Logged at `Info`.
  - `422 ApiValidationException` → branch protected. Logged at `Warning`.
  - Other failures logged at `Error`.

## Configuration

- `appsettings.json` defaults `GitHub:Production:AppSlug` to `testappspark` (matches the existing app). Override via env: `GitHub__Production__AppSlug`.
- No new env required for the recipient — it uses `IGitHubInstallationService` which is already wired.

## Frontend

- New `getAppInfo()` on `GitHubProjectsService`.
- Component fetches in parallel with project list; soft-fails (link hidden) if endpoint is unreachable.
- Translations added in en/fr/nl.

## Test plan

- [ ] `/github-projects` renders the install link below the Card with the correct URL (`https://github.com/apps/testappspark/installations/new`, opens in new tab).
- [ ] Open a test PR on a repo where the bot is installed; merge it. Confirm the head branch is deleted.
- [ ] Repeat for a PR closed without merging — head branch deleted.
- [ ] Repeat with a fork PR — head branch survives (fork case skipped).
- [ ] Repeat with a repo whose own `delete_branch_on_merge` is enabled and the PR was merged — handler logs `Info` for the 404 race; build still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)