### PR TITLE
fix(ci): Dockerfile uses Nx for Angular build; PR workflow gates on build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -68,6 +68,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-playwright-
 
+    # Run build before tests so Angular-app build failures (e.g., broken
+    # imports, type errors, budget overruns) block the PR. The .NET test
+    # target already dependsOn build, but the demo Angular apps
+    # (@spark-demo/{demo-app,fleet-demo,hr-demo,webhooks-demo}) don't have
+    # a test target — without this step their build is never exercised in
+    # CI, and the next deploy run is the first thing to notice.
+    - name: Build affected projects (Nx)
+      run: npx nx affected --target=build
+
     - name: Run affected tests (.NET + Angular via Nx)
       run: npx nx affected --target=test
       env:

--- a/Demo/WebhooksDemo/WebhooksDemo/Dockerfile
+++ b/Demo/WebhooksDemo/WebhooksDemo/Dockerfile
@@ -27,11 +27,12 @@ COPY ["MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csp
 RUN dotnet restore "./Demo/WebhooksDemo/WebhooksDemo/WebhooksDemo.csproj"
 COPY . .
 
-# Build Angular frontend
+# Build Angular frontend via Nx (post-Nx-migration: there's no per-app
+# angular.json, so `ng build` doesn't see a workspace; build target is
+# defined in Demo/WebhooksDemo/WebhooksDemo/ClientApp/project.json).
 WORKDIR /src
-RUN npm install
-WORKDIR /src/Demo/WebhooksDemo/WebhooksDemo/ClientApp
-RUN npx ng build --configuration=production
+RUN npm ci
+RUN npx nx run @spark-demo/webhooks-demo:build --configuration=production
 
 # Build .NET application
 WORKDIR "/src/Demo/WebhooksDemo/WebhooksDemo"


### PR DESCRIPTION
## Summary

Two related fixes triggered by the post-#136 deploy failure ([run](https://github.com/MintPlayer/MintPlayer.Spark/actions/runs/24952279927/job/73064379824)).

### 1. Dockerfile — `npx ng build` → `npx nx run …:build`

The Nx migration removed per-app `angular.json` files. The Dockerfile still ran `npx ng build --configuration=production` from the ClientApp directory, which now errors:

```
Error: This command is not available when running the Angular CLI outside a workspace.
```

The last 5 deploy runs all failed for this reason — pre-existing breakage that surfaces because every push to master matching the `Demo/WebhooksDemo/**` paths triggers the workflow. Replaced with `npx nx run @spark-demo/webhooks-demo:build --configuration=production`, run from the workspace root. Switched `npm install` → `npm ci` for reproducibility inside the build image.

### 2. pull-request.yml — gate on `nx affected --target=build`

The `.NET test target dependsOn: ["build"]`, so .NET build failures already block PRs. But the demo Angular apps have no `test` target — only `build`. So a broken Angular build sails through PR review and the post-merge deploy run is the first thing to notice. Added a `Build affected projects (Nx)` step before the test step that runs `npx nx affected --target=build`, exercising every project's build target, .NET and Angular alike.

## Test plan

- [ ] CI on this PR: the new "Build affected projects" step runs and passes — proves the existing tree builds clean.
- [ ] Post-merge: the next `webhooks-demo-deploy` run on master succeeds end-to-end (Docker image builds, pushes to GHCR, VPS deploy step runs).
- [ ] Optional: open a throwaway PR introducing a deliberate Angular break (e.g., reference an undefined symbol in webhooks-demo) and confirm the new step rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)