### PR TITLE
fix(webhooks-demo): mount raven-data volume at the image's actual data dir

### DIFF
--- a/Demo/WebhooksDemo/docker-compose.yml
+++ b/Demo/WebhooksDemo/docker-compose.yml
@@ -7,7 +7,10 @@ services:
       - RAVEN_Security_UnsecuredAccessAllowed=PublicNetwork
       - RAVEN_ServerUrl=http://0.0.0.0:8080
     volumes:
-      - raven-data:/opt/RavenDB/Server/RavenData
+      # ravendb:7.1-latest sets RAVEN_DataDir=/var/lib/ravendb/data; mounting the
+      # legacy /opt/RavenDB/Server/RavenData path silently lost data on every
+      # container recreate.
+      - raven-data:/var/lib/ravendb/data
     networks:
       - web
     restart: unless-stopped


### PR DESCRIPTION
## Summary

`ravendb:7.1-latest` bakes in `RAVEN_DataDir=/var/lib/ravendb/data`. Our compose file mounted `raven-data` at the legacy `/opt/RavenDB/Server/RavenData` path, which doesn't exist in this image.

Result: RavenDB wrote everything to the container's writable layer instead of the mounted volume. The DB survived container *restarts* (writable layer persists across restarts) but **not** `docker compose down` / `up` (which recreates the container with a fresh writable layer). Every deploy effectively wiped the database.

## Verification done on the live VPS

```
$ docker compose exec spark-raven env | grep RAVEN
...
RAVEN_DataDir=/var/lib/ravendb/data       <-- actual path
...

$ docker compose exec spark-raven ls -la /opt/RavenDB/Server/RavenData
ls: cannot access '/opt/RavenDB/Server/RavenData': No such file or directory

$ docker volume ls | grep raven
local     webhooks-demo_raven-data        <-- volume exists, just mounted at the wrong target

$ sudo ls $(docker volume inspect webhooks-demo_raven-data | jq -r '.[0].Mountpoint')
(empty)
```

## After this lands

The fix takes effect on the next deploy (the deploy script `curl`s `docker-compose.yml` from master before each `docker compose up -d`). Existing in-container data is in the writable layer and will be lost when the new compose recreates the container — there's nothing currently in the volume to preserve, so this is a clean transition.

## Test plan

- [ ] After merge + deploy: configure a `GitHubProject` via the UI.
- [ ] Trigger a redeploy (e.g., empty commit on master matching the deploy paths, or `workflow_dispatch`).
- [ ] Verify the configured project survives the redeploy — UI still shows it as enabled.
- [ ] On the VPS, `docker compose exec spark-raven ls -la /var/lib/ravendb/data` should show non-empty content (System database, WebhooksDemo database directories, journal `.djrs` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)