### PR TITLE
fix(ng-spark): detail page now renders AsDetail-array attributes

### DIFF
--- a/node_packages/ng-spark/pipes/src/array-value.pipe.ts
+++ b/node_packages/ng-spark/pipes/src/array-value.pipe.ts
@@ -1,11 +1,23 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { PersistentObject } from '@mintplayer/ng-spark/models';
+import { PersistentObject, nestedPoToDict } from '@mintplayer/ng-spark/models';
 
+/**
+ * Resolves an attribute to a list of flat row dicts for the detail-page table.
+ * AsDetail array attributes carry their data as nested PersistentObjects in
+ * <c>attr.objects</c>, not <c>attr.value</c> — the server stopped putting flat
+ * dicts in <c>value</c> when AsDetail moved to its dedicated wire shape. Without
+ * this branch, the detail page rendered AsDetail arrays as empty tables even
+ * when the edit page (which reads <c>attr.objects</c> directly) showed rows.
+ */
 @Pipe({ name: 'arrayValue', standalone: true, pure: true })
 export class ArrayValuePipe implements PipeTransform {
   transform(attrName: string, item: PersistentObject | null): Record<string, any>[] {
     const attr = item?.attributes.find(a => a.name === attrName);
-    if (!attr || !Array.isArray(attr.value)) return [];
-    return attr.value;
+    if (!attr) return [];
+    if (attr.dataType === 'AsDetail' && attr.isArray && Array.isArray(attr.objects)) {
+      return attr.objects.map(po => nestedPoToDict(po));
+    }
+    if (Array.isArray(attr.value)) return attr.value;
+    return [];
   }
 }

--- a/node_packages/ng-spark/pipes/src/pure-pipes.spec.ts
+++ b/node_packages/ng-spark/pipes/src/pure-pipes.spec.ts
@@ -42,6 +42,32 @@ describe('ArrayValuePipe', () => {
   it('returns empty array when item is null', () => {
     expect(pipe.transform('rows', null)).toEqual([]);
   });
+
+  it('flattens AsDetail array attribute from attr.objects (server wire shape)', () => {
+    const item = {
+      attributes: [{
+        name: 'EventMappings',
+        dataType: 'AsDetail',
+        isArray: true,
+        value: null,
+        objects: [
+          { attributes: [{ name: 'WebhookEvent', value: 'IssuesOpened' }, { name: 'AutoAddToProject', value: true }] },
+          { attributes: [{ name: 'WebhookEvent', value: 'PullRequestMerged' }, { name: 'AutoAddToProject', value: false }] },
+        ],
+      }]
+    } as any;
+    expect(pipe.transform('EventMappings', item)).toEqual([
+      { WebhookEvent: 'IssuesOpened', AutoAddToProject: true },
+      { WebhookEvent: 'PullRequestMerged', AutoAddToProject: false },
+    ]);
+  });
+
+  it('returns empty array for AsDetail array with null objects', () => {
+    const item = {
+      attributes: [{ name: 'EventMappings', dataType: 'AsDetail', isArray: true, value: null, objects: null }]
+    } as any;
+    expect(pipe.transform('EventMappings', item)).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ArrayValuePipe` (used by `spark-po-detail.component.html` line 98 to render AsDetail array attributes as a `<bs-table>`) only read `attribute.value`. The server stopped putting flat dicts there when AsDetail moved to its dedicated wire shape — array data now lives in `attribute.objects` as nested PersistentObjects.

Symptom (reported live on a deployed `GitHubProject` detail page): the section for `EventMappings` was missing entirely, while the edit page showed the same data correctly. The edit component reads `attribute.objects` directly via `initFormData()`; the detail component went through the broken pipe.

## Fix

`ArrayValuePipe` now branches on `attribute.dataType === 'AsDetail' && attribute.isArray` and flattens `attribute.objects` via the existing `nestedPoToDict` helper — the same converter the edit form uses. Non-AsDetail array attributes still fall back to `attribute.value`.

## Tests

Two new cases in `pure-pipes.spec.ts`:
- AsDetail array with populated `objects` → flattened row dicts.
- AsDetail array with `objects: null` → empty array (graceful).

The four pre-existing cases still pass.

## Test plan (post-merge)

- [ ] Production: open the GitHubProject detail page (e.g., the one mentioned in the bug report) and confirm `EventMappings` now renders as a table with rows matching what the edit page shows.
- [ ] Verify the same fix benefits any other entity using AsDetail array properties (e.g., `Columns: ProjectColumn[]` on `GitHubProject`, `Address[]` etc. in other demos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)