### PR TITLE
ci: webhooks-demo deploy triggers on Angular-lib + workspace changes too

### DIFF
--- a/.github/workflows/webhooks-demo-deploy.yml
+++ b/.github/workflows/webhooks-demo-deploy.yml
@@ -15,6 +15,14 @@ on:
       - 'MintPlayer.Spark.Webhooks.GitHub/**'
       - 'MintPlayer.Spark.Webhooks.GitHub.DevTunnel/**'
       - 'MintPlayer.Dotnet.SocketExtensions/**'
+      # Angular libraries baked into the image via `nx run @spark-demo/webhooks-demo:build`.
+      - 'node_packages/ng-spark/**'
+      - 'node_packages/ng-spark-auth/**'
+      # Workspace-level files that affect the build (lockfile, Nx config, base tsconfig).
+      - 'package.json'
+      - 'package-lock.json'
+      - 'nx.json'
+      - 'tsconfig.base.json'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The webhooks-demo Docker image bakes in the Angular frontend, which is built by `nx run @spark-demo/webhooks-demo:build` and transitively builds `@mintplayer/ng-spark` and `@mintplayer/ng-spark-auth`. The deploy workflow's `paths` filter omitted those (and the workspace-level files), so changes there landed on master without triggering a redeploy.

This is what just happened with PR #140 — the AsDetail-array detail-page fix merged but the image stayed at PR #138's revision (7 hours old). I had to trigger a manual `workflow_dispatch` to ship it.

## Change

Adds to the `paths:` list:
- `node_packages/ng-spark/**`
- `node_packages/ng-spark-auth/**`
- `package.json`, `package-lock.json`, `nx.json`, `tsconfig.base.json`

## Test plan

- [ ] After merge: a future PR touching only `node_packages/ng-spark/**` and merging to master should trigger `webhooks-demo-deploy` automatically. Verify via `gh run list --workflow=webhooks-demo-deploy.yml --limit 1`.
- [ ] The existing PR-level `nx affected --target=build` step (added in PR #137) already gates Angular build failures pre-merge, so this purely affects the post-merge deploy trigger, not PR validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)