### PR TITLE
chore(webhooks-demo): pin ravendb image to 7.1.7

### DIFF
--- a/Demo/WebhooksDemo/docker-compose.yml
+++ b/Demo/WebhooksDemo/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
 
   spark-raven:
-    image: docker.io/ravendb/ravendb:7.1-latest
+    # Pinned to a specific patch (over `7.1-latest`, which moves) so a future
+    # major-revision refresh can't surprise the on-disk format / settings.json
+    # layout. Bump deliberately when you've tested an upgrade.
+    image: docker.io/ravendb/ravendb:7.1.7-ubuntu.22.04-x64
     environment:
       - RAVEN_Setup_Mode=None
       - RAVEN_Security_UnsecuredAccessAllowed=PublicNetwork


### PR DESCRIPTION
## Summary

Replaces the moving tag `ravendb:7.1-latest` with `ravendb:7.1.7-ubuntu.22.04-x64` (latest immutable 7.1 release per docker.io/ravendb/ravendb, uploaded 2026-03-17). Same risk class as the volume-path fix in PR #138 — a future major-revision refresh on the moving tag could silently change the on-disk format / settings.json layout and re-break persistence. Pinning + a deliberate bump on upgrades cuts that off.

## Why not the second follow-up too

I'd planned to bundle "fold master's `dotnet build --configuration Release` into `nx run-many --target=build:release` so the Release build is also cached" in this PR. Locally it flakes:

```
$ npx nx reset && npx nx run-many --target=build:release --skip-nx-cache
[33m NX [0m  Successfully ran target build:release for 27 projects
[31m NX [0m  Failed tasks:
  - MintPlayer.Spark.Abstractions:build:release
  - MintPlayer.Spark.SourceGenerators:build:release
  - MintPlayer.Spark.AllFeatures.SourceGenerators:build:release
```

Single-project runs always succeed. The race is parallel-compile against `--no-dependencies` (the inferred `build:release` target's args). `--parallel=1` works reliably but ~doubles cold-run time. Worth a separate, focused PR after fixing the flake at the target definition level (probably dropping `--no-dependencies` or wiring a solution-level target). Out of scope here.

## Test plan

- [ ] After merge: webhooks-demo-deploy runs and deploys the new image. RavenDB starts up under the new tag, data dir persists.
- [ ] On the VPS post-deploy: `docker compose images spark-raven` shows the pinned tag, not `7.1-latest`. Existing volume contents survive (matches the same expectation as PR #138's deploy did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)