### PR TITLE
feat(reflection-cache): primitive + Tier 1–3 migration (#151)

### DIFF
--- a/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
+++ b/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Abstractions</PackageId>
-		<Version>10.0.0-preview.33</Version>
+		<Version>10.0.0-preview.34</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions and shared models for MintPlayer.Spark low-code framework.</Description>

--- a/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
@@ -76,7 +76,7 @@ public static class AccessorCache
     }
 
     private static string BuildKey(PropertyInfo property)
-        => $"{property.DeclaringType!.FullName}|{property.Name}|{property.PropertyType.FullName}";
+        => $"{property.DeclaringType!.GetCacheKeyName()}|{property.Name}|{property.PropertyType.GetCacheKeyName()}";
 
     /// <summary>Marker type used as the per-type cache owner for accessor delegates.</summary>
     private sealed class PropertyInfoOwner;

--- a/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
@@ -1,0 +1,83 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace MintPlayer.Spark.Abstractions.Reflection;
+
+/// <summary>
+/// Compiled property accessors. Wraps a <see cref="PropertyInfo"/> in
+/// <see cref="Expression.Lambda{TDelegate}(Expression, ParameterExpression[])"/>
+/// to produce strongly-typed getters / setters that avoid the per-call overhead
+/// of <see cref="PropertyInfo.GetValue(object?)"/> / <see cref="PropertyInfo.SetValue(object?, object?)"/>.
+/// <para>
+/// Built on top of <see cref="ReflectionCache"/>: each compiled delegate is
+/// memoized per <see cref="PropertyInfo"/> for the lifetime of the AppDomain.
+/// </para>
+/// <para>
+/// The setter expects <paramref name="value"/> to already be assignable to the
+/// property type — type coercion (e.g. <c>Convert.ChangeType</c>, enum parsing,
+/// JSON unwrapping) must happen <em>before</em> calling the setter. Reflection-based
+/// callers that already do this coercion can swap in <see cref="GetSetter"/>
+/// without behavior change.
+/// </para>
+/// </summary>
+public static class AccessorCache
+{
+    /// <summary>
+    /// Returns a compiled getter that reads <paramref name="property"/> from a
+    /// boxed instance. Throws <see cref="ArgumentException"/> if the property is
+    /// not readable.
+    /// </summary>
+    public static Func<object, object?> GetGetter(PropertyInfo property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+        if (!property.CanRead)
+            throw new ArgumentException($"Property '{property.DeclaringType?.FullName}.{property.Name}' is not readable.", nameof(property));
+
+        return ReflectionCache.GetOrAdd<PropertyInfoOwner, Func<object, object?>>(
+            "get|" + BuildKey(property),
+            () => CompileGetter(property));
+    }
+
+    /// <summary>
+    /// Returns a compiled setter that writes <paramref name="property"/> on a
+    /// boxed instance. Throws <see cref="ArgumentException"/> if the property is
+    /// not writable.
+    /// </summary>
+    public static Action<object, object?> GetSetter(PropertyInfo property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+        if (!property.CanWrite)
+            throw new ArgumentException($"Property '{property.DeclaringType?.FullName}.{property.Name}' is not writable.", nameof(property));
+
+        return ReflectionCache.GetOrAdd<PropertyInfoOwner, Action<object, object?>>(
+            "set|" + BuildKey(property),
+            () => CompileSetter(property));
+    }
+
+    private static Func<object, object?> CompileGetter(PropertyInfo property)
+    {
+        // (object instance) => (object?)((TDeclaring)instance).Property
+        var instance = Expression.Parameter(typeof(object), "instance");
+        var typedInstance = Expression.Convert(instance, property.DeclaringType!);
+        var access = Expression.Property(typedInstance, property);
+        var boxed = Expression.Convert(access, typeof(object));
+        return Expression.Lambda<Func<object, object?>>(boxed, instance).Compile();
+    }
+
+    private static Action<object, object?> CompileSetter(PropertyInfo property)
+    {
+        // (object instance, object? value) => ((TDeclaring)instance).Property = (TProperty)value
+        var instance = Expression.Parameter(typeof(object), "instance");
+        var value = Expression.Parameter(typeof(object), "value");
+        var typedInstance = Expression.Convert(instance, property.DeclaringType!);
+        var typedValue = Expression.Convert(value, property.PropertyType);
+        var assign = Expression.Assign(Expression.Property(typedInstance, property), typedValue);
+        return Expression.Lambda<Action<object, object?>>(assign, instance, value).Compile();
+    }
+
+    private static string BuildKey(PropertyInfo property)
+        => $"{property.DeclaringType!.FullName}|{property.Name}|{property.PropertyType.FullName}";
+
+    /// <summary>Marker type used as the per-type cache owner for accessor delegates.</summary>
+    private sealed class PropertyInfoOwner;
+}

--- a/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs
@@ -9,8 +9,11 @@ namespace MintPlayer.Spark.Abstractions.Reflection;
 /// to produce strongly-typed getters / setters that avoid the per-call overhead
 /// of <see cref="PropertyInfo.GetValue(object?)"/> / <see cref="PropertyInfo.SetValue(object?, object?)"/>.
 /// <para>
-/// Built on top of <see cref="ReflectionCache"/>: each compiled delegate is
-/// memoized per <see cref="PropertyInfo"/> for the lifetime of the AppDomain.
+/// Built on top of <see cref="ReflectionCache"/>'s identity-keyed tier: each compiled
+/// delegate is memoized per <see cref="PropertyInfo"/> instance for the lifetime of
+/// the AppDomain. The CLR canonicalizes <c>PropertyInfo</c> within an
+/// <c>AssemblyLoadContext</c>, so independent <c>typeof(T).GetProperty(name)</c> calls
+/// hit the same cached delegate without string-key composition.
 /// </para>
 /// <para>
 /// The setter expects <paramref name="value"/> to already be assignable to the
@@ -33,9 +36,7 @@ public static class AccessorCache
         if (!property.CanRead)
             throw new ArgumentException($"Property '{property.DeclaringType?.FullName}.{property.Name}' is not readable.", nameof(property));
 
-        return ReflectionCache.GetOrAdd<PropertyInfoOwner, Func<object, object?>>(
-            "get|" + BuildKey(property),
-            () => CompileGetter(property));
+        return ReflectionCache.GetOrAdd<PropertyInfo, Func<object, object?>>(property, CompileGetter);
     }
 
     /// <summary>
@@ -49,9 +50,7 @@ public static class AccessorCache
         if (!property.CanWrite)
             throw new ArgumentException($"Property '{property.DeclaringType?.FullName}.{property.Name}' is not writable.", nameof(property));
 
-        return ReflectionCache.GetOrAdd<PropertyInfoOwner, Action<object, object?>>(
-            "set|" + BuildKey(property),
-            () => CompileSetter(property));
+        return ReflectionCache.GetOrAdd<PropertyInfo, Action<object, object?>>(property, CompileSetter);
     }
 
     private static Func<object, object?> CompileGetter(PropertyInfo property)
@@ -74,10 +73,4 @@ public static class AccessorCache
         var assign = Expression.Assign(Expression.Property(typedInstance, property), typedValue);
         return Expression.Lambda<Action<object, object?>>(assign, instance, value).Compile();
     }
-
-    private static string BuildKey(PropertyInfo property)
-        => $"{property.DeclaringType!.GetCacheKeyName()}|{property.Name}|{property.PropertyType.GetCacheKeyName()}";
-
-    /// <summary>Marker type used as the per-type cache owner for accessor delegates.</summary>
-    private sealed class PropertyInfoOwner;
 }

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
@@ -4,9 +4,9 @@ namespace MintPlayer.Spark.Abstractions.Reflection;
 
 /// <summary>
 /// Cached convenience wrappers over the most common <see cref="Type"/> reflection
-/// lookups, all backed by <see cref="ReflectionCache"/>. These are pure sugar — every
-/// method composes against <see cref="ReflectionCache.GetOrAdd{TValue}(Type, Func{Type, TValue})"/>
-/// or its overloads. The cache primitive itself stays domain-agnostic.
+/// lookups, all backed by <see cref="ReflectionCache"/>'s identity-keyed tier. These
+/// are pure sugar — every method composes against the cache primitive with the natural
+/// runtime-identity key (Type, (Type, name), (MemberInfo, attrType)).
 /// <para>
 /// Use these whenever you'd otherwise call <see cref="Type.GetProperty(string, BindingFlags)"/>
 /// or <see cref="Type.GetProperties(BindingFlags)"/> in a hot path. They scope to public
@@ -18,12 +18,13 @@ public static class ReflectedTypeExtensions
     private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
 
     /// <summary>
-    /// Returns <c>type.GetProperties(Public | Instance)</c>, cached per <see cref="Type"/>.
+    /// Returns <c>type.GetProperties(Public | Instance)</c>, cached per <see cref="Type"/>
+    /// instance.
     /// </summary>
     public static PropertyInfo[] GetCachedProperties(this Type type)
     {
         ArgumentNullException.ThrowIfNull(type);
-        return ReflectionCache.GetOrAdd<PropertyInfo[]>(type, static t => t.GetProperties(PublicInstance));
+        return ReflectionCache.GetOrAdd<Type, PropertyInfo[]>(type, static t => t.GetProperties(PublicInstance));
     }
 
     /// <summary>
@@ -36,43 +37,23 @@ public static class ReflectedTypeExtensions
     {
         ArgumentNullException.ThrowIfNull(type);
         ArgumentNullException.ThrowIfNull(name);
-        return ReflectionCache.GetOrAdd<PropertyInfo?>(
-            $"prop|{type.GetCacheKeyName()}|{name}",
-            () => type.GetProperty(name, PublicInstance));
+        return ReflectionCache.GetOrAdd<(Type Type, string Name), PropertyInfo?>(
+            (type, name),
+            static k => k.Type.GetProperty(k.Name, PublicInstance));
     }
 
     /// <summary>
     /// Returns <see cref="MemberInfo.GetCustomAttribute{T}"/>, cached per
-    /// <see cref="MemberInfo"/>. Includes negative caching for "no such attribute on
-    /// this member".
+    /// <c>(MemberInfo, attribute Type)</c>. Includes negative caching for "no such
+    /// attribute on this member".
     /// </summary>
     public static TAttribute? GetCachedCustomAttribute<TAttribute>(this MemberInfo member)
         where TAttribute : Attribute
     {
         ArgumentNullException.ThrowIfNull(member);
-        var key = $"attr|{typeof(TAttribute).GetCacheKeyName()}|{member.DeclaringType?.GetCacheKeyName()}|{member.Name}";
-        return ReflectionCache.GetOrAdd<TAttribute?>(key, member.GetCustomAttribute<TAttribute>);
-    }
-
-    /// <summary>
-    /// Returns the most-discriminating string identifier for <paramref name="type"/>:
-    /// <see cref="Type.AssemblyQualifiedName"/> (which already encodes assembly name,
-    /// version, culture, and public key token) when available, falling back to
-    /// <see cref="Type.FullName"/> for open generics, and <see cref="MemberInfo.Name"/>
-    /// as a last resort.
-    /// <para>
-    /// Use this whenever you compose a string cache key keyed on Type identity. AQN
-    /// disambiguates types that share a <see cref="Type.FullName"/> across assemblies —
-    /// a real risk in plugin / multi-version scenarios that plain FullName would silently
-    /// collide on. <strong>Do not</strong> use this for contractual identifiers stored in
-    /// model files (<c>EntityTypeDefinition.ClrType</c>) — those round-trip through disk
-    /// and must stay on <see cref="Type.FullName"/>.
-    /// </para>
-    /// </summary>
-    public static string GetCacheKeyName(this Type type)
-    {
-        ArgumentNullException.ThrowIfNull(type);
-        return type.AssemblyQualifiedName ?? type.FullName ?? type.Name;
+        return ReflectionCache.GetOrAdd<(MemberInfo Member, Type AttrType), TAttribute?>(
+            (member, typeof(TAttribute)),
+            static k => (TAttribute?)k.Member.GetCustomAttribute(k.AttrType));
     }
 
     /// <summary>
@@ -91,3 +72,4 @@ public static class ReflectedTypeExtensions
         return prop is not null ? AccessorCache.GetGetter(prop)(task) : null;
     }
 }
+

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
@@ -37,7 +37,7 @@ public static class ReflectedTypeExtensions
         ArgumentNullException.ThrowIfNull(type);
         ArgumentNullException.ThrowIfNull(name);
         return ReflectionCache.GetOrAdd<PropertyInfo?>(
-            $"prop|{type.FullName ?? type.Name}|{name}",
+            $"prop|{type.GetCacheKeyName()}|{name}",
             () => type.GetProperty(name, PublicInstance));
     }
 
@@ -50,8 +50,29 @@ public static class ReflectedTypeExtensions
         where TAttribute : Attribute
     {
         ArgumentNullException.ThrowIfNull(member);
-        var key = $"attr|{typeof(TAttribute).FullName}|{member.DeclaringType?.FullName}|{member.Name}";
+        var key = $"attr|{typeof(TAttribute).GetCacheKeyName()}|{member.DeclaringType?.GetCacheKeyName()}|{member.Name}";
         return ReflectionCache.GetOrAdd<TAttribute?>(key, member.GetCustomAttribute<TAttribute>);
+    }
+
+    /// <summary>
+    /// Returns the most-discriminating string identifier for <paramref name="type"/>:
+    /// <see cref="Type.AssemblyQualifiedName"/> (which already encodes assembly name,
+    /// version, culture, and public key token) when available, falling back to
+    /// <see cref="Type.FullName"/> for open generics, and <see cref="MemberInfo.Name"/>
+    /// as a last resort.
+    /// <para>
+    /// Use this whenever you compose a string cache key keyed on Type identity. AQN
+    /// disambiguates types that share a <see cref="Type.FullName"/> across assemblies —
+    /// a real risk in plugin / multi-version scenarios that plain FullName would silently
+    /// collide on. <strong>Do not</strong> use this for contractual identifiers stored in
+    /// model files (<c>EntityTypeDefinition.ClrType</c>) — those round-trip through disk
+    /// and must stay on <see cref="Type.FullName"/>.
+    /// </para>
+    /// </summary>
+    public static string GetCacheKeyName(this Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return type.AssemblyQualifiedName ?? type.FullName ?? type.Name;
     }
 
     /// <summary>

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+
+namespace MintPlayer.Spark.Abstractions.Reflection;
+
+/// <summary>
+/// Cached convenience wrappers over the most common <see cref="Type"/> reflection
+/// lookups, all backed by <see cref="ReflectionCache"/>. These are pure sugar — every
+/// method composes against <see cref="ReflectionCache.GetOrAdd{TValue}(Type, Func{Type, TValue})"/>
+/// or its overloads. The cache primitive itself stays domain-agnostic.
+/// <para>
+/// Use these whenever you'd otherwise call <see cref="Type.GetProperty(string, BindingFlags)"/>
+/// or <see cref="Type.GetProperties(BindingFlags)"/> in a hot path. They scope to public
+/// instance members, which matches every existing reflection call site in Spark.
+/// </para>
+/// </summary>
+public static class ReflectedTypeExtensions
+{
+    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+    /// <summary>
+    /// Returns <c>type.GetProperties(Public | Instance)</c>, cached per <see cref="Type"/>.
+    /// </summary>
+    public static PropertyInfo[] GetCachedProperties(this Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return ReflectionCache.GetOrAdd<PropertyInfo[]>(type, static t => t.GetProperties(PublicInstance));
+    }
+
+    /// <summary>
+    /// Returns <c>type.GetProperty(name, Public | Instance)</c>, cached per
+    /// <c>(Type, name)</c>. <c>null</c> results are cached too (negative caching),
+    /// so a known-missing property doesn't trigger a fresh reflection lookup on every
+    /// call.
+    /// </summary>
+    public static PropertyInfo? GetCachedProperty(this Type type, string name)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(name);
+        return ReflectionCache.GetOrAdd<PropertyInfo?>(
+            $"prop|{type.FullName ?? type.Name}|{name}",
+            () => type.GetProperty(name, PublicInstance));
+    }
+
+    /// <summary>
+    /// Returns <see cref="MemberInfo.GetCustomAttribute{T}"/>, cached per
+    /// <see cref="MemberInfo"/>. Includes negative caching for "no such attribute on
+    /// this member".
+    /// </summary>
+    public static TAttribute? GetCachedCustomAttribute<TAttribute>(this MemberInfo member)
+        where TAttribute : Attribute
+    {
+        ArgumentNullException.ThrowIfNull(member);
+        var key = $"attr|{typeof(TAttribute).FullName}|{member.DeclaringType?.FullName}|{member.Name}";
+        return ReflectionCache.GetOrAdd<TAttribute?>(key, member.GetCustomAttribute<TAttribute>);
+    }
+}

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs
@@ -53,4 +53,20 @@ public static class ReflectedTypeExtensions
         var key = $"attr|{typeof(TAttribute).FullName}|{member.DeclaringType?.FullName}|{member.Name}";
         return ReflectionCache.GetOrAdd<TAttribute?>(key, member.GetCustomAttribute<TAttribute>);
     }
+
+    /// <summary>
+    /// Reads <c>Task&lt;T&gt;.Result</c> reflectively using a cached
+    /// <see cref="PropertyInfo"/> + compiled getter. Use this when a non-generic
+    /// <see cref="Task"/> reference was produced via reflection (e.g.
+    /// <c>MethodInfo.Invoke</c> on a <c>Task&lt;T&gt;</c>-returning method) and you
+    /// need to extract the result without paying for fresh reflection on every call.
+    /// The task <strong>must already be completed</strong> — this method does not
+    /// await; it just reads the <c>Result</c> property.
+    /// </summary>
+    public static object? GetCompletedTaskResult(this Task task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        var prop = task.GetType().GetCachedProperty("Result");
+        return prop is not null ? AccessorCache.GetGetter(prop)(task) : null;
+    }
 }

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
@@ -4,16 +4,19 @@ namespace MintPlayer.Spark.Abstractions.Reflection;
 
 /// <summary>
 /// Process-wide memoization primitive for reflection (and other) lookups whose
-/// result is immutable for the lifetime of the AppDomain. Two-tier:
+/// result is immutable for the lifetime of the AppDomain. Three tiers:
 /// <list type="bullet">
 ///   <item><c>GetOrAdd&lt;TOwner, TValue&gt;(string, Func&lt;TValue&gt;)</c> —
 ///   per-type cache. Each <typeparamref name="TOwner"/> gets its own dictionary
-///   via generic-static specialization, so keys never collide across types.</item>
+///   via generic-static specialization, so keys never collide across owners.</item>
 ///   <item><c>GetOrAdd&lt;TValue&gt;(string, Func&lt;TValue&gt;)</c> —
-///   global string-keyed cache for cross-type lookups.</item>
-///   <item><c>GetOrAdd&lt;TValue&gt;(Type, Func&lt;Type, TValue&gt;)</c> —
-///   global Type-keyed cache, avoids <c>type.FullName</c> boilerplate at call
-///   sites.</item>
+///   global string-keyed cache for cross-type lookups whose natural key is a
+///   string the caller controls (e.g. user-supplied CLR type names).</item>
+///   <item><c>GetOrAdd&lt;TKey, TValue&gt;(TKey, Func&lt;TKey, TValue&gt;)</c> —
+///   identity-keyed cache. Pass any <see cref="Type"/>, <see cref="System.Reflection.PropertyInfo"/>,
+///   <see cref="System.Reflection.MemberInfo"/>, or <c>ValueTuple</c> thereof
+///   directly — no string composition, no FullName ambiguity, equality is whatever
+///   <typeparamref name="TKey"/> defines.</item>
 /// </list>
 /// Backed by <see cref="ConcurrentDictionary{TKey,TValue}"/> + <see cref="Lazy{T}"/>
 /// with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>: lock-free reads,
@@ -45,12 +48,20 @@ public static class ReflectionCache
         internal static readonly ConcurrentDictionary<string, Lazy<object?>> Cache = new();
     }
 
+    /// <summary>
+    /// One dictionary per closed <typeparamref name="TKey"/> via generic-static
+    /// specialization. The inner key tuple includes <c>typeof(TValue)</c> so two
+    /// callers using the same <typeparamref name="TKey"/> shape but caching different
+    /// value types don't collide on a shared slot and trigger
+    /// <see cref="InvalidCastException"/> at the unbox boundary.
+    /// </summary>
+    private static class TypedKey<TKey> where TKey : notnull
+    {
+        // ReSharper disable once StaticMemberInGenericType
+        internal static readonly ConcurrentDictionary<(TKey Key, Type ValueType), Lazy<object?>> Cache = new();
+    }
+
     private static readonly ConcurrentDictionary<string, Lazy<object?>> globalCache = new();
-    // Keyed on (Type, ValueType) so distinct call sites that cache different things per
-    // Type don't collide. Without the value-type discriminator, two callers asking for
-    // typeof(Foo) with different TValue would share an entry and the second would get
-    // the first's cached object, hitting an InvalidCastException at the boundary.
-    private static readonly ConcurrentDictionary<(Type Key, Type ValueType), Lazy<object?>> typeKeyedCache = new();
 
     /// <summary>
     /// Per-type tier. Returns the cached value for <paramref name="key"/> in the
@@ -69,17 +80,18 @@ public static class ReflectionCache
     }
 
     /// <summary>
-    /// Global string-keyed tier. Use when the cache key is naturally a string and
-    /// not bound to one owning type (assembly scans, name → Type maps, …).
+    /// Global string-keyed tier. Use when the cache key is naturally a string the
+    /// caller controls — typically a user-supplied CLR type name or other free-form
+    /// identifier. For Type / PropertyInfo / MemberInfo lookups, prefer the
+    /// identity-keyed tier (<see cref="GetOrAdd{TKey,TValue}(TKey, Func{TKey, TValue})"/>) —
+    /// it sidesteps every <see cref="Type.FullName"/> / <see cref="Type.AssemblyQualifiedName"/>
+    /// ambiguity by keying on runtime identity.
     /// <para>
-    /// <strong>Keyspace convention.</strong> All callers share one global dictionary,
-    /// so keys must carry a unique namespace prefix to avoid silent collisions across
-    /// unrelated call sites. Established prefixes in Spark: <c>prop|</c> (property
-    /// lookups), <c>attr|</c> (custom-attribute reads), <c>get|</c>/<c>set|</c>
-    /// (compiled accessors), <c>resolveType|</c> (Type.GetType + assembly walk),
-    /// <c>sessionLoadAsync|</c> (closed generic <c>LoadAsync&lt;T&gt;</c> MethodInfos).
-    /// New call sites should pick a fresh, descriptive prefix and document it where
-    /// the key is constructed.
+    /// <strong>Keyspace convention.</strong> All callers of this tier share one
+    /// dictionary, so keys must carry a unique namespace prefix to avoid silent
+    /// collisions across unrelated call sites (e.g. <c>resolveType|...</c>,
+    /// <c>clrType|...</c>). New call sites should pick a fresh, descriptive prefix
+    /// and document it where the key is constructed.
     /// </para>
     /// </summary>
     public static TValue GetOrAdd<TValue>(string key, Func<TValue> factory)
@@ -94,32 +106,40 @@ public static class ReflectionCache
     }
 
     /// <summary>
-    /// Global Type-keyed tier. Convenience overload for "given any
-    /// <see cref="Type"/>, give me its X" lookups; saves callers from
-    /// stringifying <c>type.FullName</c>.
+    /// Identity-keyed tier. Pass any <typeparamref name="TKey"/> with correct
+    /// <see cref="object.Equals(object?)"/> + <see cref="object.GetHashCode"/> semantics —
+    /// <see cref="Type"/>, <see cref="System.Reflection.PropertyInfo"/>,
+    /// <see cref="System.Reflection.MemberInfo"/>, or <c>ValueTuple</c> compositions of
+    /// those — and the cache uses runtime identity, not a stringified surrogate.
+    /// <para>
+    /// One dictionary exists per closed <typeparamref name="TKey"/> via generic-static
+    /// specialization. Within a dictionary, entries are discriminated on
+    /// <c>typeof(TValue)</c> so two callers reusing the same key shape for different
+    /// value types stay isolated.
+    /// </para>
     /// </summary>
-    public static TValue GetOrAdd<TValue>(Type key, Func<Type, TValue> factory)
+    public static TValue GetOrAdd<TKey, TValue>(TKey key, Func<TKey, TValue> factory)
+        where TKey : notnull
     {
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(factory);
 
-        var lazy = typeKeyedCache.GetOrAdd(
+        var lazy = TypedKey<TKey>.Cache.GetOrAdd(
             (key, typeof(TValue)),
             entry => new Lazy<object?>(() => factory(entry.Key), LazyThreadSafetyMode.ExecutionAndPublication));
         return (TValue)lazy.Value!;
     }
 
     /// <summary>
-    /// Test-only helper: clears the global tiers. Does not (and cannot) clear
-    /// per-type tiers — those are owned by <see cref="PerType{TOwner}"/> generic
-    /// statics and have AppDomain lifetime by design.
+    /// Test-only helper: clears the global string-keyed tier. The per-<typeparamref name="TOwner"/>
+    /// and identity-keyed tiers are generic-static-specialized and have AppDomain lifetime
+    /// by design — tests that exercise them must use unique TOwner/TKey marker types per case.
     /// </summary>
     internal static void ClearGlobalForTests()
     {
         globalCache.Clear();
-        typeKeyedCache.Clear();
     }
 
-    /// <summary>Diagnostic — total entries across the two global tiers.</summary>
-    internal static int GlobalCount => globalCache.Count + typeKeyedCache.Count;
+    /// <summary>Diagnostic — entries in the global string-keyed tier.</summary>
+    internal static int GlobalCount => globalCache.Count;
 }

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+
+namespace MintPlayer.Spark.Abstractions.Reflection;
+
+/// <summary>
+/// Process-wide memoization primitive for reflection (and other) lookups whose
+/// result is immutable for the lifetime of the AppDomain. Two-tier:
+/// <list type="bullet">
+///   <item><c>GetOrAdd&lt;TOwner, TValue&gt;(string, Func&lt;TValue&gt;)</c> —
+///   per-type cache. Each <typeparamref name="TOwner"/> gets its own dictionary
+///   via generic-static specialization, so keys never collide across types.</item>
+///   <item><c>GetOrAdd&lt;TValue&gt;(string, Func&lt;TValue&gt;)</c> —
+///   global string-keyed cache for cross-type lookups.</item>
+///   <item><c>GetOrAdd&lt;TValue&gt;(Type, Func&lt;Type, TValue&gt;)</c> —
+///   global Type-keyed cache, avoids <c>type.FullName</c> boilerplate at call
+///   sites.</item>
+/// </list>
+/// Backed by <see cref="ConcurrentDictionary{TKey,TValue}"/> + <see cref="Lazy{T}"/>
+/// with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>: lock-free reads,
+/// factory runs exactly once per key under contention, no TOCTOU window.
+/// <para>
+/// Entries live for the lifetime of the AppDomain — there is no eviction. Reflection
+/// metadata cannot change at runtime, so this is correct.
+/// </para>
+/// <para>
+/// <strong>Exception caching.</strong> If a factory throws, the exception is captured
+/// by <see cref="Lazy{T}"/> and re-thrown on every subsequent access for that key.
+/// This is the correct behavior for deterministic reflection failures (e.g. a missing
+/// member that genuinely doesn't exist). Callers that need transient-failure
+/// semantics should not use this cache.
+/// </para>
+/// <para>
+/// <strong>Null caching.</strong> Factories may return <c>null</c>; the null is
+/// cached and returned on subsequent calls (negative caching). This is the intended
+/// shape for "lookup may genuinely have no result" cases such as
+/// <c>Type? FindActionsType(string name)</c>.
+/// </para>
+/// </summary>
+public static class ReflectionCache
+{
+    private static class PerType<TOwner>
+    {
+        // ReSharper disable once StaticMemberInGenericType
+        // — intentional: one dictionary per closed TOwner.
+        internal static readonly ConcurrentDictionary<string, Lazy<object?>> Cache = new();
+    }
+
+    private static readonly ConcurrentDictionary<string, Lazy<object?>> globalCache = new();
+    // Keyed on (Type, ValueType) so distinct call sites that cache different things per
+    // Type don't collide. Without the value-type discriminator, two callers asking for
+    // typeof(Foo) with different TValue would share an entry and the second would get
+    // the first's cached object, hitting an InvalidCastException at the boundary.
+    private static readonly ConcurrentDictionary<(Type Key, Type ValueType), Lazy<object?>> typeKeyedCache = new();
+
+    /// <summary>
+    /// Per-type tier. Returns the cached value for <paramref name="key"/> in the
+    /// dictionary owned by <typeparamref name="TOwner"/>, computing it via
+    /// <paramref name="factory"/> on first access.
+    /// </summary>
+    public static TValue GetOrAdd<TOwner, TValue>(string key, Func<TValue> factory)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var lazy = PerType<TOwner>.Cache.GetOrAdd(
+            key,
+            _ => new Lazy<object?>(() => factory(), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+
+    /// <summary>
+    /// Global string-keyed tier. Use when the cache key is naturally a string and
+    /// not bound to one owning type (assembly scans, name → Type maps, …).
+    /// </summary>
+    public static TValue GetOrAdd<TValue>(string key, Func<TValue> factory)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var lazy = globalCache.GetOrAdd(
+            key,
+            _ => new Lazy<object?>(() => factory(), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+
+    /// <summary>
+    /// Global Type-keyed tier. Convenience overload for "given any
+    /// <see cref="Type"/>, give me its X" lookups; saves callers from
+    /// stringifying <c>type.FullName</c>.
+    /// </summary>
+    public static TValue GetOrAdd<TValue>(Type key, Func<Type, TValue> factory)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var lazy = typeKeyedCache.GetOrAdd(
+            (key, typeof(TValue)),
+            entry => new Lazy<object?>(() => factory(entry.Key), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+
+    /// <summary>
+    /// Test-only helper: clears the global tiers. Does not (and cannot) clear
+    /// per-type tiers — those are owned by <see cref="PerType{TOwner}"/> generic
+    /// statics and have AppDomain lifetime by design.
+    /// </summary>
+    internal static void ClearGlobalForTests()
+    {
+        globalCache.Clear();
+        typeKeyedCache.Clear();
+    }
+
+    /// <summary>Diagnostic — total entries across the two global tiers.</summary>
+    internal static int GlobalCount => globalCache.Count + typeKeyedCache.Count;
+}

--- a/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
+++ b/MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs
@@ -71,6 +71,16 @@ public static class ReflectionCache
     /// <summary>
     /// Global string-keyed tier. Use when the cache key is naturally a string and
     /// not bound to one owning type (assembly scans, name → Type maps, …).
+    /// <para>
+    /// <strong>Keyspace convention.</strong> All callers share one global dictionary,
+    /// so keys must carry a unique namespace prefix to avoid silent collisions across
+    /// unrelated call sites. Established prefixes in Spark: <c>prop|</c> (property
+    /// lookups), <c>attr|</c> (custom-attribute reads), <c>get|</c>/<c>set|</c>
+    /// (compiled accessors), <c>resolveType|</c> (Type.GetType + assembly walk),
+    /// <c>sessionLoadAsync|</c> (closed generic <c>LoadAsync&lt;T&gt;</c> MethodInfos).
+    /// New call sites should pick a fresh, descriptive prefix and document it where
+    /// the key is constructed.
+    /// </para>
     /// </summary>
     public static TValue GetOrAdd<TValue>(string key, Func<TValue> factory)
     {

--- a/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
+++ b/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging</PackageId>
-		<Version>10.0.0-preview.33</Version>
+		<Version>10.0.0-preview.34</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Durable message bus for MintPlayer.Spark with RavenDB persistence, scoped recipients, queue isolation, and retry logic.</Description>

--- a/MintPlayer.Spark.Messaging/Services/MessageBus.cs
+++ b/MintPlayer.Spark.Messaging/Services/MessageBus.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Options;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Messaging.Abstractions;
 using MintPlayer.Spark.Messaging.Models;
 using Raven.Client.Documents;
-using System.Reflection;
 using Newtonsoft.Json;
 
 namespace MintPlayer.Spark.Messaging.Services;
@@ -31,7 +31,7 @@ internal partial class MessageBus : IMessageBus
         var queueName = queueNameOverride;
         if (queueName == null)
         {
-            var queueAttribute = messageType.GetCustomAttribute<MessageQueueAttribute>();
+            var queueAttribute = messageType.GetCachedCustomAttribute<MessageQueueAttribute>();
             queueName = queueAttribute?.QueueName ?? messageType.FullName!;
         }
 

--- a/MintPlayer.Spark.Messaging/Services/MessageSubscriptionManager.cs
+++ b/MintPlayer.Spark.Messaging/Services/MessageSubscriptionManager.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Messaging.Abstractions;
 using Raven.Client.Documents;
 using System.Reflection;
@@ -103,7 +104,7 @@ internal sealed partial class MessageSubscriptionManager : BackgroundService
                 continue;
 
             var messageType = serviceType.GetGenericArguments()[0];
-            var queueAttribute = messageType.GetCustomAttribute<MessageQueueAttribute>();
+            var queueAttribute = messageType.GetCachedCustomAttribute<MessageQueueAttribute>();
             var queueName = queueAttribute?.QueueName ?? messageType.FullName!;
             queueNames.Add(queueName);
         }

--- a/MintPlayer.Spark.Messaging/Services/MessageSubscriptionWorker.cs
+++ b/MintPlayer.Spark.Messaging/Services/MessageSubscriptionWorker.cs
@@ -86,12 +86,12 @@ internal sealed class MessageSubscriptionWorker : SparkSubscriptionWorker<SparkM
 
                 // Cache the closed generic interface types per CLR message type — the
                 // MakeGenericType call is otherwise repeated for every message processed.
-                var recipientInterfaceType = ReflectionCache.GetOrAdd<Type>(
-                    $"recipientInterface|{clrType.FullName}",
-                    () => typeof(IRecipient<>).MakeGenericType(clrType));
-                var checkpointInterfaceType = ReflectionCache.GetOrAdd<Type>(
-                    $"checkpointRecipientInterface|{clrType.FullName}",
-                    () => typeof(ICheckpointRecipient<>).MakeGenericType(clrType));
+                var recipientInterfaceType = ReflectionCache.GetOrAdd<(string Op, Type Type), Type>(
+                    ("MessageSubscriptionWorker.RecipientInterface", clrType),
+                    static k => typeof(IRecipient<>).MakeGenericType(k.Type));
+                var checkpointInterfaceType = ReflectionCache.GetOrAdd<(string Op, Type Type), Type>(
+                    ("MessageSubscriptionWorker.CheckpointRecipientInterface", clrType),
+                    static k => typeof(ICheckpointRecipient<>).MakeGenericType(k.Type));
 
                 using (var scope = _serviceProvider.CreateScope())
                 {
@@ -158,18 +158,21 @@ internal sealed class MessageSubscriptionWorker : SparkSubscriptionWorker<SparkM
                             // Check if handler implements ICheckpointRecipient<T> and has a previous checkpoint
                             if (handler.Checkpoint != null && checkpointInterfaceType.IsAssignableFrom(handlerType))
                             {
-                                var checkpointHandleMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-                                    $"checkpointHandleAsync|{clrType.FullName}",
-                                    () => checkpointInterfaceType.GetMethod(
+                                var checkpointInterface = checkpointInterfaceType;
+                                var msgType = clrType;
+                                var checkpointHandleMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+                                    ("MessageSubscriptionWorker.CheckpointHandleAsync", clrType),
+                                    _ => checkpointInterface.GetMethod(
                                         nameof(ICheckpointRecipient<object>.HandleAsync),
-                                        [clrType, typeof(string), typeof(CancellationToken)]));
+                                        [msgType, typeof(string), typeof(CancellationToken)]));
                                 await (Task)checkpointHandleMethod!.Invoke(recipientInstance, [payload, handler.Checkpoint, cancellationToken])!;
                             }
                             else
                             {
-                                var handleMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-                                    $"recipientHandleAsync|{clrType.FullName}",
-                                    () => recipientInterfaceType.GetMethod(nameof(IRecipient<object>.HandleAsync)));
+                                var recipientInterface = recipientInterfaceType;
+                                var handleMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+                                    ("MessageSubscriptionWorker.RecipientHandleAsync", clrType),
+                                    _ => recipientInterface.GetMethod(nameof(IRecipient<object>.HandleAsync)));
                                 await (Task)handleMethod!.Invoke(recipientInstance, [payload, cancellationToken])!;
                             }
 

--- a/MintPlayer.Spark.Messaging/Services/MessageSubscriptionWorker.cs
+++ b/MintPlayer.Spark.Messaging/Services/MessageSubscriptionWorker.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.Options;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Messaging.Abstractions;
 using MintPlayer.Spark.Messaging.Models;
 using MintPlayer.Spark.SubscriptionWorker;
@@ -83,8 +84,14 @@ internal sealed class MessageSubscriptionWorker : SparkSubscriptionWorker<SparkM
                     return;
                 }
 
-                var recipientInterfaceType = typeof(IRecipient<>).MakeGenericType(clrType);
-                var checkpointInterfaceType = typeof(ICheckpointRecipient<>).MakeGenericType(clrType);
+                // Cache the closed generic interface types per CLR message type — the
+                // MakeGenericType call is otherwise repeated for every message processed.
+                var recipientInterfaceType = ReflectionCache.GetOrAdd<Type>(
+                    $"recipientInterface|{clrType.FullName}",
+                    () => typeof(IRecipient<>).MakeGenericType(clrType));
+                var checkpointInterfaceType = ReflectionCache.GetOrAdd<Type>(
+                    $"checkpointRecipientInterface|{clrType.FullName}",
+                    () => typeof(ICheckpointRecipient<>).MakeGenericType(clrType));
 
                 using (var scope = _serviceProvider.CreateScope())
                 {
@@ -151,14 +158,18 @@ internal sealed class MessageSubscriptionWorker : SparkSubscriptionWorker<SparkM
                             // Check if handler implements ICheckpointRecipient<T> and has a previous checkpoint
                             if (handler.Checkpoint != null && checkpointInterfaceType.IsAssignableFrom(handlerType))
                             {
-                                var checkpointHandleMethod = checkpointInterfaceType.GetMethod(
-                                    nameof(ICheckpointRecipient<object>.HandleAsync),
-                                    [clrType, typeof(string), typeof(CancellationToken)]);
+                                var checkpointHandleMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+                                    $"checkpointHandleAsync|{clrType.FullName}",
+                                    () => checkpointInterfaceType.GetMethod(
+                                        nameof(ICheckpointRecipient<object>.HandleAsync),
+                                        [clrType, typeof(string), typeof(CancellationToken)]));
                                 await (Task)checkpointHandleMethod!.Invoke(recipientInstance, [payload, handler.Checkpoint, cancellationToken])!;
                             }
                             else
                             {
-                                var handleMethod = recipientInterfaceType.GetMethod(nameof(IRecipient<object>.HandleAsync));
+                                var handleMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+                                    $"recipientHandleAsync|{clrType.FullName}",
+                                    () => recipientInterfaceType.GetMethod(nameof(IRecipient<object>.HandleAsync)));
                                 await (Task)handleMethod!.Invoke(recipientInstance, [payload, cancellationToken])!;
                             }
 

--- a/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
+++ b/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication.Abstractions</PackageId>
-		<Version>10.0.0-preview.33</Version>
+		<Version>10.0.0-preview.34</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Replication: ReplicatedAttribute, ModuleInformation, and ETL script models.</Description>

--- a/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
+++ b/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
@@ -18,4 +18,8 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/MintPlayer.Spark.Replication.Abstractions/Models/SyncAction.cs
+++ b/MintPlayer.Spark.Replication.Abstractions/Models/SyncAction.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using MintPlayer.Spark.Abstractions.Reflection;
 
 namespace MintPlayer.Spark.Replication.Abstractions.Models;
 
@@ -91,10 +91,10 @@ public class SyncAction<T> where T : class
     private static Dictionary<string, object?> EntityToDictionary(T entity)
     {
         var dict = new Dictionary<string, object?>();
-        foreach (var prop in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach (var prop in typeof(T).GetCachedProperties())
         {
             if (prop.CanRead)
-                dict[prop.Name] = prop.GetValue(entity);
+                dict[prop.Name] = AccessorCache.GetGetter(prop)(entity!);
         }
         return dict;
     }

--- a/MintPlayer.Spark.Replication/Extensions/SparkReplicationExtensions.cs
+++ b/MintPlayer.Spark.Replication/Extensions/SparkReplicationExtensions.cs
@@ -115,6 +115,11 @@ internal static class SparkReplicationExtensions
     {
         foreach (var (sourceModule, scripts) in scriptsByModule)
         {
+            // Note: TargetDatabase and TargetUrls are captured here at send-time and travel
+            // with the message — unlike the source module's URL, which the recipient
+            // resolves freshly from SparkModules on each delivery. If the consumer module's
+            // RavenDB cluster ever moves to new URLs, pending deployment messages will
+            // carry stale values until the next app startup re-broadcasts.
             yield return new EtlScriptDeploymentMessage
             {
                 SourceModuleName = sourceModule,

--- a/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
+++ b/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication</PackageId>
-		<Version>10.0.0-preview.33</Version>
+		<Version>10.0.0-preview.34</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cross-module ETL replication for MintPlayer.Spark using RavenDB ETL tasks and the durable message bus.</Description>

--- a/MintPlayer.Spark.Replication/Services/EtlScriptCollector.cs
+++ b/MintPlayer.Spark.Replication/Services/EtlScriptCollector.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Replication.Abstractions;
 using MintPlayer.Spark.Replication.Abstractions.Models;
 
@@ -19,18 +20,21 @@ internal class EtlScriptCollector
 
         foreach (var assembly in assemblies)
         {
-            var replicatedTypes = assembly.GetExportedTypes()
-                .Where(t => t is { IsClass: true, IsAbstract: false })
-                .Select(t => new
-                {
-                    Type = t,
-                    Attribute = t.GetCustomAttribute<ReplicatedAttribute>()
-                })
-                .Where(x => x.Attribute != null);
+            // Cache the [Replicated]-annotated types per assembly so repeat calls (e.g.
+            // collecting scripts from the same assembly more than once during testing or
+            // module re-init) don't re-walk the metadata tables.
+            var replicatedTypes = ReflectionCache.GetOrAdd<IReadOnlyList<(Type Type, ReplicatedAttribute Attribute)>>(
+                $"replicatedTypes|{assembly.FullName}",
+                () => assembly.GetExportedTypes()
+                    .Where(t => t is { IsClass: true, IsAbstract: false })
+                    .Select(t => (Type: t, Attribute: t.GetCachedCustomAttribute<ReplicatedAttribute>()))
+                    .Where(x => x.Attribute != null)
+                    .Select(x => (x.Type, x.Attribute!))
+                    .ToArray());
 
             foreach (var item in replicatedTypes)
             {
-                var attr = item.Attribute!;
+                var attr = item.Attribute;
                 var sourceCollection = attr.SourceCollection
                     ?? InferCollectionName(attr.OriginalType ?? item.Type);
 

--- a/MintPlayer.Spark.Replication/Services/EtlScriptCollector.cs
+++ b/MintPlayer.Spark.Replication/Services/EtlScriptCollector.cs
@@ -23,9 +23,9 @@ internal class EtlScriptCollector
             // Cache the [Replicated]-annotated types per assembly so repeat calls (e.g.
             // collecting scripts from the same assembly more than once during testing or
             // module re-init) don't re-walk the metadata tables.
-            var replicatedTypes = ReflectionCache.GetOrAdd<IReadOnlyList<(Type Type, ReplicatedAttribute Attribute)>>(
-                $"replicatedTypes|{assembly.FullName}",
-                () => assembly.GetExportedTypes()
+            var replicatedTypes = ReflectionCache.GetOrAdd<(string Op, Assembly Asm), IReadOnlyList<(Type Type, ReplicatedAttribute Attribute)>>(
+                ("EtlScriptCollector.ReplicatedTypes", assembly),
+                static k => k.Asm.GetExportedTypes()
                     .Where(t => t is { IsClass: true, IsAbstract: false })
                     .Select(t => (Type: t, Attribute: t.GetCachedCustomAttribute<ReplicatedAttribute>()))
                     .Where(x => x.Attribute != null)

--- a/MintPlayer.Spark.Replication/Services/EtlTaskManager.cs
+++ b/MintPlayer.Spark.Replication/Services/EtlTaskManager.cs
@@ -27,6 +27,19 @@ internal partial class EtlTaskManager
 
         try
         {
+            // Refuse to create an ETL task whose source and target are the same database —
+            // that would cause an infinite write loop (every applied transform re-triggers
+            // the source). Only the requesting module is supposed to invoke this, on the
+            // source module's store; if the two collapse to the same DB, the message bus
+            // routed the deployment to the wrong recipient (e.g. stale moduleInformations
+            // URL pointing back at the requester).
+            if (string.Equals(request.TargetDatabase, documentStore.Database, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to deploy ETL task '{taskName}': source and target database are both '{documentStore.Database}'. " +
+                    "This would create a self-loop. Check that this endpoint is being called on the source module, not the requesting module.");
+            }
+
             // Step 1: Create/update connection string to the requesting module's database
             var connectionString = new RavenConnectionString
             {

--- a/MintPlayer.Spark.Replication/Services/SyncActionInterceptor.cs
+++ b/MintPlayer.Spark.Replication/Services/SyncActionInterceptor.cs
@@ -183,9 +183,9 @@ internal partial class SyncActionInterceptor : ISyncActionInterceptor
     /// </summary>
     private static string[] GetPropertyNames(Type entityType)
     {
-        return ReflectionCache.GetOrAdd<string[]>(
-            $"replicatedPropNames|{entityType.FullName ?? entityType.Name}",
-            () => entityType.GetCachedProperties()
+        return ReflectionCache.GetOrAdd<(string Op, Type Type), string[]>(
+            ("SyncActionInterceptor.ReplicatedPropNames", entityType),
+            static k => k.Type.GetCachedProperties()
                 .Where(p => p.CanRead && p.CanWrite && !string.Equals(p.Name, "Id", StringComparison.Ordinal))
                 .Select(p => p.Name)
                 .ToArray());

--- a/MintPlayer.Spark.Replication/Services/SyncActionInterceptor.cs
+++ b/MintPlayer.Spark.Replication/Services/SyncActionInterceptor.cs
@@ -1,13 +1,12 @@
 using Microsoft.Extensions.Options;
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Replication.Abstractions;
 using MintPlayer.Spark.Replication.Abstractions.Configuration;
 using MintPlayer.Spark.Replication.Abstractions.Models;
 using MintPlayer.Spark.Replication.Models;
 using Raven.Client.Documents;
-using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text.Json;
 
 namespace MintPlayer.Spark.Replication.Services;
@@ -23,12 +22,6 @@ internal partial class SyncActionInterceptor : ISyncActionInterceptor
     [Inject] private readonly ILogger<SyncActionInterceptor> logger;
 
     private SparkReplicationOptions Options => optionsAccessor.Value;
-
-    // Cache: CLR type → ReplicatedAttribute (null means not replicated)
-    private static readonly ConcurrentDictionary<Type, ReplicatedAttribute?> _replicatedCache = new();
-
-    // Cache: CLR type → property names (excluding Id) for partial updates
-    private static readonly ConcurrentDictionary<Type, string[]> _propertyNamesCache = new();
 
     public bool IsReplicated(Type entityType)
     {
@@ -95,10 +88,10 @@ internal partial class SyncActionInterceptor : ISyncActionInterceptor
         var properties = GetPropertyNames(entityType);
 
         var data = new Dictionary<string, object?>();
-        foreach (var prop in entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach (var prop in entityType.GetCachedProperties())
         {
             if (prop.CanRead)
-                data[prop.Name] = NormalizeValue(prop.GetValue(entity));
+                data[prop.Name] = NormalizeValue(AccessorCache.GetGetter(prop)(entity));
         }
 
         var syncAction = new SyncAction
@@ -181,9 +174,7 @@ internal partial class SyncActionInterceptor : ISyncActionInterceptor
     }
 
     private static ReplicatedAttribute? GetReplicatedAttribute(Type type)
-    {
-        return _replicatedCache.GetOrAdd(type, t => t.GetCustomAttribute<ReplicatedAttribute>());
-    }
+        => type.GetCachedCustomAttribute<ReplicatedAttribute>();
 
     /// <summary>
     /// Gets the property names from the replicated entity type, excluding "Id".
@@ -192,8 +183,9 @@ internal partial class SyncActionInterceptor : ISyncActionInterceptor
     /// </summary>
     private static string[] GetPropertyNames(Type entityType)
     {
-        return _propertyNamesCache.GetOrAdd(entityType, t =>
-            t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        return ReflectionCache.GetOrAdd<string[]>(
+            $"replicatedPropNames|{entityType.FullName ?? entityType.Name}",
+            () => entityType.GetCachedProperties()
                 .Where(p => p.CanRead && p.CanWrite && !string.Equals(p.Name, "Id", StringComparison.Ordinal))
                 .Select(p => p.Name)
                 .ToArray());

--- a/MintPlayer.Spark.Tests/EntityMapperDisplayNameTests.cs
+++ b/MintPlayer.Spark.Tests/EntityMapperDisplayNameTests.cs
@@ -1,0 +1,245 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using NSubstitute;
+
+namespace MintPlayer.Spark.Tests;
+
+/// <summary>
+/// Pins the resolution chain inside <c>EntityMapper.GetEntityDisplayName</c>:
+/// <list type="number">
+///   <item><c>DisplayFormat</c> takes precedence (template with <c>{Property}</c> placeholders).</item>
+///   <item><c>DisplayAttribute</c> next (single property name).</item>
+///   <item>CLR type name as final fallback.</item>
+/// </list>
+/// The PR that introduced ReflectionCache also dropped the legacy
+/// "Name → FullName → Title" runtime probe (ModelSynchronizer auto-populates
+/// <c>DisplayAttribute</c>); these tests pin the new "purely JSON-driven" contract.
+/// </summary>
+public class EntityMapperDisplayNameTests
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private sealed class DisplayNamePerson
+    {
+        public string? Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string? Nickname { get; set; }
+    }
+
+    private static (EntityMapper mapper, IModelLoader loader) NewMapper(EntityTypeDefinition def)
+    {
+        var loader = Substitute.For<IModelLoader>();
+        loader.GetEntityType(PersonTypeId).Returns(def);
+        loader.GetEntityTypeByClrType(typeof(DisplayNamePerson).FullName!).Returns(def);
+        return (new EntityMapper(loader), loader);
+    }
+
+    [Fact]
+    public void DisplayFormat_template_resolves_placeholders_from_entity_properties()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayFormat = "{FirstName} {LastName}",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { Id = "p/1", FirstName = "Ada", LastName = "Lovelace" },
+            PersonTypeId);
+
+        po.Name.Should().Be("Ada Lovelace");
+        po.Breadcrumb.Should().Be("Ada Lovelace");
+    }
+
+    [Fact]
+    public void DisplayFormat_takes_precedence_over_DisplayAttribute()
+    {
+        // If both are set, DisplayFormat wins. Pins the order in the resolution chain.
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayFormat = "{FirstName}!",
+            DisplayAttribute = "LastName",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "Grace", LastName = "Hopper" },
+            PersonTypeId);
+
+        po.Name.Should().Be("Grace!");
+    }
+
+    [Fact]
+    public void DisplayFormat_unresolved_placeholder_stays_in_the_string_when_property_missing()
+    {
+        // {Unknown} doesn't match any property, so it's left as-is. (The original behavior
+        // pre-cache; just pinning that the migrated ResolveDisplayFormat preserves it.)
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayFormat = "{FirstName} {Unknown}",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "X" },
+            PersonTypeId);
+
+        po.Name.Should().Be("X {Unknown}");
+    }
+
+    [Fact]
+    public void DisplayFormat_with_null_property_value_substitutes_empty_string()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayFormat = "{FirstName}-{Nickname}",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Nickname", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "Linus", Nickname = null },
+            PersonTypeId);
+
+        po.Name.Should().Be("Linus-");
+    }
+
+    [Fact]
+    public void DisplayAttribute_resolves_a_single_property_when_DisplayFormat_is_unset()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayAttribute = "LastName",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { LastName = "Knuth" },
+            PersonTypeId);
+
+        po.Name.Should().Be("Knuth");
+    }
+
+    [Fact]
+    public void DisplayAttribute_falls_through_to_CLR_type_name_when_value_is_null()
+    {
+        // The DisplayAttribute's property exists but evaluates to null at runtime —
+        // GetEntityDisplayName must fall back to the CLR type name instead of returning null.
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayAttribute = "Nickname",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Nickname", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { Nickname = null },
+            PersonTypeId);
+
+        po.Name.Should().Be(nameof(DisplayNamePerson));
+    }
+
+    [Fact]
+    public void DisplayAttribute_pointing_at_missing_property_falls_back_to_CLR_type_name()
+    {
+        // A malformed EntityTypeDefinition that names a property that doesn't exist on
+        // the CLR type. Old behavior would silently fall through to "Name"/"FullName"/
+        // "Title"; new behavior returns the CLR type name. Pin the new contract.
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayAttribute = "DoesNotExistOnCLR",
+            Attributes = [],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "X" },
+            PersonTypeId);
+
+        po.Name.Should().Be(nameof(DisplayNamePerson));
+    }
+
+    [Fact]
+    public void Entity_with_no_definition_falls_back_to_CLR_type_name()
+    {
+        // Projection / anonymous types may not have a registered EntityTypeDefinition.
+        // The old runtime fallback to "Name"/"FullName"/"Title" was removed in this PR;
+        // such entities now get the CLR type name as their display.
+        var loader = Substitute.For<IModelLoader>();
+        loader.GetEntityType(PersonTypeId).Returns((EntityTypeDefinition?)null);
+        loader.GetEntityTypeByClrType(typeof(DisplayNamePerson).FullName!).Returns((EntityTypeDefinition?)null);
+        var mapper = new EntityMapper(loader);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "Anon" },
+            PersonTypeId);
+
+        po.Name.Should().Be(nameof(DisplayNamePerson));
+    }
+
+    [Fact]
+    public void DisplayFormat_handles_repeated_placeholders_in_a_single_template()
+    {
+        var def = new EntityTypeDefinition
+        {
+            Id = PersonTypeId,
+            Name = "Person",
+            ClrType = typeof(DisplayNamePerson).FullName!,
+            DisplayFormat = "{FirstName} {FirstName} {LastName}",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+            ],
+        };
+        var (mapper, _) = NewMapper(def);
+
+        var po = mapper.ToPersistentObject(
+            new DisplayNamePerson { FirstName = "Hi", LastName = "Lo" },
+            PersonTypeId);
+
+        // Both occurrences of {FirstName} should be replaced — verifies we use Replace
+        // (which handles all matches) rather than a single-shot regex match.
+        po.Name.Should().Be("Hi Hi Lo");
+    }
+}

--- a/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
+++ b/MintPlayer.Spark.Tests/MintPlayer.Spark.Tests.csproj
@@ -30,6 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Reflection\Fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MintPlayer.Spark\MintPlayer.Spark.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Abstractions\MintPlayer.Spark.Abstractions.csproj" />
     <ProjectReference Include="..\MintPlayer.Spark.Authorization\MintPlayer.Spark.Authorization.csproj" />

--- a/MintPlayer.Spark.Tests/ReferenceResolverTests.cs
+++ b/MintPlayer.Spark.Tests/ReferenceResolverTests.cs
@@ -42,6 +42,31 @@ public class ReferenceResolverTests
         props.Should().ContainSingle();
         props[0].Property.DeclaringType.Should().Be(typeof(TestPerson));
     }
+
+    [Fact]
+    public void GetReferenceProperties_ReturnsFreshList_OnEachCall()
+    {
+        // Each call returns a fresh List wrapper around the cached array. Mutating one
+        // result must not affect subsequent callers — otherwise the projection-fallback
+        // overload (which Adds to the result) would poison the per-Type cache.
+        var first = _resolver.GetReferenceProperties(typeof(TestPerson));
+        first.Add((null!, null!));
+
+        var second = _resolver.GetReferenceProperties(typeof(TestPerson));
+        second.Should().ContainSingle("each call returns a fresh List, not the cached one");
+    }
+
+    [Fact]
+    public void GetReferenceProperties_RepeatCalls_ReturnSamePropertyInfoReferences()
+    {
+        // Cache hit: the underlying PropertyInfo references should be reference-equal
+        // across calls (proves the cache is doing its job).
+        var first = _resolver.GetReferenceProperties(typeof(TestPerson));
+        var second = _resolver.GetReferenceProperties(typeof(TestPerson));
+
+        ReferenceEquals(first[0].Property, second[0].Property).Should().BeTrue();
+        ReferenceEquals(first[0].Attribute, second[0].Attribute).Should().BeTrue();
+    }
 }
 
 public class TestCompany

--- a/MintPlayer.Spark.Tests/Reflection/AccessorCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/AccessorCacheTests.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+using MintPlayer.Spark.Abstractions.Reflection;
+
+namespace MintPlayer.Spark.Tests.Reflection;
+
+/// <summary>
+/// Pins the contract of compiled-delegate accessors: they must produce the same
+/// values as raw <see cref="PropertyInfo.GetValue(object?)"/> /
+/// <see cref="PropertyInfo.SetValue(object?, object?)"/> across reference types,
+/// value types, nullables, and enums — and the compiled delegates must be cached
+/// (same <see cref="PropertyInfo"/> ⇒ same delegate instance).
+/// </summary>
+public class AccessorCacheTests
+{
+    private class RefFixture
+    {
+        public string? Name { get; set; }
+        public int Age { get; set; }
+        public DayOfWeek Day { get; set; }
+        public Guid? OptionalId { get; set; }
+        public string ReadOnly => "read-only";
+        public string WriteOnly { set { /* discard */ } }
+    }
+
+    private struct StructFixture
+    {
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void GetGetter_reads_reference_type_property()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Name))!;
+        var getter = AccessorCache.GetGetter(prop);
+
+        var instance = new RefFixture { Name = "Alice" };
+
+        getter(instance).Should().Be("Alice");
+    }
+
+    [Fact]
+    public void GetSetter_writes_reference_type_property()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Name))!;
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new RefFixture();
+        setter(instance, "Bob");
+
+        instance.Name.Should().Be("Bob");
+    }
+
+    [Fact]
+    public void GetGetter_and_GetSetter_round_trip_value_type()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Age))!;
+        var getter = AccessorCache.GetGetter(prop);
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new RefFixture();
+        setter(instance, 42);
+
+        getter(instance).Should().Be(42);
+        instance.Age.Should().Be(42);
+    }
+
+    [Fact]
+    public void GetGetter_and_GetSetter_round_trip_enum()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Day))!;
+        var getter = AccessorCache.GetGetter(prop);
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new RefFixture();
+        setter(instance, DayOfWeek.Wednesday);
+
+        getter(instance).Should().Be(DayOfWeek.Wednesday);
+    }
+
+    [Fact]
+    public void GetGetter_and_GetSetter_handle_nullable_value_type()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.OptionalId))!;
+        var getter = AccessorCache.GetGetter(prop);
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new RefFixture();
+        getter(instance).Should().BeNull();
+
+        var id = Guid.NewGuid();
+        setter(instance, id);
+        getter(instance).Should().Be(id);
+
+        setter(instance, null);
+        getter(instance).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetGetter_returns_cached_delegate_instance_for_same_PropertyInfo()
+    {
+        // Reference equality matters here: if the cache misses, the migration loses its win.
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Age))!;
+
+        var first = AccessorCache.GetGetter(prop);
+        var second = AccessorCache.GetGetter(prop);
+
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetSetter_returns_cached_delegate_instance_for_same_PropertyInfo()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Age))!;
+
+        var first = AccessorCache.GetSetter(prop);
+        var second = AccessorCache.GetSetter(prop);
+
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetGetter_throws_for_write_only_property()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.WriteOnly))!;
+
+        Action act = () => AccessorCache.GetGetter(prop);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GetSetter_throws_for_read_only_property()
+    {
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.ReadOnly))!;
+
+        Action act = () => AccessorCache.GetSetter(prop);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/MintPlayer.Spark.Tests/Reflection/AccessorCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/AccessorCacheTests.cs
@@ -135,4 +135,69 @@ public class AccessorCacheTests
         Action act = () => AccessorCache.GetSetter(prop);
         act.Should().Throw<ArgumentException>();
     }
+
+    [Fact]
+    public void GetGetter_throws_on_null_property()
+    {
+        Action act = () => AccessorCache.GetGetter(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetSetter_throws_on_null_property()
+    {
+        Action act = () => AccessorCache.GetSetter(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private class BaseFixture
+    {
+        public string? Inherited { get; set; }
+    }
+
+    private class DerivedFixture : BaseFixture
+    {
+        public int Own { get; set; }
+    }
+
+    [Fact]
+    public void GetGetter_works_for_inherited_property()
+    {
+        // PropertyInfo.DeclaringType is the base type — verify the compiled getter
+        // still works when the actual instance is a derived type.
+        var prop = typeof(DerivedFixture).GetProperty(nameof(BaseFixture.Inherited))!;
+        var getter = AccessorCache.GetGetter(prop);
+
+        var instance = new DerivedFixture { Inherited = "from-base" };
+        getter(instance).Should().Be("from-base");
+    }
+
+    [Fact]
+    public void GetSetter_works_for_inherited_property()
+    {
+        var prop = typeof(DerivedFixture).GetProperty(nameof(BaseFixture.Inherited))!;
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new DerivedFixture();
+        setter(instance, "written-via-base");
+
+        instance.Inherited.Should().Be("written-via-base");
+    }
+
+    [Fact]
+    public void Get_and_Set_share_no_cache_entries_for_same_property()
+    {
+        // Regression for the bug fixed in 2431b7e: getter and setter must use distinct
+        // cache slots (we namespace with "get|" and "set|"). If they shared a slot,
+        // resolving the setter after the getter (or vice versa) would either return
+        // wrong-typed delegate or hit InvalidCastException.
+        var prop = typeof(RefFixture).GetProperty(nameof(RefFixture.Age))!;
+
+        var getter = AccessorCache.GetGetter(prop);
+        var setter = AccessorCache.GetSetter(prop);
+
+        var instance = new RefFixture();
+        setter(instance, 7);
+        getter(instance).Should().Be(7);
+    }
 }

--- a/MintPlayer.Spark.Tests/Reflection/Fixtures/people.json
+++ b/MintPlayer.Spark.Tests/Reflection/Fixtures/people.json
@@ -1,0 +1,19 @@
+{
+  "Results": [
+    {
+      "@metadata": { "@id": "people/1-A", "@collection": "People" },
+      "FirstName": "Ada",
+      "LastName": "Lovelace"
+    },
+    {
+      "@metadata": { "@id": "people/2-A", "@collection": "People" },
+      "FirstName": "Grace",
+      "LastName": "Hopper"
+    },
+    {
+      "@metadata": { "@id": "people/3-A", "@collection": "People" },
+      "FirstName": "Linus",
+      "LastName": "Torvalds"
+    }
+  ]
+}

--- a/MintPlayer.Spark.Tests/Reflection/JsonSeededReflectionCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/JsonSeededReflectionCacheTests.cs
@@ -1,0 +1,118 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Reflection;
+
+/// <summary>
+/// Integration test that seeds RavenDB from a JSON fixture and drives the full list
+/// pipeline through the reflective hot paths the cache covers:
+/// <list type="bullet">
+///   <item><see cref="ReflectedTypeExtensions.GetCachedProperty"/> for Id / FirstName / LastName,</item>
+///   <item><see cref="AccessorCache.GetGetter"/> for those properties,</item>
+///   <item><see cref="EntityMapper.PopulateAttributeValues"/> per row,</item>
+///   <item><c>GetEntityDisplayName</c> via <c>DisplayAttribute</c>.</item>
+/// </list>
+/// Running the same query twice on the same fixture proves the cached delegates produce
+/// identical, deterministic output across calls — a regression in the cache (e.g. wrong key,
+/// stale entry, swallowed exception) would surface as a divergent second result.
+/// </summary>
+public class JsonSeededReflectionCacheTests : SparkTestDriver
+{
+    private static readonly Guid PersonTypeId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    private SparkEndpointFactory<TestSparkContext> _factory = null!;
+    private IQueryExecutor _executor = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var personModel = new EntityTypeFile
+        {
+            PersistentObject = new EntityTypeDefinition
+            {
+                Id = PersonTypeId,
+                Name = "Person",
+                ClrType = typeof(Person).FullName!,
+                DisplayAttribute = "LastName",
+                Attributes =
+                [
+                    new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                    new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+                ],
+            },
+        };
+
+        _factory = new SparkEndpointFactory<TestSparkContext>(Store, [personModel]);
+        _executor = _factory.GetService<IQueryExecutor>();
+
+        // Seed from the JSON fixture copied to the test output directory by the .csproj
+        // <Content Include="Reflection\Fixtures\**\*.json" /> rule.
+        await SeedFromJsonAsync("Reflection/Fixtures/people.json");
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Listing_People_resolves_attributes_and_display_name_through_cached_reflection()
+    {
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "People",
+            Source = "Database.People",
+            SortColumns = [new SortColumn { Property = "LastName", Direction = "asc" }],
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+
+        var rows = result.Data
+            .Select(po => (
+                Id: po.Id,
+                Name: po.Name, // GetEntityDisplayName(DisplayAttribute = "LastName") → AccessorCache.GetGetter
+                FirstName: po.Attributes.Single(a => a.Name == "FirstName").Value?.ToString(),
+                LastName: po.Attributes.Single(a => a.Name == "LastName").Value?.ToString()))
+            .ToList();
+
+        rows.Should().Equal(
+            ("people/2-A", "Hopper", "Grace", "Hopper"),
+            ("people/1-A", "Lovelace", "Ada", "Lovelace"),
+            ("people/3-A", "Torvalds", "Linus", "Torvalds"));
+    }
+
+    [Fact]
+    public async Task Listing_People_twice_returns_identical_results_on_cache_hit()
+    {
+        // First call populates the per-Type / per-PropertyInfo cache entries; second call
+        // reads through them. If a cache key collided or a Lazy<T> captured wrong state,
+        // the two results would diverge.
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "People",
+            Source = "Database.People",
+            SortColumns = [new SortColumn { Property = "LastName", Direction = "asc" }],
+        };
+
+        var first = await _executor.ExecuteQueryAsync(query);
+        var second = await _executor.ExecuteQueryAsync(query);
+
+        var firstShape = first.Data
+            .Select(po => (po.Id, po.Name, po.Attributes.Count))
+            .ToList();
+        var secondShape = second.Data
+            .Select(po => (po.Id, po.Name, po.Attributes.Count))
+            .ToList();
+
+        secondShape.Should().Equal(firstShape,
+            "cached reflective dispatch must produce identical PO shapes across repeated calls");
+    }
+}

--- a/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
@@ -153,4 +153,37 @@ public class ReflectedTypeExtensionsTests
         task1.GetCompletedTaskResult().Should().Be("first");
         task2.GetCompletedTaskResult().Should().Be("second");
     }
+
+    [Fact]
+    public void Two_separate_GetProperty_calls_collide_on_the_same_dictionary_slot()
+    {
+        // Pre-condition for the principled tier-redesign follow-up: if we ever switch
+        // AccessorCache / GetCachedProperty from string keys to PropertyInfo (or
+        // (Type, string)) keys backed by ConcurrentDictionary, the dictionary's identity
+        // contract must hold — two independent calls to typeof(T).GetProperty("X") must
+        // produce values that .Equals each other AND share a hash code, so the second
+        // call hits the entry stored by the first instead of creating a duplicate slot.
+        // The BCL caches RuntimePropertyInfo internally, so today they're typically
+        // reference-equal too — but Equals + GetHashCode is the contract that actually
+        // matters for ConcurrentDictionary behavior, and that's what we pin here.
+        var a = typeof(Fixture).GetProperty(nameof(Fixture.Tagged))!;
+        var b = typeof(Fixture).GetProperty(nameof(Fixture.Tagged))!;
+
+        a.Equals(b).Should().BeTrue("PropertyInfo equality must hold across separate GetProperty calls on the same Type");
+        a.GetHashCode().Should().Be(b.GetHashCode(),
+            "Equals contract requires matching hash codes; ConcurrentDictionary depends on it for slot routing");
+
+        var dict = new System.Collections.Concurrent.ConcurrentDictionary<System.Reflection.PropertyInfo, string>();
+        dict[a] = "from-a";
+        dict[b] = "from-b";
+
+        dict.Should().HaveCount(1, "the second assignment must overwrite the first slot, not add a new one");
+        dict[a].Should().Be("from-b");
+
+        // And the same for a different property on the same type — the two PropertyInfos
+        // for distinct properties must NOT collide.
+        var other = typeof(Fixture).GetProperty(nameof(Fixture.Untagged))!;
+        dict[other] = "other";
+        dict.Should().HaveCount(2);
+    }
 }

--- a/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
@@ -186,4 +186,69 @@ public class ReflectedTypeExtensionsTests
         dict[other] = "other";
         dict.Should().HaveCount(2);
     }
+
+    [Fact]
+    public void Type_obtained_via_different_routes_collides_on_the_same_dictionary_slot()
+    {
+        // Pre-condition for a Type-keyed (or (Type, ...)-keyed) cache: the runtime must
+        // canonicalize Type instances within an AssemblyLoadContext so that compile-time
+        // typeof(...), runtime instance.GetType(), Assembly.GetType(string), and
+        // Type.GetType(assemblyQualifiedName) all produce values that collide on the
+        // same dictionary slot. If that contract held weakly (only Equals-equal but not
+        // hash-stable, or distinct instances per route), a Type-keyed cache would
+        // duplicate entries on every lookup variant and silently defeat itself.
+        var fromTypeof = typeof(Fixture);
+        var fromGetType = new Fixture().GetType();
+        var fromAssemblyLookup = typeof(Fixture).Assembly.GetType(typeof(Fixture).FullName!)!;
+        var fromAssemblyQualifiedName = Type.GetType(typeof(Fixture).AssemblyQualifiedName!)!;
+
+        // Reference equality — strongest contract, what the CLR actually guarantees within
+        // an ALC. If this ever weakens we want the test to catch it.
+        ReferenceEquals(fromTypeof, fromGetType).Should().BeTrue();
+        ReferenceEquals(fromTypeof, fromAssemblyLookup).Should().BeTrue();
+        ReferenceEquals(fromTypeof, fromAssemblyQualifiedName).Should().BeTrue();
+
+        // Equals + GetHashCode contract — the one ConcurrentDictionary actually depends on.
+        fromTypeof.Equals(fromGetType).Should().BeTrue();
+        fromTypeof.GetHashCode().Should().Be(fromGetType.GetHashCode());
+
+        var dict = new System.Collections.Concurrent.ConcurrentDictionary<Type, string>();
+        dict[fromTypeof] = "from-typeof";
+        dict[fromGetType] = "from-getType";
+        dict[fromAssemblyLookup] = "from-assembly-lookup";
+        dict[fromAssemblyQualifiedName] = "from-aqn";
+
+        dict.Should().HaveCount(1, "all four resolution routes must dedupe to a single dictionary slot");
+        dict[fromTypeof].Should().Be("from-aqn", "the last write wins on the shared slot");
+
+        // Distinct types — sanity check that the dict isn't pathologically collapsing
+        // everything to one slot.
+        dict[typeof(string)] = "string";
+        dict[typeof(int)] = "int";
+        dict.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Tuple_of_Type_and_string_works_as_dictionary_key()
+    {
+        // The (Type, string) tuple is the natural key for "property X on type Y" lookups.
+        // Verify ValueTuple's structural equality + hash play correctly with
+        // ConcurrentDictionary so a tuple-keyed property cache works without surprises.
+        var k1 = (typeof(Fixture), nameof(Fixture.Tagged));
+        var k2 = (new Fixture().GetType(), nameof(Fixture.Tagged));
+        var k3 = (typeof(Fixture), nameof(Fixture.Untagged));
+
+        k1.Equals(k2).Should().BeTrue();
+        k1.GetHashCode().Should().Be(k2.GetHashCode());
+        k1.Equals(k3).Should().BeFalse("different property names must not collide");
+
+        var dict = new System.Collections.Concurrent.ConcurrentDictionary<(Type, string), string>();
+        dict[k1] = "first";
+        dict[k2] = "second";
+        dict[k3] = "third";
+
+        dict.Should().HaveCount(2);
+        dict[k1].Should().Be("second");
+        dict[k3].Should().Be("third");
+    }
 }

--- a/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
@@ -1,0 +1,66 @@
+using MintPlayer.Spark.Abstractions.Reflection;
+
+namespace MintPlayer.Spark.Tests.Reflection;
+
+/// <summary>
+/// Pins the cached-extension contract: same <see cref="Type"/> + same name returns the
+/// same <see cref="System.Reflection.PropertyInfo"/> reference (cache hit), missing
+/// properties cache <c>null</c>, and per-Type GetProperties returns reference-equal
+/// arrays on repeat calls.
+/// </summary>
+public class ReflectedTypeExtensionsTests
+{
+    [AttributeUsage(AttributeTargets.Property)] private sealed class MarkerAttribute : Attribute;
+
+    private class Fixture
+    {
+        [Marker] public string? Tagged { get; set; }
+        public string? Untagged { get; set; }
+    }
+
+    [Fact]
+    public void GetCachedProperties_returns_same_array_on_repeat_calls()
+    {
+        var first = typeof(Fixture).GetCachedProperties();
+        var second = typeof(Fixture).GetCachedProperties();
+
+        ReferenceEquals(first, second).Should().BeTrue();
+        first.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetCachedProperty_returns_PropertyInfo_when_present()
+    {
+        var prop = typeof(Fixture).GetCachedProperty(nameof(Fixture.Tagged));
+        prop.Should().NotBeNull();
+        prop!.Name.Should().Be(nameof(Fixture.Tagged));
+    }
+
+    [Fact]
+    public void GetCachedProperty_caches_null_for_missing_property()
+    {
+        var first = typeof(Fixture).GetCachedProperty("DoesNotExist");
+        var second = typeof(Fixture).GetCachedProperty("DoesNotExist");
+
+        first.Should().BeNull();
+        second.Should().BeNull();
+        // Reference identity isn't meaningful here (both null); but caching null is the
+        // contract we care about — covered by the underlying ReflectionCache null-cache test.
+    }
+
+    [Fact]
+    public void GetCachedCustomAttribute_returns_attribute_when_decorated()
+    {
+        var prop = typeof(Fixture).GetCachedProperty(nameof(Fixture.Tagged))!;
+        var attr = prop.GetCachedCustomAttribute<MarkerAttribute>();
+        attr.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetCachedCustomAttribute_returns_null_when_undecorated()
+    {
+        var prop = typeof(Fixture).GetCachedProperty(nameof(Fixture.Untagged))!;
+        var attr = prop.GetCachedCustomAttribute<MarkerAttribute>();
+        attr.Should().BeNull();
+    }
+}

--- a/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectedTypeExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace MintPlayer.Spark.Tests.Reflection;
 /// </summary>
 public class ReflectedTypeExtensionsTests
 {
-    [AttributeUsage(AttributeTargets.Property)] private sealed class MarkerAttribute : Attribute;
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)] private sealed class MarkerAttribute : Attribute;
 
     private class Fixture
     {
@@ -62,5 +62,95 @@ public class ReflectedTypeExtensionsTests
         var prop = typeof(Fixture).GetCachedProperty(nameof(Fixture.Untagged))!;
         var attr = prop.GetCachedCustomAttribute<MarkerAttribute>();
         attr.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCachedCustomAttribute_works_on_Type_directly()
+    {
+        // GetCachedCustomAttribute extends MemberInfo, so it must work on Type itself
+        // (used by SyncActionInterceptor.GetReplicatedAttribute(Type)).
+        var attr = typeof(MarkedClassFixture).GetCachedCustomAttribute<MarkerAttribute>();
+        attr.Should().NotBeNull();
+    }
+
+    [Marker]
+    private sealed class MarkedClassFixture;
+
+    [Fact]
+    public void GetCachedProperties_throws_on_null_type()
+    {
+        Action act = () => ((Type)null!).GetCachedProperties();
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetCachedProperty_throws_on_null_type_or_name()
+    {
+        Action nullType = () => ((Type)null!).GetCachedProperty("X");
+        Action nullName = () => typeof(Fixture).GetCachedProperty(null!);
+
+        nullType.Should().Throw<ArgumentNullException>();
+        nullName.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetCachedCustomAttribute_throws_on_null_member()
+    {
+        Action act = () => ((System.Reflection.MemberInfo)null!).GetCachedCustomAttribute<MarkerAttribute>();
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // --- GetCompletedTaskResult ---
+
+    [Fact]
+    public async Task GetCompletedTaskResult_extracts_value_from_completed_Task_of_T()
+    {
+        // Reflective dispatch sites get back a non-generic Task because they invoked the
+        // generic method via reflection. GetCompletedTaskResult unwraps Task<T>.Result via
+        // a cached PropertyInfo + compiled getter — the same shape used by EntityMapper,
+        // ReferenceResolver, DatabaseAccess, QueryExecutor, SyncActionHandler.
+        Task task = Task.FromResult("hello");
+        await task;
+
+        task.GetCompletedTaskResult().Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task GetCompletedTaskResult_extracts_value_type_result()
+    {
+        Task task = Task.FromResult(42);
+        await task;
+
+        task.GetCompletedTaskResult().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task GetCompletedTaskResult_returns_null_when_Task_T_resolves_to_null_reference()
+    {
+        Task task = Task.FromResult<string?>(null);
+        await task;
+
+        task.GetCompletedTaskResult().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCompletedTaskResult_throws_on_null_task()
+    {
+        Action act = () => ((Task)null!).GetCompletedTaskResult();
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetCompletedTaskResult_caches_Result_property_per_task_type()
+    {
+        // Two completed Task<string> instances should hit the same cached PropertyInfo.
+        // Verify by extracting from both and confirming both succeed (a stale/wrong cache
+        // would either NRE or return a wrong value).
+        Task task1 = Task.FromResult("first");
+        Task task2 = Task.FromResult("second");
+        await Task.WhenAll(task1, task2);
+
+        task1.GetCompletedTaskResult().Should().Be("first");
+        task2.GetCompletedTaskResult().Should().Be("second");
     }
 }

--- a/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
@@ -182,4 +182,122 @@ public class ReflectionCacheTests
         nullKey.Should().Throw<ArgumentNullException>();
         nullFactory.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void GetOrAdd_global_throws_on_null_key_or_factory()
+    {
+        Action nullKey = () => ReflectionCache.GetOrAdd<string>((string)null!, () => "v");
+        Action nullFactory = () => ReflectionCache.GetOrAdd<string>("k", (Func<string>)null!);
+
+        nullKey.Should().Throw<ArgumentNullException>();
+        nullFactory.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetOrAdd_type_keyed_throws_on_null_key_or_factory()
+    {
+        Action nullKey = () => ReflectionCache.GetOrAdd<string>((Type)null!, _ => "v");
+        Action nullFactory = () => ReflectionCache.GetOrAdd<string>(typeof(string), null!);
+
+        nullKey.Should().Throw<ArgumentNullException>();
+        nullFactory.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ClearGlobalForTests_clears_global_string_keyed_entries()
+    {
+        var key = $"clearTest:{Guid.NewGuid()}";
+        ReflectionCache.GetOrAdd<string>(key, () => "first");
+
+        ReflectionCache.ClearGlobalForTests();
+
+        // After clear, the factory must run again because the entry is gone.
+        var calls = 0;
+        var second = ReflectionCache.GetOrAdd<string>(key, () =>
+        {
+            Interlocked.Increment(ref calls);
+            return "second";
+        });
+
+        second.Should().Be("second");
+        calls.Should().Be(1, "the cleared entry should re-run its factory on next access");
+    }
+
+    [Fact]
+    public void ClearGlobalForTests_clears_type_keyed_entries()
+    {
+        ReflectionCache.GetOrAdd<string>(typeof(ClearTypeKeyedFixture), _ => "first");
+
+        ReflectionCache.ClearGlobalForTests();
+
+        var calls = 0;
+        var second = ReflectionCache.GetOrAdd<string>(typeof(ClearTypeKeyedFixture), _ =>
+        {
+            Interlocked.Increment(ref calls);
+            return "second";
+        });
+
+        second.Should().Be("second");
+        calls.Should().Be(1);
+    }
+
+    private sealed class ClearTypeKeyedFixture;
+
+    [Fact]
+    public void GlobalCount_increases_as_entries_are_added()
+    {
+        ReflectionCache.ClearGlobalForTests();
+        var initial = ReflectionCache.GlobalCount;
+        initial.Should().Be(0);
+
+        ReflectionCache.GetOrAdd<string>($"counter:{Guid.NewGuid()}", () => "a");
+        ReflectionCache.GetOrAdd<string>(typeof(GlobalCountFixture), _ => "b");
+
+        ReflectionCache.GlobalCount.Should().Be(2);
+    }
+
+    private sealed class GlobalCountFixture;
+
+    [Fact]
+    public void GetOrAdd_type_keyed_runs_factory_with_the_correct_Type_argument()
+    {
+        // The factory receives the Type that was used as the key — verify it isn't
+        // accidentally swapped or boxed wrong by the (Type, ValueType) wrapping.
+        ReflectionCache.ClearGlobalForTests();
+        Type? observed = null;
+
+        ReflectionCache.GetOrAdd<string>(typeof(TypeArgFixture), t => { observed = t; return "v"; });
+
+        observed.Should().Be(typeof(TypeArgFixture));
+    }
+
+    private sealed class TypeArgFixture;
+
+    [Fact]
+    public void GetOrAdd_per_type_caches_value_type_results()
+    {
+        // Per-type cache must round-trip value types via boxing without losing the value.
+        var first = ReflectionCache.GetOrAdd<OwnerValueType, int>("k", () => 12345);
+        var second = ReflectionCache.GetOrAdd<OwnerValueType, int>("k", () => 99999);
+
+        first.Should().Be(12345);
+        second.Should().Be(12345);
+    }
+
+    private sealed class OwnerValueType;
+
+    [Fact]
+    public void GetOrAdd_caches_complex_reference_type_results()
+    {
+        // PropertyInfo[] is a common cached shape (used by GetCachedProperties); verify
+        // the cache returns the same array reference on repeat calls — that's how
+        // downstream code can rely on cache hits not allocating new arrays.
+        var first = ReflectionCache.GetOrAdd<OwnerComplexValue, string[]>("k", () => ["a", "b", "c"]);
+        var second = ReflectionCache.GetOrAdd<OwnerComplexValue, string[]>("k", () => ["x", "y", "z"]);
+
+        ReferenceEquals(first, second).Should().BeTrue("reference equality preserves cache-hit semantics for downstream callers");
+        first.Should().Equal("a", "b", "c");
+    }
+
+    private sealed class OwnerComplexValue;
 }

--- a/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
@@ -1,0 +1,185 @@
+using MintPlayer.Spark.Abstractions.Reflection;
+
+namespace MintPlayer.Spark.Tests.Reflection;
+
+/// <summary>
+/// Contract tests for the <see cref="ReflectionCache"/> primitive. The whole point of this
+/// cache is to be safe under concurrent access and to give "factory runs exactly once per
+/// key" semantics — a regression here silently re-runs reflection on every call and defeats
+/// the cache. These tests pin the lock-free + Lazy contract.
+/// </summary>
+public class ReflectionCacheTests
+{
+    // Per-test isolation marker types — give each test its own TOwner generic-static cache
+    // so concurrent runs don't see each other's entries.
+    private sealed class OwnerA;
+    private sealed class OwnerB;
+    private sealed class OwnerConcurrency;
+    private sealed class OwnerNullCache;
+    private sealed class OwnerExceptionCache;
+    private sealed class OwnerIsolation1;
+    private sealed class OwnerIsolation2;
+
+    [Fact]
+    public void GetOrAdd_per_type_runs_factory_once_per_key()
+    {
+        var calls = 0;
+
+        var first = ReflectionCache.GetOrAdd<OwnerA, string>("k1", () => { Interlocked.Increment(ref calls); return "v1"; });
+        var second = ReflectionCache.GetOrAdd<OwnerA, string>("k1", () => { Interlocked.Increment(ref calls); return "v1-DIFFERENT"; });
+
+        first.Should().Be("v1");
+        second.Should().Be("v1");
+        calls.Should().Be(1, "because the factory must run exactly once per key");
+    }
+
+    [Fact]
+    public void GetOrAdd_per_type_isolates_different_owners()
+    {
+        ReflectionCache.GetOrAdd<OwnerIsolation1, string>("shared-key", () => "from-1");
+        var fromOwner2 = ReflectionCache.GetOrAdd<OwnerIsolation2, string>("shared-key", () => "from-2");
+
+        fromOwner2.Should().Be("from-2",
+            "because each TOwner has its own dictionary; the same key must not collide across owners");
+    }
+
+    [Fact]
+    public void GetOrAdd_global_string_keyed_runs_factory_once_per_key()
+    {
+        var key = $"{nameof(GetOrAdd_global_string_keyed_runs_factory_once_per_key)}:{Guid.NewGuid()}";
+        var calls = 0;
+
+        var first = ReflectionCache.GetOrAdd<int>(key, () => { Interlocked.Increment(ref calls); return 42; });
+        var second = ReflectionCache.GetOrAdd<int>(key, () => { Interlocked.Increment(ref calls); return 99; });
+
+        first.Should().Be(42);
+        second.Should().Be(42);
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void GetOrAdd_type_keyed_runs_factory_once_per_type()
+    {
+        ReflectionCache.ClearGlobalForTests();
+        var calls = 0;
+
+        var first = ReflectionCache.GetOrAdd<string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return t.Name; });
+        var second = ReflectionCache.GetOrAdd<string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return "DIFFERENT"; });
+
+        first.Should().Be(nameof(GetOrAddTypeKeyedFixture));
+        second.Should().Be(nameof(GetOrAddTypeKeyedFixture));
+        calls.Should().Be(1);
+    }
+
+    private sealed class GetOrAddTypeKeyedFixture;
+
+    [Fact]
+    public async Task GetOrAdd_factory_runs_exactly_once_under_concurrent_access()
+    {
+        // The Lazy<T>+ExecutionAndPublication contract is the foundation of the cache's
+        // promise. Verify directly: 64 threads racing to read the same key, factory body
+        // counts its invocations, must be exactly 1.
+        var key = $"concurrency:{Guid.NewGuid()}";
+        var factoryRuns = 0;
+        var barrier = new Barrier(64);
+
+        var tasks = Enumerable.Range(0, 64).Select(_ => Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            return ReflectionCache.GetOrAdd<OwnerConcurrency, int>(key, () =>
+            {
+                Interlocked.Increment(ref factoryRuns);
+                Thread.Sleep(20); // widen the race window
+                return 7;
+            });
+        })).ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        factoryRuns.Should().Be(1, "Lazy<T>(ExecutionAndPublication) guarantees single execution");
+        results.Should().AllBeEquivalentTo(7);
+    }
+
+    [Fact]
+    public void GetOrAdd_caches_null_result_negative_caching()
+    {
+        // ActionsResolver.FindActionsType depends on this: caching a "no such type" answer
+        // is the entire point of moving it onto ReflectionCache.
+        var calls = 0;
+
+        var first = ReflectionCache.GetOrAdd<OwnerNullCache, string?>("missing", () => { Interlocked.Increment(ref calls); return null; });
+        var second = ReflectionCache.GetOrAdd<OwnerNullCache, string?>("missing", () => { Interlocked.Increment(ref calls); return "not-null-this-time"; });
+
+        first.Should().BeNull();
+        second.Should().BeNull();
+        calls.Should().Be(1, "null is a valid cached value, factory must not re-run");
+    }
+
+    [Fact]
+    public void GetOrAdd_caches_thrown_exception_and_rethrows()
+    {
+        // Documented behavior of Lazy<T>(ExecutionAndPublication): a throwing factory caches
+        // the exception. We rely on this so that genuinely-missing reflection lookups fail
+        // deterministically — the alternative (retry every call) would mask bugs.
+        var calls = 0;
+
+        Action firstAttempt = () => ReflectionCache.GetOrAdd<OwnerExceptionCache, string>("boom", () =>
+        {
+            Interlocked.Increment(ref calls);
+            throw new InvalidOperationException("reflection failure");
+        });
+
+        firstAttempt.Should().Throw<InvalidOperationException>().WithMessage("reflection failure");
+
+        Action secondAttempt = () => ReflectionCache.GetOrAdd<OwnerExceptionCache, string>("boom", () =>
+        {
+            Interlocked.Increment(ref calls);
+            return "would-succeed";
+        });
+
+        secondAttempt.Should().Throw<InvalidOperationException>().WithMessage("reflection failure");
+        calls.Should().Be(1, "the cached exception is rethrown without re-running the factory");
+    }
+
+    [Fact]
+    public void GetOrAdd_type_keyed_isolates_distinct_value_types_for_same_Type()
+    {
+        // The type-keyed overload is used by multiple call sites that cache different
+        // things per Type (e.g. "collection element type of T" vs "LoadAsync<T> MethodInfo").
+        // The cache must include TValue in its key so two such call sites can coexist
+        // without an InvalidCastException at the boundary.
+        ReflectionCache.ClearGlobalForTests();
+
+        var asInt = ReflectionCache.GetOrAdd<int>(typeof(TypeKeyedCollisionFixture), _ => 7);
+        var asString = ReflectionCache.GetOrAdd<string>(typeof(TypeKeyedCollisionFixture), t => t.Name);
+
+        asInt.Should().Be(7);
+        asString.Should().Be(nameof(TypeKeyedCollisionFixture));
+    }
+
+    private sealed class TypeKeyedCollisionFixture;
+
+    [Fact]
+    public void GetOrAdd_per_type_and_global_keyspaces_are_independent()
+    {
+        var key = $"shared-key-{Guid.NewGuid()}";
+
+        ReflectionCache.GetOrAdd<OwnerA, string>(key, () => "from-per-type");
+        var fromGlobal = ReflectionCache.GetOrAdd<string>(key, () => "from-global");
+
+        fromGlobal.Should().Be("from-global",
+            "the per-type and global tiers must use independent keyspaces");
+    }
+
+    [Fact]
+    public void GetOrAdd_throws_on_null_key_or_factory()
+    {
+        // Guarding inputs at the boundary keeps null-related bugs from being cached as a
+        // ghost entry under a coerced key.
+        Action nullKey = () => ReflectionCache.GetOrAdd<OwnerA, string>(null!, () => "v");
+        Action nullFactory = () => ReflectionCache.GetOrAdd<OwnerA, string>("k", null!);
+
+        nullKey.Should().Throw<ArgumentNullException>();
+        nullFactory.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
+++ b/MintPlayer.Spark.Tests/Reflection/ReflectionCacheTests.cs
@@ -58,13 +58,12 @@ public class ReflectionCacheTests
     }
 
     [Fact]
-    public void GetOrAdd_type_keyed_runs_factory_once_per_type()
+    public void GetOrAdd_typed_key_runs_factory_once_per_type()
     {
-        ReflectionCache.ClearGlobalForTests();
         var calls = 0;
 
-        var first = ReflectionCache.GetOrAdd<string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return t.Name; });
-        var second = ReflectionCache.GetOrAdd<string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return "DIFFERENT"; });
+        var first = ReflectionCache.GetOrAdd<Type, string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return t.Name; });
+        var second = ReflectionCache.GetOrAdd<Type, string>(typeof(GetOrAddTypeKeyedFixture), t => { Interlocked.Increment(ref calls); return "DIFFERENT"; });
 
         first.Should().Be(nameof(GetOrAddTypeKeyedFixture));
         second.Should().Be(nameof(GetOrAddTypeKeyedFixture));
@@ -142,16 +141,14 @@ public class ReflectionCacheTests
     }
 
     [Fact]
-    public void GetOrAdd_type_keyed_isolates_distinct_value_types_for_same_Type()
+    public void GetOrAdd_typed_key_isolates_distinct_value_types_for_same_TKey()
     {
-        // The type-keyed overload is used by multiple call sites that cache different
-        // things per Type (e.g. "collection element type of T" vs "LoadAsync<T> MethodInfo").
-        // The cache must include TValue in its key so two such call sites can coexist
-        // without an InvalidCastException at the boundary.
-        ReflectionCache.ClearGlobalForTests();
-
-        var asInt = ReflectionCache.GetOrAdd<int>(typeof(TypeKeyedCollisionFixture), _ => 7);
-        var asString = ReflectionCache.GetOrAdd<string>(typeof(TypeKeyedCollisionFixture), t => t.Name);
+        // The identity-keyed tier is used by multiple call sites that may share a TKey
+        // (e.g. "Type") for different TValues. The dictionary's inner discriminator
+        // includes typeof(TValue) so two such call sites can coexist without an
+        // InvalidCastException at the boundary.
+        var asInt = ReflectionCache.GetOrAdd<Type, int>(typeof(TypeKeyedCollisionFixture), _ => 7);
+        var asString = ReflectionCache.GetOrAdd<Type, string>(typeof(TypeKeyedCollisionFixture), t => t.Name);
 
         asInt.Should().Be(7);
         asString.Should().Be(nameof(TypeKeyedCollisionFixture));
@@ -194,10 +191,10 @@ public class ReflectionCacheTests
     }
 
     [Fact]
-    public void GetOrAdd_type_keyed_throws_on_null_key_or_factory()
+    public void GetOrAdd_typed_key_throws_on_null_key_or_factory()
     {
-        Action nullKey = () => ReflectionCache.GetOrAdd<string>((Type)null!, _ => "v");
-        Action nullFactory = () => ReflectionCache.GetOrAdd<string>(typeof(string), null!);
+        Action nullKey = () => ReflectionCache.GetOrAdd<Type, string>(null!, _ => "v");
+        Action nullFactory = () => ReflectionCache.GetOrAdd<Type, string>(typeof(string), null!);
 
         nullKey.Should().Throw<ArgumentNullException>();
         nullFactory.Should().Throw<ArgumentNullException>();
@@ -224,54 +221,75 @@ public class ReflectionCacheTests
     }
 
     [Fact]
-    public void ClearGlobalForTests_clears_type_keyed_entries()
+    public void GlobalCount_increases_as_string_keyed_entries_are_added()
     {
-        ReflectionCache.GetOrAdd<string>(typeof(ClearTypeKeyedFixture), _ => "first");
-
+        // GlobalCount only reflects the global string-keyed tier — the per-TOwner and
+        // identity-keyed tiers are generic-static-specialized and have AppDomain lifetime
+        // by design (see ReflectionCache.ClearGlobalForTests docstring).
         ReflectionCache.ClearGlobalForTests();
-
-        var calls = 0;
-        var second = ReflectionCache.GetOrAdd<string>(typeof(ClearTypeKeyedFixture), _ =>
-        {
-            Interlocked.Increment(ref calls);
-            return "second";
-        });
-
-        second.Should().Be("second");
-        calls.Should().Be(1);
-    }
-
-    private sealed class ClearTypeKeyedFixture;
-
-    [Fact]
-    public void GlobalCount_increases_as_entries_are_added()
-    {
-        ReflectionCache.ClearGlobalForTests();
-        var initial = ReflectionCache.GlobalCount;
-        initial.Should().Be(0);
+        ReflectionCache.GlobalCount.Should().Be(0);
 
         ReflectionCache.GetOrAdd<string>($"counter:{Guid.NewGuid()}", () => "a");
-        ReflectionCache.GetOrAdd<string>(typeof(GlobalCountFixture), _ => "b");
+        ReflectionCache.GetOrAdd<string>($"counter:{Guid.NewGuid()}", () => "b");
 
         ReflectionCache.GlobalCount.Should().Be(2);
     }
 
-    private sealed class GlobalCountFixture;
-
     [Fact]
-    public void GetOrAdd_type_keyed_runs_factory_with_the_correct_Type_argument()
+    public void GetOrAdd_typed_key_runs_factory_with_the_correct_key_argument()
     {
-        // The factory receives the Type that was used as the key — verify it isn't
-        // accidentally swapped or boxed wrong by the (Type, ValueType) wrapping.
-        ReflectionCache.ClearGlobalForTests();
+        // The factory receives the TKey value that was used — verify it isn't accidentally
+        // swapped or boxed wrong by the (TKey, ValueType) wrapping.
         Type? observed = null;
 
-        ReflectionCache.GetOrAdd<string>(typeof(TypeArgFixture), t => { observed = t; return "v"; });
+        ReflectionCache.GetOrAdd<Type, string>(typeof(TypeArgFixture), t => { observed = t; return "v"; });
 
         observed.Should().Be(typeof(TypeArgFixture));
     }
 
     private sealed class TypeArgFixture;
+
+    [Fact]
+    public void GetOrAdd_typed_key_works_for_string_Type_string_tuple_shape()
+    {
+        // Framework call sites compose (string Op, Type, string Method)-shape tuple keys
+        // when a cache purpose is identified by a label + a runtime Type + an instance
+        // method name (e.g. StreamingQueryExecutor.ResolveStreamingMethod and
+        // QueryExecutor.CustomQueryMethod). Pin the contract: ValueTuple's structural
+        // equality + GetHashCode play correctly with the cache's per-TKey-type generic-static
+        // specialization, including across the heterogeneous Type-vs-string members.
+        var typeFromTypeof = typeof(TupleKeyFixture);
+        var typeFromGetType = new TupleKeyFixture().GetType();
+        var calls = 0;
+
+        var first = ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), string>(
+            ("MyOp", typeFromTypeof, "MyMethod"),
+            k => { Interlocked.Increment(ref calls); return $"{k.Op}|{k.Type.Name}|{k.Method}"; });
+
+        // Same conceptual key reached via a different Type-resolution route — should hit
+        // the same dictionary slot and skip the factory.
+        var second = ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), string>(
+            ("MyOp", typeFromGetType, "MyMethod"),
+            k => { Interlocked.Increment(ref calls); return "DIFFERENT"; });
+
+        first.Should().Be("MyOp|TupleKeyFixture|MyMethod");
+        second.Should().Be("MyOp|TupleKeyFixture|MyMethod");
+        calls.Should().Be(1, "Type identity holds across resolution routes; the tuple cache must collapse them to one slot");
+
+        // Differing on any tuple component → distinct slots.
+        var differentOp = ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), string>(
+            ("OtherOp", typeFromTypeof, "MyMethod"),
+            k => { Interlocked.Increment(ref calls); return "differentOp"; });
+        var differentMethod = ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), string>(
+            ("MyOp", typeFromTypeof, "OtherMethod"),
+            k => { Interlocked.Increment(ref calls); return "differentMethod"; });
+
+        differentOp.Should().Be("differentOp");
+        differentMethod.Should().Be("differentMethod");
+        calls.Should().Be(3, "the leading Op string and the trailing Method string both discriminate within the dict");
+    }
+
+    private sealed class TupleKeyFixture;
 
     [Fact]
     public void GetOrAdd_per_type_caches_value_type_results()

--- a/MintPlayer.Spark.Tests/Replication/EtlTaskManagerTests.cs
+++ b/MintPlayer.Spark.Tests/Replication/EtlTaskManagerTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MintPlayer.Spark.Replication.Abstractions.Models;
+using MintPlayer.Spark.Replication.Services;
+using NSubstitute;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Replication;
+
+/// <summary>
+/// Pins the self-loop guard in <see cref="EtlTaskManager.DeployAsync"/>: a deployment
+/// whose <c>TargetDatabase</c> equals the local store's database must be refused —
+/// otherwise a misrouted deployment (stale moduleInformations URL pointing back at
+/// the requester) silently installs an ETL task that reads from and writes to the
+/// same DB, producing an infinite RavenDB-internal write loop.
+/// </summary>
+public class EtlTaskManagerTests
+{
+    [Fact]
+    public async Task DeployAsync_returns_failure_when_target_database_equals_local_store_database()
+    {
+        var documentStore = Substitute.For<IDocumentStore>();
+        documentStore.Database.Returns("SparkHR");
+
+        var manager = new EtlTaskManager(documentStore, NullLogger<EtlTaskManager>.Instance);
+
+        var request = new EtlScriptRequest
+        {
+            RequestingModule = "HR",
+            TargetDatabase = "SparkHR",
+            TargetUrls = ["http://localhost:8080"],
+            Scripts = [new EtlScriptItem { SourceCollection = "Cars", Script = "loadToCars(this);" }],
+        };
+
+        var result = await manager.DeployAsync(request);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("self-loop");
+        result.TasksCreated.Should().Be(0);
+        result.TasksUpdated.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeployAsync_self_loop_check_is_case_insensitive()
+    {
+        var documentStore = Substitute.For<IDocumentStore>();
+        documentStore.Database.Returns("SparkHR");
+
+        var manager = new EtlTaskManager(documentStore, NullLogger<EtlTaskManager>.Instance);
+
+        var request = new EtlScriptRequest
+        {
+            RequestingModule = "HR",
+            TargetDatabase = "sparkhr",
+            TargetUrls = ["http://localhost:8080"],
+            Scripts = [],
+        };
+
+        var result = await manager.DeployAsync(request);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("self-loop");
+    }
+}

--- a/MintPlayer.Spark.Tests/Services/ActionsResolverTests.cs
+++ b/MintPlayer.Spark.Tests/Services/ActionsResolverTests.cs
@@ -128,6 +128,46 @@ public class ActionsResolverTests
         first.Should().BeSameAs(registeredInstance);
         second.Should().BeSameAs(registeredInstance);
     }
+
+    [Fact]
+    public void FindActionsType_caches_negative_result_for_missing_actions_class()
+    {
+        // ResolverFixtureC has no entity-specific Actions class anywhere. The cache
+        // primitive's negative-caching contract means the assembly walk should run at
+        // most once per missing type name, no matter how many times Resolve is called.
+        // We can't directly observe assembly walks, but two consecutive Resolve calls
+        // returning the same Default instance shape proves the resolver is stable.
+        var services = BaseServices();
+        var provider = services.BuildServiceProvider();
+
+        var resolver = new ActionsResolver(provider);
+
+        var first = resolver.Resolve<ResolverFixtureC>();
+        var second = resolver.Resolve<ResolverFixtureC>();
+
+        first.Should().BeOfType<DefaultPersistentObjectActions<ResolverFixtureC>>();
+        second.Should().BeOfType<DefaultPersistentObjectActions<ResolverFixtureC>>();
+    }
+
+    [Fact]
+    public void ResolveForType_caches_closed_generic_method_per_entity_type()
+    {
+        // ResolveForType reflects on Resolve<T> + MakeGenericMethod(entityType); the
+        // closed MethodInfo is cached per entityType. Repeated dispatches for the same
+        // entityType must keep returning the right shape.
+        var services = BaseServices();
+        var provider = services.BuildServiceProvider();
+
+        var resolver = new ActionsResolver(provider);
+
+        var firstA = resolver.ResolveForType(typeof(ResolverFixtureA));
+        var secondA = resolver.ResolveForType(typeof(ResolverFixtureA));
+        var firstC = resolver.ResolveForType(typeof(ResolverFixtureC));
+
+        firstA.Should().BeOfType<ResolverFixtureAActions>();
+        secondA.Should().BeOfType<ResolverFixtureAActions>();
+        firstC.Should().BeOfType<DefaultPersistentObjectActions<ResolverFixtureC>>();
+    }
 }
 
 // Top-level fixtures so FindActionsType can match by Type.Name.

--- a/MintPlayer.Spark.Tests/Services/DatabaseAccessIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/DatabaseAccessIntegrationTests.cs
@@ -4,6 +4,7 @@ using MintPlayer.Spark.Services;
 using MintPlayer.Spark.Testing;
 using MintPlayer.Spark.Tests._Infrastructure;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 
 namespace MintPlayer.Spark.Tests.Services;
 
@@ -209,5 +210,70 @@ public class DatabaseAccessIntegrationTests : SparkTestDriver
         using var session = Store.OpenAsyncSession();
         var loaded = await session.LoadAsync<GuardedDoc>(id);
         loaded.Should().BeNull();
+    }
+
+    // --- GetDocumentsByObjectTypeIdAsync (generic typed list filtered by ObjectTypeId) ---
+
+    [Fact]
+    public async Task GetDocumentsByObjectTypeIdAsync_returns_empty_when_no_documents_have_the_id()
+    {
+        // GuardedDoc has no ObjectTypeId field, so the LINQ Where short-circuits to empty.
+        // Pin the empty-result shape so a future change to GuardedDoc doesn't accidentally
+        // make this throw.
+        var act = () => _dbAccess.GetDocumentsByObjectTypeIdAsync<GuardedDoc>(Guid.NewGuid());
+
+        // GuardedDoc isn't a PersistentObject so the cast in the LINQ Where will fail at runtime;
+        // that's the framework's documented contract — only PersistentObject-derived types
+        // can use this overload. We accept either an empty result or InvalidCastException.
+        try
+        {
+            var docs = await act();
+            docs.Should().BeEmpty();
+        }
+        catch (InvalidCastException)
+        {
+            // Acceptable: GuardedDoc isn't a PersistentObject.
+        }
+    }
+
+    // --- GetPersistentObjectsAsync via index + projection ----------------------
+
+    /// <summary>Map index that drives DatabaseAccess.QueryEntitiesWithIncludesAsync's
+    /// reflective ApplyIndex / ApplyProjection / ApplyToListAsync paths through the
+    /// IndexRegistry projection registration.</summary>
+    public class GuardedDocs_ByName : AbstractIndexCreationTask<GuardedDoc>
+    {
+        public GuardedDocs_ByName()
+        {
+            Map = docs => from d in docs select new { d.Name, d.IsVisible };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    public class VGuardedDoc
+    {
+        public string? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool IsVisible { get; set; }
+    }
+
+    [Fact]
+    public async Task GetPersistentObjectsAsync_through_registered_index_and_projection_succeeds()
+    {
+        await SeedAsync(new GuardedDoc { Id = "docs/i1", Name = "Alpha", IsVisible = true });
+        await SeedAsync(new GuardedDoc { Id = "docs/i2", Name = "Bravo", IsVisible = true });
+        await SeedAsync(new GuardedDoc { Id = "docs/i3", Name = "Charlie", IsVisible = true });
+
+        await new GuardedDocs_ByName().ExecuteAsync(Store);
+        WaitForIndexing(Store);
+
+        var indexRegistry = _factory.GetService<IIndexRegistry>();
+        indexRegistry.RegisterIndex(typeof(GuardedDocs_ByName));
+        indexRegistry.RegisterProjection(typeof(VGuardedDoc), typeof(GuardedDocs_ByName));
+
+        var results = (await _dbAccess.GetPersistentObjectsAsync(DocTypeId)).ToList();
+
+        results.Should().HaveCount(3);
+        results.Select(po => po.Id).Should().BeEquivalentTo(["docs/i1", "docs/i2", "docs/i3"]);
     }
 }

--- a/MintPlayer.Spark.Tests/Services/DatabaseAccessIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/DatabaseAccessIntegrationTests.cs
@@ -1,0 +1,213 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Exceptions;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+using Raven.Client.Documents;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Integration tests for <see cref="IDatabaseAccess"/> covering the reflective dispatch
+/// paths that the ReflectionCache migration touched: SavePersistentObjectAsync,
+/// DeletePersistentObjectAsync, optimistic-concurrency check, and the generic flat APIs
+/// (GetDocumentsAsync, SaveDocumentAsync, DeleteDocumentAsync) that hit
+/// <c>typeof(T).GetProperty("Id")</c>. Sister file to
+/// <see cref="DatabaseAccessRowLevelAuthzTests"/> which covers the Get/list authz path.
+/// </summary>
+public class DatabaseAccessIntegrationTests : SparkTestDriver
+{
+    private static readonly Guid DocTypeId = Guid.Parse("8b0a22aa-22aa-22aa-22aa-8b0a22aa22aa");
+
+    private SparkEndpointFactory<GuardedContext> _factory = null!;
+    private IDatabaseAccess _dbAccess = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory<GuardedContext>(Store, [GuardedDocModel.For(DocTypeId)]);
+        _dbAccess = _factory.GetService<IDatabaseAccess>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task<string> SeedAsync(GuardedDoc doc)
+    {
+        using var session = Store.OpenAsyncSession();
+        await session.StoreAsync(doc);
+        await session.SaveChangesAsync();
+        return doc.Id!;
+    }
+
+    // --- SavePersistentObjectAsync (insert + update via the actions pipeline) --------
+
+    [Fact]
+    public async Task SavePersistentObjectAsync_inserts_a_new_entity_and_returns_the_generated_Id()
+    {
+        var po = new PersistentObject
+        {
+            Id = null,
+            ObjectTypeId = DocTypeId,
+            Name = "GuardedDoc",
+        };
+        po.AddAttribute(new PersistentObjectAttribute { Name = "Name", DataType = "string", Value = "fresh", IsValueChanged = true });
+        po.AddAttribute(new PersistentObjectAttribute { Name = "IsVisible", DataType = "bool", Value = true, IsValueChanged = true });
+
+        var result = await _dbAccess.SavePersistentObjectAsync(po);
+
+        result.Id.Should().NotBeNullOrEmpty(
+            "the insert path should populate the generated RavenDB document Id reflectively");
+        result.Etag.Should().NotBeNullOrEmpty();
+
+        // Verify the doc landed in the store.
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(result.Id);
+        loaded.Should().NotBeNull();
+        loaded!.Name.Should().Be("fresh");
+        loaded.IsVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SavePersistentObjectAsync_updates_an_existing_entity_when_Id_is_set()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "before", IsVisible = true });
+
+        // Read current Etag for the OCC path.
+        string currentEtag;
+        using (var session = Store.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<GuardedDoc>(id);
+            currentEtag = session.Advanced.GetChangeVectorFor(loaded);
+        }
+
+        var po = new PersistentObject
+        {
+            Id = id,
+            Etag = currentEtag,
+            Name = "GuardedDoc",
+            ObjectTypeId = DocTypeId,
+        };
+        po.AddAttribute(new PersistentObjectAttribute { Name = "Name", DataType = "string", Value = "after", IsValueChanged = true });
+        po.AddAttribute(new PersistentObjectAttribute { Name = "IsVisible", DataType = "bool", Value = true, IsValueChanged = true });
+
+        await _dbAccess.SavePersistentObjectAsync(po);
+
+        using var verify = Store.OpenAsyncSession();
+        var updated = await verify.LoadAsync<GuardedDoc>(id);
+        updated!.Name.Should().Be("after");
+    }
+
+    [Fact]
+    public async Task SavePersistentObjectAsync_throws_SparkConcurrencyException_on_stale_Etag()
+    {
+        // Optimistic concurrency: the caller sent an Etag that no longer matches the
+        // server-side change vector. This path opens a side session via documentStore
+        // (so change tracking on the main session isn't polluted) and should throw
+        // before the actions pipeline runs.
+        var id = await SeedAsync(new GuardedDoc { Name = "v1", IsVisible = true });
+
+        var po = new PersistentObject
+        {
+            Id = id,
+            Etag = "A:1-deadbeefdeadbeefdeadbeefdeadbeef", // intentionally bogus
+            Name = "GuardedDoc",
+            ObjectTypeId = DocTypeId,
+        };
+        po.AddAttribute(new PersistentObjectAttribute { Name = "Name", DataType = "string", Value = "v2", IsValueChanged = true });
+        po.AddAttribute(new PersistentObjectAttribute { Name = "IsVisible", DataType = "bool", Value = true, IsValueChanged = true });
+
+        var act = () => _dbAccess.SavePersistentObjectAsync(po);
+
+        await act.Should().ThrowAsync<SparkConcurrencyException>();
+    }
+
+    // --- DeletePersistentObjectAsync ------------------------------------------------
+
+    [Fact]
+    public async Task DeletePersistentObjectAsync_removes_the_document_via_the_actions_pipeline()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "doomed", IsVisible = true });
+
+        await _dbAccess.DeletePersistentObjectAsync(DocTypeId, id);
+
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(id);
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeletePersistentObjectAsync_silently_returns_when_objectTypeId_is_unknown()
+    {
+        // Unknown ObjectTypeId — modelLoader returns null, so the call short-circuits.
+        // Verifies the early-out guard rather than letting a NullReferenceException leak.
+        var unknownTypeId = Guid.NewGuid();
+
+        var act = () => _dbAccess.DeletePersistentObjectAsync(unknownTypeId, "docs/whatever");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // --- Generic flat APIs (hit the typeof(T).GetProperty("Id") line in SaveDocumentAsync) -----
+
+    [Fact]
+    public async Task SaveDocumentAsync_persists_the_typed_document_and_returns_it_with_Id()
+    {
+        var doc = new GuardedDoc { Name = "via-generic-save", IsVisible = true };
+
+        var saved = await _dbAccess.SaveDocumentAsync(doc);
+
+        saved.Id.Should().NotBeNullOrEmpty();
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(saved.Id);
+        loaded.Should().NotBeNull();
+        loaded!.Name.Should().Be("via-generic-save");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_returns_all_documents_of_the_given_type()
+    {
+        await SeedAsync(new GuardedDoc { Name = "a", IsVisible = true });
+        await SeedAsync(new GuardedDoc { Name = "b", IsVisible = true });
+        WaitForIndexing(Store);
+
+        var docs = (await _dbAccess.GetDocumentsAsync<GuardedDoc>()).ToList();
+
+        docs.Should().HaveCount(2);
+        docs.Select(d => d.Name).Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_returns_the_document_by_Id()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "loadme", IsVisible = true });
+
+        var loaded = await _dbAccess.GetDocumentAsync<GuardedDoc>(id);
+
+        loaded.Should().NotBeNull();
+        loaded!.Name.Should().Be("loadme");
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_returns_null_when_the_document_does_not_exist()
+    {
+        var loaded = await _dbAccess.GetDocumentAsync<GuardedDoc>("docs/nonexistent");
+
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteDocumentAsync_removes_the_typed_document()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "doomed-typed", IsVisible = true });
+
+        await _dbAccess.DeleteDocumentAsync<GuardedDoc>(id);
+
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(id);
+        loaded.Should().BeNull();
+    }
+}

--- a/MintPlayer.Spark.Tests/Services/QueryExecutorAdvancedIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/QueryExecutorAdvancedIntegrationTests.cs
@@ -1,0 +1,361 @@
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Actions;
+using MintPlayer.Spark.Queries;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Integration tests targeting the reflective dispatch tail of <see cref="QueryExecutor"/>:
+/// custom-query method invocation (cached <see cref="System.Reflection.MethodInfo"/>),
+/// sorting via <c>typeof(Queryable).GetMethods()</c> + <c>MakeGenericMethod</c>,
+/// reference-include resolution via cached generic <c>LoadAsync&lt;T&gt;</c>, and the
+/// custom-query async + sync queryable shapes that <c>ResolveCustomQueryMethod</c> caches.
+///
+/// These paths can only be exercised with a real document store — the cached MethodInfos
+/// only fire when the actions pipeline runs end-to-end.
+/// </summary>
+public class QueryExecutorAdvancedIntegrationTests : SparkTestDriver
+{
+    private static readonly Guid CompanyTypeId = Guid.Parse("aaaa1111-aaaa-aaaa-aaaa-aaaa11111111");
+    private static readonly Guid EmployeeTypeId = Guid.Parse("bbbb2222-bbbb-bbbb-bbbb-bbbb22222222");
+
+    public class Company
+    {
+        public string? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class Employee
+    {
+        public string? Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+
+        [Reference(typeof(Company))]
+        public string? Company { get; set; }
+    }
+
+    public class TestContext : SparkContext
+    {
+        public IRavenQueryable<Company> Companies => Session.Query<Company>();
+        public IRavenQueryable<Employee> Employees => Session.Query<Employee>();
+    }
+
+    private static EntityTypeFile CompanyModel() => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = CompanyTypeId,
+            Name = "Company",
+            ClrType = typeof(Company).FullName!,
+            DisplayAttribute = "Name",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Name", DataType = "string" },
+            ],
+        },
+    };
+
+    private static EntityTypeFile EmployeeModel() => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = EmployeeTypeId,
+            Name = "Employee",
+            ClrType = typeof(Employee).FullName!,
+            DisplayAttribute = "LastName",
+            Attributes = [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "FirstName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "LastName", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Company", DataType = "Reference" },
+            ],
+        },
+    };
+
+    private SparkEndpointFactory<TestContext> _factory = null!;
+    private IQueryExecutor _executor = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory<TestContext>(Store, [CompanyModel(), EmployeeModel()]);
+        _executor = _factory.GetService<IQueryExecutor>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task<(string companyId, string[] employeeIds)> SeedAsync()
+    {
+        using var session = Store.OpenAsyncSession();
+        var company = new Company { Name = "Acme" };
+        await session.StoreAsync(company);
+        var employees = new[]
+        {
+            new Employee { FirstName = "Ada", LastName = "Lovelace", Company = company.Id },
+            new Employee { FirstName = "Grace", LastName = "Hopper", Company = company.Id },
+            new Employee { FirstName = "Linus", LastName = "Torvalds", Company = company.Id },
+        };
+        foreach (var e in employees) await session.StoreAsync(e);
+        await session.SaveChangesAsync();
+        WaitForIndexing(Store);
+        return (company.Id!, employees.Select(e => e.Id!).ToArray());
+    }
+
+    // --- Database query with reference Include() ---------------------------
+
+    [Fact]
+    public async Task Database_query_resolves_reference_breadcrumbs_via_ApplyIncludes()
+    {
+        // Exercises the entire reference-resolution chain:
+        //   - ReferenceResolver.GetReferenceProperties (cached PropertyInfo + ReferenceAttribute)
+        //   - ReferenceResolver.ApplyIncludes (cached MethodInfo for queryable.Include(string))
+        //   - ReferenceResolver.ResolveReferencedDocumentsAsync (cached LoadAsync<T>)
+        //   - EntityMapper.PopulateAttributeValues (sets Breadcrumb from includedDocuments)
+        var (companyId, _) = await SeedAsync();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "Employees",
+            Source = "Database.Employees",
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+        var first = result.Data.First();
+        var companyAttr = first.Attributes.Single(a => a.Name == "Company");
+        companyAttr.Value.Should().Be(companyId);
+        companyAttr.Breadcrumb.Should().Be("Acme",
+            "the breadcrumb comes from the cached LoadAsync<Company> dispatch");
+    }
+
+    // --- Database query with sorting --------------------------------------
+
+    [Fact]
+    public async Task Database_query_sorts_results_via_reflective_OrderBy_call()
+    {
+        // ApplySorting reflects on typeof(Queryable).GetMethods() and calls MakeGenericMethod
+        // on the matching OrderBy / OrderByDescending overload — these closed MethodInfos
+        // are cached per (entityType, propertyType, methodName).
+        await SeedAsync();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesSorted",
+            Source = "Database.Employees",
+            SortColumns = [
+                new SortColumn { Property = "LastName", Direction = "asc" },
+            ],
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        var lastNames = result.Data
+            .Select(po => po.Attributes.Single(a => a.Name == "LastName").Value?.ToString())
+            .ToList();
+
+        lastNames.Should().Equal("Hopper", "Lovelace", "Torvalds");
+    }
+
+    [Fact]
+    public async Task Database_query_sorts_results_descending()
+    {
+        await SeedAsync();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesSortedDesc",
+            Source = "Database.Employees",
+            SortColumns = [
+                new SortColumn { Property = "LastName", Direction = "desc" },
+            ],
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        var lastNames = result.Data
+            .Select(po => po.Attributes.Single(a => a.Name == "LastName").Value?.ToString())
+            .ToList();
+
+        lastNames.Should().Equal("Torvalds", "Lovelace", "Hopper");
+    }
+
+    [Fact]
+    public async Task Database_query_supports_multi_column_sort()
+    {
+        // Multi-column sort drives the i==0/ThenBy branch in ApplySorting.
+        using (var session = Store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Employee { FirstName = "B", LastName = "Z" });
+            await session.StoreAsync(new Employee { FirstName = "A", LastName = "Z" });
+            await session.StoreAsync(new Employee { FirstName = "B", LastName = "A" });
+            await session.SaveChangesAsync();
+        }
+        WaitForIndexing(Store);
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesMultiSort",
+            Source = "Database.Employees",
+            SortColumns = [
+                new SortColumn { Property = "LastName", Direction = "asc" },
+                new SortColumn { Property = "FirstName", Direction = "asc" },
+            ],
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        var ordered = result.Data
+            .Select(po => (po.Attributes.Single(a => a.Name == "LastName").Value?.ToString(),
+                           po.Attributes.Single(a => a.Name == "FirstName").Value?.ToString()))
+            .ToList();
+
+        ordered.Should().Equal(("A", "B"), ("Z", "A"), ("Z", "B"));
+    }
+
+    // --- Custom query path -------------------------------------------------
+
+    /// <summary>
+    /// Custom-query Actions class that returns a real IRavenQueryable<T> via the session.
+    /// The session is supplied through DI by SparkEndpointFactory's scoped registration.
+    /// </summary>
+    public class EmployeeActions : DefaultPersistentObjectActions<Employee>
+    {
+        private readonly IAsyncDocumentSession _session;
+        public EmployeeActions(IEntityMapper entityMapper, IAsyncDocumentSession session) : base(entityMapper)
+        {
+            _session = session;
+        }
+
+        public IRavenQueryable<Employee> AllEmployees(CustomQueryArgs _) => _session.Query<Employee>();
+        public IRavenQueryable<Employee> NoArgs() => _session.Query<Employee>();
+        // Async returns Task<IEnumerable<T>> (already-materialized) — that's the only async
+        // shape the executor supports cleanly; Task<IRavenQueryable<T>> would synchronously
+        // enumerate the Raven query after awaiting and Raven rejects sync ops on async sessions.
+        public async Task<IEnumerable<Employee>> AllEmployeesAsync(CustomQueryArgs _)
+        {
+            return await _session.Query<Employee>().ToListAsync();
+        }
+        public IQueryable<Employee> InMemoryEmployees() => new[]
+        {
+            new Employee { Id = "memory/1", FirstName = "InMemory", LastName = "Entity" },
+        }.AsQueryable();
+    }
+
+    // EmployeeActions is discovered through the framework's normal Tier-1 path:
+    // ActionsResolver.FindActionsType walks the loaded assemblies for a public class
+    // named "{EntityName}Actions" and constructs it via ActivatorUtilities (which pulls
+    // IEntityMapper + IAsyncDocumentSession from the DI scope). No explicit registration
+    // is needed; we deliberately rely on the same convention production apps use.
+    private IQueryExecutor CustomExecutor() => _factory.GetService<IQueryExecutor>();
+
+    [Fact]
+    public async Task Custom_query_with_sync_IRavenQueryable_executes_via_cached_MethodInfo()
+    {
+        await SeedAsync();
+        var executor = CustomExecutor();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "CustomEmployeesAll",
+            Source = "Custom.AllEmployees",
+            EntityType = "Employee",
+        };
+
+        var result = await executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Custom_query_with_zero_args_method_executes_via_cached_MethodInfo()
+    {
+        await SeedAsync();
+        var executor = CustomExecutor();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "CustomEmployeesNoArgs",
+            Source = "Custom.NoArgs",
+            EntityType = "Employee",
+        };
+
+        var result = await executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Custom_query_with_async_method_unwraps_Task_result_via_GetCompletedTaskResult()
+    {
+        await SeedAsync();
+        var executor = CustomExecutor();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "CustomEmployeesAsync",
+            Source = "Custom.AllEmployeesAsync",
+            EntityType = "Employee",
+        };
+
+        var result = await executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Custom_query_with_in_memory_IQueryable_uses_MaterializeQueryable()
+    {
+        var executor = CustomExecutor();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "CustomInMemory",
+            Source = "Custom.InMemoryEmployees",
+            EntityType = "Employee",
+        };
+
+        var result = await executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(1);
+        result.Data.Single().Id.Should().Be("memory/1");
+    }
+
+    [Fact]
+    public async Task Custom_query_throws_for_method_with_unsupported_signature()
+    {
+        // ResolveCustomQueryMethod returns null for invalid signatures; the executor
+        // converts that to a clear InvalidOperationException.
+        var executor = CustomExecutor();
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "Bogus",
+            Source = "Custom.NoSuchMethod",
+            EntityType = "Employee",
+        };
+
+        var act = () => executor.ExecuteQueryAsync(query);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains("not found"));
+    }
+}

--- a/MintPlayer.Spark.Tests/Services/QueryExecutorAdvancedIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/QueryExecutorAdvancedIntegrationTests.cs
@@ -5,6 +5,7 @@ using MintPlayer.Spark.Queries;
 using MintPlayer.Spark.Services;
 using MintPlayer.Spark.Testing;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
 
@@ -357,5 +358,118 @@ public class QueryExecutorAdvancedIntegrationTests : SparkTestDriver
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .Where(e => e.Message.Contains("not found"));
+    }
+
+    // --- Index + projection path ------------------------------------------
+
+    /// <summary>
+    /// Map index over Employee that projects FirstName + LastName as stored fields.
+    /// Drives QueryExecutor.ApplyIndexWithType + ApplyProjection through the registered
+    /// projection-type path.
+    /// </summary>
+    public class Employees_ByLastName : AbstractIndexCreationTask<Employee>
+    {
+        public Employees_ByLastName()
+        {
+            Map = employees => from e in employees
+                               select new
+                               {
+                                   e.FirstName,
+                                   e.LastName,
+                               };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    /// <summary>Projection type for the index.</summary>
+    public class VEmployee
+    {
+        public string? Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task Database_query_through_registered_index_uses_ApplyIndexWithType_and_ApplyProjection()
+    {
+        // Exercises the cached MethodInfos for:
+        //   - IAsyncDocumentSession.Query<TResult, TIndexCreator>() (zero-arg overload)
+        //   - LinqExtensions.ProjectInto<T>(IQueryable)
+        //   - LinqExtensions.ToListAsync<T>(IQueryable, CancellationToken)
+        await SeedAsync();
+
+        // Deploy the index to RavenDB and register it with the framework's IndexRegistry.
+        await new Employees_ByLastName().ExecuteAsync(Store);
+        WaitForIndexing(Store);
+
+        var indexRegistry = _factory.GetService<IIndexRegistry>();
+        indexRegistry.RegisterIndex(typeof(Employees_ByLastName));
+        indexRegistry.RegisterProjection(typeof(VEmployee), typeof(Employees_ByLastName));
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesByIndex",
+            Source = "Database.Employees",
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Database_query_through_index_supports_sorting_on_indexed_field()
+    {
+        await SeedAsync();
+
+        await new Employees_ByLastName().ExecuteAsync(Store);
+        WaitForIndexing(Store);
+
+        var indexRegistry = _factory.GetService<IIndexRegistry>();
+        indexRegistry.RegisterIndex(typeof(Employees_ByLastName));
+        indexRegistry.RegisterProjection(typeof(VEmployee), typeof(Employees_ByLastName));
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesByIndexSorted",
+            Source = "Database.Employees",
+            SortColumns = [
+                new SortColumn { Property = "LastName", Direction = "asc" },
+            ],
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        var lastNames = result.Data
+            .Select(po => po.Attributes.Single(a => a.Name == "LastName").Value?.ToString())
+            .ToList();
+
+        lastNames.Should().Equal("Hopper", "Lovelace", "Torvalds");
+    }
+
+    [Fact]
+    public async Task Database_query_with_explicit_IndexName_uses_ApplyIndexByName_when_no_index_type_registered()
+    {
+        // SparkQuery.IndexName is set but no index *type* is registered with the registry —
+        // QueryExecutor must fall through to the ApplyIndexByName path that takes the index
+        // name as a string and reflects on the 3-arg Query<T>(string, string, bool) overload.
+        await SeedAsync();
+
+        await new Employees_ByLastName().ExecuteAsync(Store);
+        WaitForIndexing(Store);
+
+        var query = new SparkQuery
+        {
+            Id = Guid.NewGuid(),
+            Name = "EmployeesByExplicitIndex",
+            Source = "Database.Employees",
+            IndexName = "Employees_ByLastName",
+        };
+
+        var result = await _executor.ExecuteQueryAsync(query);
+
+        result.TotalRecords.Should().Be(3);
     }
 }

--- a/MintPlayer.Spark.Tests/Services/SyncActionHandlerIntegrationTests.cs
+++ b/MintPlayer.Spark.Tests/Services/SyncActionHandlerIntegrationTests.cs
@@ -1,0 +1,172 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using MintPlayer.Spark.Tests._Infrastructure;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// Integration tests for <see cref="ISyncActionHandler"/> covering the reflective
+/// dispatch chain that the ReflectionCache migration touched: collection name →
+/// CLR type resolution, "Id" PropertyInfo extraction, and the actions-pipeline
+/// MethodInfo lookups (OnSaveAsync / OnDeleteAsync). Existing
+/// <see cref="SyncActionHandlerBuildPersistentObjectTests"/> covers the
+/// PersistentObject construction step in isolation; this file exercises the
+/// full HandleSaveAsync / HandleDeleteAsync flows against a real document store
+/// through <see cref="SparkEndpointFactory{TContext}"/>.
+/// </summary>
+public class SyncActionHandlerIntegrationTests : SparkTestDriver
+{
+    private static readonly Guid DocTypeId = Guid.Parse("9c0a33aa-33aa-33aa-33aa-9c0a33aa33aa");
+
+    private SparkEndpointFactory<GuardedContext> _factory = null!;
+    private ISyncActionHandler _handler = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory<GuardedContext>(Store, [GuardedDocModel.For(DocTypeId)]);
+        _handler = _factory.GetService<ISyncActionHandler>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task<string> SeedAsync(GuardedDoc doc)
+    {
+        using var session = Store.OpenAsyncSession();
+        await session.StoreAsync(doc);
+        await session.SaveChangesAsync();
+        return doc.Id!;
+    }
+
+    // --- HandleSaveAsync: insert path ----------------------------------------
+
+    [Fact]
+    public async Task HandleSaveAsync_with_null_documentId_creates_a_new_document_and_returns_generated_Id()
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["Name"] = "from-sync",
+            ["IsVisible"] = true,
+        };
+
+        var generatedId = await _handler.HandleSaveAsync("GuardedDocs", documentId: null, data, properties: null);
+
+        generatedId.Should().NotBeNullOrEmpty(
+            "the insert path should reflect the generated Id off the saved entity via cached PropertyInfo");
+
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(generatedId);
+        loaded.Should().NotBeNull();
+        loaded!.Name.Should().Be("from-sync");
+        loaded.IsVisible.Should().BeTrue();
+    }
+
+    // --- HandleSaveAsync: update path ----------------------------------------
+
+    [Fact]
+    public async Task HandleSaveAsync_with_existing_documentId_updates_the_document()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "before-sync", IsVisible = true });
+
+        var data = new Dictionary<string, object?>
+        {
+            ["Name"] = "after-sync",
+            ["IsVisible"] = true,
+        };
+
+        var resultId = await _handler.HandleSaveAsync("GuardedDocs", id, data, properties: ["Name"]);
+
+        resultId.Should().Be(id);
+
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(id);
+        loaded!.Name.Should().Be("after-sync");
+    }
+
+    // --- Collection name resolution ------------------------------------------
+
+    [Fact]
+    public async Task HandleSaveAsync_throws_when_collection_does_not_resolve_to_any_entity_type()
+    {
+        // ResolveEntityType walks every registered EntityTypeDefinition, looks up the CLR
+        // type via cached resolution, and asks the document store's convention for the
+        // collection name. An unknown collection should surface as an InvalidOperationException
+        // rather than silently no-oping.
+        var data = new Dictionary<string, object?> { ["Name"] = "x" };
+
+        var act = () => _handler.HandleSaveAsync("DefinitelyNotARealCollectionName", null, data, null);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains("DefinitelyNotARealCollectionName"));
+    }
+
+    [Fact]
+    public async Task HandleSaveAsync_collection_name_lookup_is_case_insensitive()
+    {
+        // The collection cache uses StringComparer.OrdinalIgnoreCase explicitly — pinned
+        // because the new ReflectionCache primitive is case-sensitive, so we deliberately
+        // kept the local cache for collection-name lookups.
+        var data = new Dictionary<string, object?>
+        {
+            ["Name"] = "case-test",
+            ["IsVisible"] = true,
+        };
+
+        // Lowercase variant must still resolve.
+        var generatedId = await _handler.HandleSaveAsync("guardeddocs", documentId: null, data, properties: null);
+
+        generatedId.Should().NotBeNullOrEmpty();
+    }
+
+    // --- HandleDeleteAsync ----------------------------------------------------
+
+    [Fact]
+    public async Task HandleDeleteAsync_removes_the_document_through_the_actions_pipeline()
+    {
+        var id = await SeedAsync(new GuardedDoc { Name = "to-delete", IsVisible = true });
+
+        await _handler.HandleDeleteAsync("GuardedDocs", id);
+
+        using var session = Store.OpenAsyncSession();
+        var loaded = await session.LoadAsync<GuardedDoc>(id);
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleDeleteAsync_throws_when_collection_is_unknown()
+    {
+        var act = () => _handler.HandleDeleteAsync("DefinitelyNotARealCollectionName", "docs/anything");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // --- Repeat-call cache stability -----------------------------------------
+
+    [Fact]
+    public async Task Repeat_HandleSaveAsync_calls_for_the_same_collection_succeed_consistently()
+    {
+        // The collection-name cache and the ResolveType cache (now backed by ReflectionCache)
+        // should make the second call see the cached resolution. Verify both calls succeed
+        // and produce documents of the right shape.
+        var data1 = new Dictionary<string, object?> { ["Name"] = "first", ["IsVisible"] = true };
+        var data2 = new Dictionary<string, object?> { ["Name"] = "second", ["IsVisible"] = true };
+
+        var id1 = await _handler.HandleSaveAsync("GuardedDocs", null, data1, null);
+        var id2 = await _handler.HandleSaveAsync("GuardedDocs", null, data2, null);
+
+        id1.Should().NotBeNullOrEmpty();
+        id2.Should().NotBeNullOrEmpty();
+        id1.Should().NotBe(id2);
+
+        using var session = Store.OpenAsyncSession();
+        var doc1 = await session.LoadAsync<GuardedDoc>(id1);
+        var doc2 = await session.LoadAsync<GuardedDoc>(id2);
+        doc1!.Name.Should().Be("first");
+        doc2!.Name.Should().Be("second");
+    }
+}

--- a/MintPlayer.Spark/Endpoints/ProgramUnits/Get.cs
+++ b/MintPlayer.Spark/Endpoints/ProgramUnits/Get.cs
@@ -2,9 +2,9 @@ using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Services;
 using Raven.Client.Documents;
-using System.Reflection;
 
 namespace MintPlayer.Spark.Endpoints.ProgramUnits;
 
@@ -70,7 +70,7 @@ internal sealed partial class GetProgramUnits : IGetEndpoint, IMemberOf<SparkGro
             var sparkContext = sparkContextResolver.ResolveContext(session);
             if (sparkContext is null) return map;
 
-            foreach (var property in sparkContext.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var property in sparkContext.GetType().GetCachedProperties())
             {
                 var propertyType = property.PropertyType;
                 if (!propertyType.IsGenericType) continue;

--- a/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark</PackageId>
-		<Version>10.0.0-preview.33</Version>
+		<Version>10.0.0-preview.34</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Low-code .NET framework for building data-driven web applications with minimal boilerplate. Uses PersistentObject pattern to eliminate DTOs and repository layers.</Description>

--- a/MintPlayer.Spark/Services/ActionsResolver.cs
+++ b/MintPlayer.Spark/Services/ActionsResolver.cs
@@ -57,11 +57,13 @@ internal partial class ActionsResolver : IActionsResolver
     {
         // Cache the closed Resolve<TEntity>() MethodInfo per entity type — the reflective
         // GetMethod + MakeGenericMethod was previously hit on every dispatch.
-        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(entityType, static t =>
-        {
-            var method = typeof(ActionsResolver).GetMethod(nameof(Resolve))!;
-            return method.MakeGenericMethod(t);
-        });
+        var genericMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo>(
+            ("ActionsResolver.Resolve", entityType),
+            static k =>
+            {
+                var method = typeof(ActionsResolver).GetMethod(nameof(Resolve))!;
+                return method.MakeGenericMethod(k.Type);
+            });
         return genericMethod.Invoke(this, null)!;
     }
 

--- a/MintPlayer.Spark/Services/ActionsResolver.cs
+++ b/MintPlayer.Spark/Services/ActionsResolver.cs
@@ -1,4 +1,5 @@
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Actions;
 using System.Reflection;
 
@@ -54,27 +55,40 @@ internal partial class ActionsResolver : IActionsResolver
 
     public object ResolveForType(Type entityType)
     {
-        var method = typeof(ActionsResolver).GetMethod(nameof(Resolve))!;
-        var genericMethod = method.MakeGenericMethod(entityType);
+        // Cache the closed Resolve<TEntity>() MethodInfo per entity type — the reflective
+        // GetMethod + MakeGenericMethod was previously hit on every dispatch.
+        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(entityType, static t =>
+        {
+            var method = typeof(ActionsResolver).GetMethod(nameof(Resolve))!;
+            return method.MakeGenericMethod(t);
+        });
         return genericMethod.Invoke(this, null)!;
     }
 
-    private Type? FindActionsType(string typeName)
+    private static Type? FindActionsType(string typeName)
     {
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            try
+        // Negative caching matters here: when no Actions class exists for an entity, the
+        // resolver still walks every loaded assembly on every request unless the null
+        // is cached. ReflectionCache caches null too via Lazy<object?>.
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"actionsType|{typeName}",
+            () =>
             {
-                var type = assembly.GetTypes()
-                    .FirstOrDefault(t => t.Name == typeName && !t.IsAbstract && !t.IsInterface);
-                if (type != null) return type;
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                // Skip assemblies that can't be loaded
-                continue;
-            }
-        }
-        return null;
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    try
+                    {
+                        var type = assembly.GetTypes()
+                            .FirstOrDefault(t => t.Name == typeName && !t.IsAbstract && !t.IsInterface);
+                        if (type != null) return type;
+                    }
+                    catch (ReflectionTypeLoadException)
+                    {
+                        // Skip assemblies that can't be loaded
+                        continue;
+                    }
+                }
+                return null;
+            });
     }
 }

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -264,14 +264,14 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
     private async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
-        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionLoadAsync|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+            ("DatabaseAccess.SessionLoadAsync", entityType),
+            static k =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(
                     nameof(IAsyncDocumentSession.LoadAsync),
                     [typeof(string), typeof(CancellationToken)]);
-                return method?.MakeGenericMethod(entityType);
+                return method?.MakeGenericMethod(k.Type);
             });
         var task = genericMethod?.Invoke(session, [id, CancellationToken.None]) as Task;
 
@@ -316,15 +316,15 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         // Query method signature: Query<T>(string indexName, string collectionName, bool isMapReduce)
         var sessionType = session.GetType();
-        var genericQueryMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionQuery3|{sessionType.GetCacheKeyName()}|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericQueryMethod = ReflectionCache.GetOrAdd<(string Op, Type Session, Type Entity), MethodInfo?>(
+            ("DatabaseAccess.SessionQuery3", sessionType, entityType),
+            static k =>
             {
-                var queryMethod = sessionType.GetMethods()
+                var queryMethod = k.Session.GetMethods()
                     .FirstOrDefault(m => m.Name == "Query"
                         && m.GetGenericArguments().Length == 1
                         && m.GetParameters().Length == 3);
-                return queryMethod?.MakeGenericMethod(entityType);
+                return queryMethod?.MakeGenericMethod(k.Entity);
             });
 
         if (genericQueryMethod == null)
@@ -342,9 +342,9 @@ internal partial class DatabaseAccess : IDatabaseAccess
         // This ensures computed/stored fields like FullName are populated from the index
         if (!string.IsNullOrEmpty(indexName))
         {
-            var genericProjectIntoMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-                $"linqProjectInto|{entityType.GetCacheKeyName()}",
-                () =>
+            var genericProjectIntoMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+                ("DatabaseAccess.LinqProjectInto", entityType),
+                static k =>
                 {
                     var projectIntoMethod = typeof(LinqExtensions).GetMethods()
                         .FirstOrDefault(m => m.Name == "ProjectInto"
@@ -352,7 +352,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
                             && m.GetGenericArguments().Length == 1
                             && m.GetParameters().Length == 1
                             && m.GetParameters()[0].ParameterType == typeof(IQueryable));
-                    return projectIntoMethod?.MakeGenericMethod(entityType);
+                    return projectIntoMethod?.MakeGenericMethod(k.Type);
                 });
 
             if (genericProjectIntoMethod != null)
@@ -368,15 +368,15 @@ internal partial class DatabaseAccess : IDatabaseAccess
         }
 
         // Call ToListAsync on the query
-        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqToListAsync|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericToListMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+            ("DatabaseAccess.LinqToListAsync", entityType),
+            static k =>
             {
                 var toListMethod = typeof(LinqExtensions).GetMethods()
                     .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
                         && m.GetGenericArguments().Length == 1
                         && m.GetParameters().Length == 2);
-                return toListMethod?.MakeGenericMethod(entityType);
+                return toListMethod?.MakeGenericMethod(k.Type);
             });
 
         if (genericToListMethod == null)
@@ -418,9 +418,9 @@ internal partial class DatabaseAccess : IDatabaseAccess
     {
         var actions = actionsResolver.ResolveForType(entityType);
         var actionsType = actions.GetType();
-        var method = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"actionsMethod|{actionsType.FullName}|IsAllowedAsync|{entityType.FullName}",
-            () => actionsType.GetMethod("IsAllowedAsync", [typeof(string), entityType]));
+        var method = ReflectionCache.GetOrAdd<(string Op, Type Actions, Type Entity), MethodInfo?>(
+            ("DatabaseAccess.IsAllowedAsync", actionsType, entityType),
+            static k => k.Actions.GetMethod("IsAllowedAsync", [typeof(string), k.Entity]));
         if (method is null)
             return true; // Unknown shape — fail open rather than dropping valid rows.
         var task = (Task)method.Invoke(actions, [action, entity])!;
@@ -453,11 +453,11 @@ internal partial class DatabaseAccess : IDatabaseAccess
     /// a runtime condition we want to silently swallow.
     /// </summary>
     private static MethodInfo GetCachedActionMethod(Type actionsType, string methodName)
-        => ReflectionCache.GetOrAdd<MethodInfo>(
-            $"actionsMethod|{actionsType.FullName}|{methodName}",
-            () => actionsType.GetMethod(methodName)
+        => ReflectionCache.GetOrAdd<(string Op, Type Actions, string Method), MethodInfo>(
+            ("DatabaseAccess.ActionsMethod", actionsType, methodName),
+            static k => k.Actions.GetMethod(k.Method)
                 ?? throw new InvalidOperationException(
-                    $"Actions type '{actionsType.FullName}' is missing required method '{methodName}'."));
+                    $"Actions type '{k.Actions.FullName}' is missing required method '{k.Method}'."));
 
     #endregion
 }

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -265,7 +265,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
     private async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionLoadAsync|{entityType.FullName ?? entityType.Name}",
+            $"sessionLoadAsync|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(
@@ -317,7 +317,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
         // Query method signature: Query<T>(string indexName, string collectionName, bool isMapReduce)
         var sessionType = session.GetType();
         var genericQueryMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionQuery3|{sessionType.FullName ?? sessionType.Name}|{entityType.FullName ?? entityType.Name}",
+            $"sessionQuery3|{sessionType.GetCacheKeyName()}|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var queryMethod = sessionType.GetMethods()
@@ -343,7 +343,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
         if (!string.IsNullOrEmpty(indexName))
         {
             var genericProjectIntoMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-                $"linqProjectInto|{entityType.FullName ?? entityType.Name}",
+                $"linqProjectInto|{entityType.GetCacheKeyName()}",
                 () =>
                 {
                     var projectIntoMethod = typeof(LinqExtensions).GetMethods()
@@ -369,7 +369,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         // Call ToListAsync on the query
         var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
+            $"linqToListAsync|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var toListMethod = typeof(LinqExtensions).GetMethods()

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -282,60 +282,6 @@ internal partial class DatabaseAccess : IDatabaseAccess
         return task.GetCompletedTaskResult();
     }
 
-    private async Task<IEnumerable<object>> QueryEntitiesAsync(IAsyncDocumentSession session, Type entityType)
-    {
-        // Use Query<T> directly on the session (not via Advanced)
-        // Query(string indexName, string collectionName, bool isMapReduce) with 1 generic param and 3 regular params
-        var sessionType = session.GetType();
-
-        var genericQueryMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionQuery3|{sessionType.FullName ?? sessionType.Name}|{entityType.FullName ?? entityType.Name}",
-            () =>
-            {
-                var queryMethod = sessionType.GetMethods()
-                    .FirstOrDefault(m => m.Name == "Query"
-                        && m.GetGenericArguments().Length == 1
-                        && m.GetParameters().Length == 3);
-                return queryMethod?.MakeGenericMethod(entityType);
-            });
-
-        if (genericQueryMethod == null) return [];
-
-        // Pass null for indexName, null for collectionName, false for isMapReduce
-        var query = genericQueryMethod.Invoke(session, [null, null, false]);
-
-        if (query == null) return [];
-
-        // Call ToListAsync on the IRavenQueryable<T>
-        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
-            () =>
-            {
-                var toListMethod = typeof(LinqExtensions).GetMethods()
-                    .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
-                        && m.GetGenericArguments().Length == 1
-                        && m.GetParameters().Length == 2);
-                return toListMethod?.MakeGenericMethod(entityType);
-            });
-
-        if (genericToListMethod == null) return [];
-
-        var task = genericToListMethod.Invoke(null, [query, CancellationToken.None]) as Task;
-
-        if (task == null) return [];
-
-        await task;
-
-        var result = task.GetCompletedTaskResult();
-
-        if (result is System.Collections.IEnumerable enumerable)
-        {
-            return enumerable.Cast<object>().ToList();
-        }
-
-        return [];
-    }
-
     private Type? ResolveType(string clrType)
     {
         return ReflectionCache.GetOrAdd<Type?>(
@@ -480,22 +426,6 @@ internal partial class DatabaseAccess : IDatabaseAccess
         var task = (Task)method.Invoke(actions, [action, entity])!;
         await task;
         return (bool)task.GetCompletedTaskResult()!;
-    }
-
-    private async Task<IEnumerable<object>> QueryEntitiesViaActionsAsync(IAsyncDocumentSession session, Type entityType)
-    {
-        var actions = actionsResolver.ResolveForType(entityType);
-        var onQueryMethod = GetCachedActionMethod(actions.GetType(), "OnQueryAsync");
-        var task = (Task)onQueryMethod.Invoke(actions, [session])!;
-        await task;
-        var result = task.GetCompletedTaskResult();
-
-        if (result is System.Collections.IEnumerable enumerable)
-        {
-            return enumerable.Cast<object>().ToList();
-        }
-
-        return [];
     }
 
     private async Task<object> SaveEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, PersistentObject obj)

--- a/MintPlayer.Spark/Services/DatabaseAccess.cs
+++ b/MintPlayer.Spark/Services/DatabaseAccess.cs
@@ -1,6 +1,7 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Exceptions;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
@@ -48,8 +49,10 @@ internal partial class DatabaseAccess : IDatabaseAccess
         var interceptor = serviceProvider.GetService<ISyncActionInterceptor>();
         if (interceptor != null && interceptor.IsReplicated(typeof(T)))
         {
-            var idProperty = typeof(T).GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-            var documentId = idProperty?.GetValue(document)?.ToString();
+            var idProperty = typeof(T).GetCachedProperty("Id");
+            var documentId = idProperty is not null && idProperty.CanRead
+                ? AccessorCache.GetGetter(idProperty)(document)?.ToString()
+                : null;
             await interceptor.HandleSaveAsync(document, documentId);
         }
 
@@ -163,8 +166,9 @@ internal partial class DatabaseAccess : IDatabaseAccess
     {
         if (entities.Count == 0) return entities;
 
-        var idProperty = queryType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        if (idProperty is null) return entities; // Can't resolve IDs — fail open.
+        var idProperty = queryType.GetCachedProperty("Id");
+        if (idProperty is null || !idProperty.CanRead) return entities; // Can't resolve IDs — fail open.
+        var idGetter = AccessorCache.GetGetter(idProperty);
 
         var visible = new List<object>(entities.Count);
         foreach (var entity in entities)
@@ -172,7 +176,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
             object? subject = entity;
             if (queryType != entityType)
             {
-                var id = idProperty.GetValue(entity)?.ToString();
+                var id = idGetter(entity)?.ToString();
                 if (string.IsNullOrEmpty(id)) { visible.Add(entity); continue; }
                 subject = await LoadEntityAsync(session, entityType, id);
                 if (subject is null) { visible.Add(entity); continue; }
@@ -217,8 +221,10 @@ internal partial class DatabaseAccess : IDatabaseAccess
         var savedEntity = await SaveEntityViaActionsAsync(session, entityType, persistentObject);
 
         // Get the generated ID from the entity
-        var idProperty = entityType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        var generatedId = idProperty?.GetValue(savedEntity)?.ToString();
+        var idProperty = entityType.GetCachedProperty("Id");
+        var generatedId = idProperty is not null && idProperty.CanRead
+            ? AccessorCache.GetGetter(idProperty)(savedEntity)?.ToString()
+            : null;
 
         persistentObject.Id = generatedId;
         // Return the fresh change vector so the client can round-trip it to the next update.
@@ -258,18 +264,22 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
     private async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
-        // Use reflection to call the generic LoadAsync<T> method
-        var method = typeof(IAsyncDocumentSession).GetMethod(nameof(IAsyncDocumentSession.LoadAsync), [typeof(string), typeof(CancellationToken)]);
-        var genericMethod = method?.MakeGenericMethod(entityType);
+        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"sessionLoadAsync|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var method = typeof(IAsyncDocumentSession).GetMethod(
+                    nameof(IAsyncDocumentSession.LoadAsync),
+                    [typeof(string), typeof(CancellationToken)]);
+                return method?.MakeGenericMethod(entityType);
+            });
         var task = genericMethod?.Invoke(session, [id, CancellationToken.None]) as Task;
 
         if (task == null) return null;
 
         await task;
 
-        // Get the result from the task
-        var resultProperty = task.GetType().GetProperty("Result");
-        return resultProperty?.GetValue(task);
+        return task.GetCompletedTaskResult();
     }
 
     private async Task<IEnumerable<object>> QueryEntitiesAsync(IAsyncDocumentSession session, Type entityType)
@@ -278,37 +288,45 @@ internal partial class DatabaseAccess : IDatabaseAccess
         // Query(string indexName, string collectionName, bool isMapReduce) with 1 generic param and 3 regular params
         var sessionType = session.GetType();
 
-        var queryMethod = sessionType.GetMethods()
-            .FirstOrDefault(m => m.Name == "Query"
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 3);
+        var genericQueryMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"sessionQuery3|{sessionType.FullName ?? sessionType.Name}|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var queryMethod = sessionType.GetMethods()
+                    .FirstOrDefault(m => m.Name == "Query"
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 3);
+                return queryMethod?.MakeGenericMethod(entityType);
+            });
 
-        if (queryMethod == null) return [];
+        if (genericQueryMethod == null) return [];
 
-        var genericQueryMethod = queryMethod.MakeGenericMethod(entityType);
         // Pass null for indexName, null for collectionName, false for isMapReduce
         var query = genericQueryMethod.Invoke(session, [null, null, false]);
 
         if (query == null) return [];
 
         // Call ToListAsync on the IRavenQueryable<T>
-        // ToListAsync is an extension method in Raven.Client.Documents.Linq.LinqExtensions
-        var toListMethod = typeof(LinqExtensions).GetMethods()
-            .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 2);
+        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var toListMethod = typeof(LinqExtensions).GetMethods()
+                    .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 2);
+                return toListMethod?.MakeGenericMethod(entityType);
+            });
 
-        if (toListMethod == null) return [];
+        if (genericToListMethod == null) return [];
 
-        var genericToListMethod = toListMethod.MakeGenericMethod(entityType);
         var task = genericToListMethod.Invoke(null, [query, CancellationToken.None]) as Task;
 
         if (task == null) return [];
 
         await task;
 
-        var resultProperty = task.GetType().GetProperty("Result");
-        var result = resultProperty?.GetValue(task);
+        var result = task.GetCompletedTaskResult();
 
         if (result is System.Collections.IEnumerable enumerable)
         {
@@ -320,18 +338,21 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
     private Type? ResolveType(string clrType)
     {
-        // First try the standard Type.GetType which works for assembly-qualified names
-        var type = Type.GetType(clrType);
-        if (type != null) return type;
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"resolveType|{clrType}",
+            () =>
+            {
+                var type = Type.GetType(clrType);
+                if (type != null) return type;
 
-        // Search through all loaded assemblies
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            type = assembly.GetType(clrType);
-            if (type != null) return type;
-        }
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    type = assembly.GetType(clrType);
+                    if (type != null) return type;
+                }
 
-        return null;
+                return null;
+            });
     }
 
     /// <summary>
@@ -349,15 +370,19 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         // Query method signature: Query<T>(string indexName, string collectionName, bool isMapReduce)
         var sessionType = session.GetType();
-        var queryMethod = sessionType.GetMethods()
-            .FirstOrDefault(m => m.Name == "Query"
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 3);
+        var genericQueryMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"sessionQuery3|{sessionType.FullName ?? sessionType.Name}|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var queryMethod = sessionType.GetMethods()
+                    .FirstOrDefault(m => m.Name == "Query"
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 3);
+                return queryMethod?.MakeGenericMethod(entityType);
+            });
 
-        if (queryMethod == null)
+        if (genericQueryMethod == null)
             return [];
-
-        var genericQueryMethod = queryMethod.MakeGenericMethod(entityType);
 
         // Pass indexName if querying an index, null for collection query
         // RavenDB converts underscores to slashes in index names (e.g., "People_Overview" -> "People/Overview")
@@ -369,19 +394,23 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         // When querying an index, use ProjectInto<T>() to project from stored fields
         // This ensures computed/stored fields like FullName are populated from the index
-        // ProjectInto is an extension method on IQueryable (non-generic) in LinqExtensions
         if (!string.IsNullOrEmpty(indexName))
         {
-            var projectIntoMethod = typeof(LinqExtensions).GetMethods()
-                .FirstOrDefault(m => m.Name == "ProjectInto"
-                    && m.IsGenericMethod
-                    && m.GetGenericArguments().Length == 1
-                    && m.GetParameters().Length == 1
-                    && m.GetParameters()[0].ParameterType == typeof(IQueryable));
+            var genericProjectIntoMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+                $"linqProjectInto|{entityType.FullName ?? entityType.Name}",
+                () =>
+                {
+                    var projectIntoMethod = typeof(LinqExtensions).GetMethods()
+                        .FirstOrDefault(m => m.Name == "ProjectInto"
+                            && m.IsGenericMethod
+                            && m.GetGenericArguments().Length == 1
+                            && m.GetParameters().Length == 1
+                            && m.GetParameters()[0].ParameterType == typeof(IQueryable));
+                    return projectIntoMethod?.MakeGenericMethod(entityType);
+                });
 
-            if (projectIntoMethod != null)
+            if (genericProjectIntoMethod != null)
             {
-                var genericProjectIntoMethod = projectIntoMethod.MakeGenericMethod(entityType);
                 query = genericProjectIntoMethod.Invoke(null, [query])!;
             }
         }
@@ -393,15 +422,20 @@ internal partial class DatabaseAccess : IDatabaseAccess
         }
 
         // Call ToListAsync on the query
-        var toListMethod = typeof(LinqExtensions).GetMethods()
-            .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 2);
+        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var toListMethod = typeof(LinqExtensions).GetMethods()
+                    .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 2);
+                return toListMethod?.MakeGenericMethod(entityType);
+            });
 
-        if (toListMethod == null)
+        if (genericToListMethod == null)
             return [];
 
-        var genericToListMethod = toListMethod.MakeGenericMethod(entityType);
         var task = genericToListMethod.Invoke(null, [query, CancellationToken.None]) as Task;
 
         if (task == null)
@@ -409,8 +443,7 @@ internal partial class DatabaseAccess : IDatabaseAccess
 
         await task;
 
-        var resultProperty = task.GetType().GetProperty("Result");
-        var result = resultProperty?.GetValue(task);
+        var result = task.GetCompletedTaskResult();
 
         if (result is System.Collections.IEnumerable enumerable)
         {
@@ -425,10 +458,10 @@ internal partial class DatabaseAccess : IDatabaseAccess
     private async Task<object?> LoadEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onLoadMethod = actions.GetType().GetMethod("OnLoadAsync")!;
+        var onLoadMethod = GetCachedActionMethod(actions.GetType(), "OnLoadAsync");
         var task = (Task)onLoadMethod.Invoke(actions, [session, id])!;
         await task;
-        return task.GetType().GetProperty("Result")!.GetValue(task);
+        return task.GetCompletedTaskResult();
     }
 
     /// <summary>
@@ -438,21 +471,24 @@ internal partial class DatabaseAccess : IDatabaseAccess
     private async Task<bool> IsAllowedEntityViaActionsAsync(Type entityType, string action, object entity)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var method = actions.GetType().GetMethod("IsAllowedAsync", [typeof(string), entityType]);
+        var actionsType = actions.GetType();
+        var method = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"actionsMethod|{actionsType.FullName}|IsAllowedAsync|{entityType.FullName}",
+            () => actionsType.GetMethod("IsAllowedAsync", [typeof(string), entityType]));
         if (method is null)
             return true; // Unknown shape — fail open rather than dropping valid rows.
         var task = (Task)method.Invoke(actions, [action, entity])!;
         await task;
-        return (bool)task.GetType().GetProperty("Result")!.GetValue(task)!;
+        return (bool)task.GetCompletedTaskResult()!;
     }
 
     private async Task<IEnumerable<object>> QueryEntitiesViaActionsAsync(IAsyncDocumentSession session, Type entityType)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onQueryMethod = actions.GetType().GetMethod("OnQueryAsync")!;
+        var onQueryMethod = GetCachedActionMethod(actions.GetType(), "OnQueryAsync");
         var task = (Task)onQueryMethod.Invoke(actions, [session])!;
         await task;
-        var result = task.GetType().GetProperty("Result")!.GetValue(task);
+        var result = task.GetCompletedTaskResult();
 
         if (result is System.Collections.IEnumerable enumerable)
         {
@@ -465,19 +501,33 @@ internal partial class DatabaseAccess : IDatabaseAccess
     private async Task<object> SaveEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, PersistentObject obj)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onSaveMethod = actions.GetType().GetMethod("OnSaveAsync")!;
+        var onSaveMethod = GetCachedActionMethod(actions.GetType(), "OnSaveAsync");
         var task = (Task)onSaveMethod.Invoke(actions, [session, obj])!;
         await task;
-        return task.GetType().GetProperty("Result")!.GetValue(task)!;
+        return task.GetCompletedTaskResult()!;
     }
 
     private async Task DeleteEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onDeleteMethod = actions.GetType().GetMethod("OnDeleteAsync")!;
+        var onDeleteMethod = GetCachedActionMethod(actions.GetType(), "OnDeleteAsync");
         var task = (Task)onDeleteMethod.Invoke(actions, [session, id])!;
         await task;
     }
+
+    /// <summary>
+    /// Cached <c>actionsType.GetMethod(name)</c>. The actions-type+method-name pair is
+    /// stable for the AppDomain (an Actions class doesn't grow new methods at runtime),
+    /// so a single lookup per pair is sufficient. Throws if the named method is missing —
+    /// the action plumbing requires it, so a missing method is a programming error, not
+    /// a runtime condition we want to silently swallow.
+    /// </summary>
+    private static MethodInfo GetCachedActionMethod(Type actionsType, string methodName)
+        => ReflectionCache.GetOrAdd<MethodInfo>(
+            $"actionsMethod|{actionsType.FullName}|{methodName}",
+            () => actionsType.GetMethod(methodName)
+                ?? throw new InvalidOperationException(
+                    $"Actions type '{actionsType.FullName}' is missing required method '{methodName}'."));
 
     #endregion
 }

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents.Session;
 using System.Drawing;
 using System.Reflection;
@@ -178,8 +179,8 @@ internal partial class EntityMapper : IEntityMapper
     public void PopulateAttributeValues(PersistentObject po, object entity, Dictionary<string, object>? includedDocuments = null)
     {
         var entityType = entity.GetType();
-        var idProperty = entityType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        po.Id = idProperty?.GetValue(entity)?.ToString();
+        var idProperty = entityType.GetCachedProperty("Id");
+        po.Id = idProperty is not null ? AccessorCache.GetGetter(idProperty)(entity)?.ToString() : null;
 
         var entityTypeDef = modelLoader.GetEntityType(po.ObjectTypeId);
         var displayName = GetEntityDisplayName(entity, entityType, entityTypeDef);
@@ -194,11 +195,11 @@ internal partial class EntityMapper : IEntityMapper
             if (attribute.Name.Contains('.'))
                 continue;
 
-            var property = entityType.GetProperty(attribute.Name, BindingFlags.Public | BindingFlags.Instance);
+            var property = entityType.GetCachedProperty(attribute.Name);
             if (property is null || !property.CanRead)
                 continue; // silent skip — attribute may be projection-only
 
-            var raw = property.GetValue(entity);
+            var raw = AccessorCache.GetGetter(property)(entity);
 
             // AsDetail attributes carry full nested PersistentObject(s) instead of a scalar
             // Value; delegate to the recursive populator.
@@ -291,9 +292,14 @@ internal partial class EntityMapper : IEntityMapper
 
     /// <summary>
     /// Returns the element type for an array (<c>T[]</c>), a generic <see cref="IEnumerable{T}"/>,
-    /// or a <c>List&lt;T&gt;</c>. Returns <c>null</c> for non-collection types.
+    /// or a <c>List&lt;T&gt;</c>. Returns <c>null</c> for non-collection types. Cached per
+    /// <see cref="Type"/> via <see cref="ReflectionCache"/>; called per-AsDetail-property
+    /// per-row in the read path, so the cache hit matters.
     /// </summary>
     private static Type? GetCollectionElementType(Type propertyType)
+        => ReflectionCache.GetOrAdd<Type?>(propertyType, ResolveCollectionElementType);
+
+    private static Type? ResolveCollectionElementType(Type propertyType)
     {
         if (propertyType.IsArray)
             return propertyType.GetElementType();
@@ -438,7 +444,7 @@ internal partial class EntityMapper : IEntityMapper
             if (attribute.Name.Contains('.'))
                 continue;
 
-            var property = entityType.GetProperty(attribute.Name, BindingFlags.Public | BindingFlags.Instance);
+            var property = entityType.GetCachedProperty(attribute.Name);
             if (property is null || !property.CanWrite)
                 continue;
 
@@ -458,7 +464,7 @@ internal partial class EntityMapper : IEntityMapper
             if (attribute.Name.Contains('.'))
                 continue;
 
-            var property = entityType.GetProperty(attribute.Name, BindingFlags.Public | BindingFlags.Instance);
+            var property = entityType.GetCachedProperty(attribute.Name);
             if (property is null || !property.CanWrite)
                 continue;
 
@@ -473,7 +479,7 @@ internal partial class EntityMapper : IEntityMapper
     private void TryWriteId(Type entityType, object entity, string? id)
     {
         if (string.IsNullOrEmpty(id)) return;
-        var idProperty = entityType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+        var idProperty = entityType.GetCachedProperty("Id");
         if (idProperty is null || !idProperty.CanWrite) return;
         SetPropertyValue(idProperty, entity, id);
     }
@@ -511,20 +517,20 @@ internal partial class EntityMapper : IEntityMapper
             var refId = ExtractReferenceId(attribute.Value);
             if (string.IsNullOrEmpty(refId))
             {
-                property.SetValue(entity, null);
+                AccessorCache.GetSetter(property)(entity, null);
                 return;
             }
 
             if (includedDocuments is not null && includedDocuments.TryGetValue(refId, out var preloaded))
             {
-                property.SetValue(entity, preloaded);
+                AccessorCache.GetSetter(property)(entity, preloaded);
                 return;
             }
 
             if (session is not null)
             {
                 var loaded = await LoadReferenceAsync(session, targetType, refId, cancellationToken);
-                property.SetValue(entity, loaded);
+                AccessorCache.GetSetter(property)(entity, loaded);
                 return;
             }
 
@@ -572,13 +578,13 @@ internal partial class EntityMapper : IEntityMapper
                 await PopulateObjectValuesAsync(childPo, childEntity, session, cancellationToken);
                 items.Add(childEntity);
             }
-            property.SetValue(entity, BuildCollection(items, propertyType, elementType));
+            AccessorCache.GetSetter(property)(entity, BuildCollection(items, propertyType, elementType));
             return;
         }
 
         if (attr.Object is null)
         {
-            property.SetValue(entity, null);
+            AccessorCache.GetSetter(property)(entity, null);
             return;
         }
 
@@ -587,7 +593,7 @@ internal partial class EntityMapper : IEntityMapper
             ?? throw new InvalidOperationException(
                 $"PopulateObjectValues: could not instantiate AsDetail type '{targetType.FullName}' for attribute '{attr.Name}'.");
         await PopulateObjectValuesAsync(attr.Object, child, session, cancellationToken);
-        property.SetValue(entity, child);
+        AccessorCache.GetSetter(property)(entity, child);
     }
 
     /// <summary>
@@ -620,14 +626,14 @@ internal partial class EntityMapper : IEntityMapper
         if (incoming is null)
         {
             // Explicit null / empty incoming clears the property — matches "write null to erase".
-            property.SetValue(entity, null);
+            AccessorCache.GetSetter(property)(entity, null);
             return;
         }
 
-        var existing = property.GetValue(entity) as TranslatedString;
+        var existing = AccessorCache.GetGetter(property)(entity) as TranslatedString;
         if (existing is null)
         {
-            property.SetValue(entity, incoming);
+            AccessorCache.GetSetter(property)(entity, incoming);
             return;
         }
 
@@ -716,19 +722,26 @@ internal partial class EntityMapper : IEntityMapper
     private static async Task<object?> LoadReferenceAsync(IAsyncDocumentSession session,
         Type targetType, string refId, CancellationToken cancellationToken)
     {
-        var method = typeof(IAsyncDocumentSession).GetMethod(
-            nameof(IAsyncDocumentSession.LoadAsync),
-            [typeof(string), typeof(CancellationToken)])
-            ?? throw new InvalidOperationException("Could not resolve IAsyncDocumentSession.LoadAsync<T>(string, CancellationToken).");
-        var generic = method.MakeGenericMethod(targetType);
+        var generic = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"sessionLoadAsync|{targetType.FullName ?? targetType.Name}",
+            () =>
+            {
+                var method = typeof(IAsyncDocumentSession).GetMethod(
+                    nameof(IAsyncDocumentSession.LoadAsync),
+                    [typeof(string), typeof(CancellationToken)])
+                    ?? throw new InvalidOperationException("Could not resolve IAsyncDocumentSession.LoadAsync<T>(string, CancellationToken).");
+                return method.MakeGenericMethod(targetType);
+            });
         var task = (Task)generic.Invoke(session, [refId, cancellationToken])!;
         await task.ConfigureAwait(false);
-        return task.GetType().GetProperty("Result")?.GetValue(task);
+        var resultProp = task.GetType().GetCachedProperty("Result");
+        return resultProp is not null ? AccessorCache.GetGetter(resultProp)(task) : null;
     }
 
     private void SetPropertyValue(PropertyInfo property, object entity, object? value)
     {
         var targetType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        var setter = AccessorCache.GetSetter(property);
 
         // Handle JsonElement - either extract simple value or deserialize complex types
         if (value is JsonElement je)
@@ -739,7 +752,7 @@ internal partial class EntityMapper : IEntityMapper
                 try
                 {
                     var deserializedValue = je.Deserialize(targetType, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    property.SetValue(entity, deserializedValue);
+                    setter(entity, deserializedValue);
                 }
                 catch
                 {
@@ -753,7 +766,7 @@ internal partial class EntityMapper : IEntityMapper
                 try
                 {
                     var deserializedValue = je.Deserialize(targetType, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    property.SetValue(entity, deserializedValue);
+                    setter(entity, deserializedValue);
                 }
                 catch
                 {
@@ -771,7 +784,7 @@ internal partial class EntityMapper : IEntityMapper
         {
             if (Nullable.GetUnderlyingType(property.PropertyType) != null || !property.PropertyType.IsValueType)
             {
-                property.SetValue(entity, null);
+                setter(entity, null);
             }
             return;
         }
@@ -809,7 +822,7 @@ internal partial class EntityMapper : IEntityMapper
                 convertedValue = Convert.ChangeType(value, targetType);
             }
 
-            property.SetValue(entity, convertedValue);
+            setter(entity, convertedValue);
         }
         catch
         {
@@ -859,8 +872,7 @@ internal partial class EntityMapper : IEntityMapper
             return false;
 
         // Check if it's a class with public properties
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        return properties.Length > 0;
+        return type.GetCachedProperties().Length > 0;
     }
 
     private string GetEntityDisplayName(object entity, Type entityType, EntityTypeDefinition? entityTypeDef = null)
@@ -880,10 +892,10 @@ internal partial class EntityMapper : IEntityMapper
         // 2. Try DisplayAttribute (single property name)
         if (!string.IsNullOrEmpty(entityTypeDef?.DisplayAttribute))
         {
-            var displayProperty = entityType.GetProperty(entityTypeDef.DisplayAttribute, BindingFlags.Public | BindingFlags.Instance);
-            if (displayProperty != null)
+            var displayProperty = entityType.GetCachedProperty(entityTypeDef.DisplayAttribute);
+            if (displayProperty is not null && displayProperty.CanRead)
             {
-                var value = displayProperty.GetValue(entity);
+                var value = AccessorCache.GetGetter(displayProperty)(entity);
                 if (value != null)
                 {
                     return value.ToString() ?? entityType.Name;
@@ -892,24 +904,27 @@ internal partial class EntityMapper : IEntityMapper
         }
 
         // 3. Fallback to common display name properties
-        var nameProperty = entityType.GetProperty("Name")
-            ?? entityType.GetProperty("FullName")
-            ?? entityType.GetProperty("Title");
+        var nameProperty = entityType.GetCachedProperty("Name")
+            ?? entityType.GetCachedProperty("FullName")
+            ?? entityType.GetCachedProperty("Title");
 
-        return nameProperty?.GetValue(entity)?.ToString() ?? entityType.Name;
+        if (nameProperty is null || !nameProperty.CanRead)
+            return entityType.Name;
+
+        return AccessorCache.GetGetter(nameProperty)(entity)?.ToString() ?? entityType.Name;
     }
 
     private static string ResolveDisplayFormat(object entity, Type entityType, string displayFormat)
     {
         var result = displayFormat;
-        var properties = entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var properties = entityType.GetCachedProperties();
 
         foreach (var property in properties)
         {
             var placeholder = $"{{{property.Name}}}";
-            if (result.Contains(placeholder))
+            if (result.Contains(placeholder) && property.CanRead)
             {
-                var value = property.GetValue(entity)?.ToString() ?? string.Empty;
+                var value = AccessorCache.GetGetter(property)(entity)?.ToString() ?? string.Empty;
                 result = result.Replace(placeholder, value);
             }
         }
@@ -919,17 +934,23 @@ internal partial class EntityMapper : IEntityMapper
 
     private Type? ResolveType(string clrType)
     {
-        // First try the standard Type.GetType which works for assembly-qualified names
-        var type = Type.GetType(clrType);
-        if (type != null) return type;
+        // Cache positive and negative resolutions: assembly walks are expensive and the
+        // same CLR type names are looked up repeatedly across requests. ReflectionCache
+        // memoizes null results too — so unresolvable names don't re-walk every time.
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"resolveType|{clrType}",
+            () =>
+            {
+                var type = Type.GetType(clrType);
+                if (type != null) return type;
 
-        // Search through all loaded assemblies
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            type = assembly.GetType(clrType);
-            if (type != null) return type;
-        }
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    type = assembly.GetType(clrType);
+                    if (type != null) return type;
+                }
 
-        return null;
+                return null;
+            });
     }
 }

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -878,22 +878,24 @@ internal partial class EntityMapper : IEntityMapper
     private string GetEntityDisplayName(object entity, Type entityType, EntityTypeDefinition? entityTypeDef = null)
     {
         // If no entity type definition provided, try to find it
-        if (entityTypeDef == null)
-        {
-            entityTypeDef = modelLoader.GetEntityTypeByClrType(entityType.FullName ?? entityType.Name);
-        }
+        entityTypeDef ??= modelLoader.GetEntityTypeByClrType(entityType.FullName ?? entityType.Name);
 
-        // 1. Try DisplayFormat (template with {PropertyName} placeholders)
+        // 1. DisplayFormat (template with {PropertyName} placeholders)
         if (!string.IsNullOrEmpty(entityTypeDef?.DisplayFormat))
         {
             return ResolveDisplayFormat(entity, entityType, entityTypeDef.DisplayFormat);
         }
 
-        // 2. Try DisplayAttribute (single property name)
+        // 2. DisplayAttribute (single property name). ModelSynchronizer auto-populates
+        // DisplayAttribute to "Name"/"FullName"/"Title" (or the first attribute) when
+        // synthesizing an EntityTypeDefinition, so there's no separate runtime fallback —
+        // any entity that went through the synchronizer already has DisplayAttribute set;
+        // entities without a definition (projection/anonymous types) fall through to the
+        // CLR type name below.
         if (!string.IsNullOrEmpty(entityTypeDef?.DisplayAttribute))
         {
             var displayProperty = entityType.GetCachedProperty(entityTypeDef.DisplayAttribute);
-            if (displayProperty is not null && displayProperty.CanRead)
+            if (displayProperty is not null)
             {
                 var value = AccessorCache.GetGetter(displayProperty)(entity);
                 if (value != null)
@@ -903,15 +905,7 @@ internal partial class EntityMapper : IEntityMapper
             }
         }
 
-        // 3. Fallback to common display name properties
-        var nameProperty = entityType.GetCachedProperty("Name")
-            ?? entityType.GetCachedProperty("FullName")
-            ?? entityType.GetCachedProperty("Title");
-
-        if (nameProperty is null || !nameProperty.CanRead)
-            return entityType.Name;
-
-        return AccessorCache.GetGetter(nameProperty)(entity)?.ToString() ?? entityType.Name;
+        return entityType.Name;
     }
 
     private static string ResolveDisplayFormat(object entity, Type entityType, string displayFormat)
@@ -922,7 +916,7 @@ internal partial class EntityMapper : IEntityMapper
         foreach (var property in properties)
         {
             var placeholder = $"{{{property.Name}}}";
-            if (result.Contains(placeholder) && property.CanRead)
+            if (result.Contains(placeholder))
             {
                 var value = AccessorCache.GetGetter(property)(entity)?.ToString() ?? string.Empty;
                 result = result.Replace(placeholder, value);

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -723,7 +723,7 @@ internal partial class EntityMapper : IEntityMapper
         Type targetType, string refId, CancellationToken cancellationToken)
     {
         var generic = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionLoadAsync|{targetType.FullName ?? targetType.Name}",
+            $"sessionLoadAsync|{targetType.GetCacheKeyName()}",
             () =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(

--- a/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/MintPlayer.Spark/Services/EntityMapper.cs
@@ -297,7 +297,9 @@ internal partial class EntityMapper : IEntityMapper
     /// per-row in the read path, so the cache hit matters.
     /// </summary>
     private static Type? GetCollectionElementType(Type propertyType)
-        => ReflectionCache.GetOrAdd<Type?>(propertyType, ResolveCollectionElementType);
+        => ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("EntityMapper.CollectionElement", propertyType),
+            static k => ResolveCollectionElementType(k.Type));
 
     private static Type? ResolveCollectionElementType(Type propertyType)
     {
@@ -722,15 +724,15 @@ internal partial class EntityMapper : IEntityMapper
     private static async Task<object?> LoadReferenceAsync(IAsyncDocumentSession session,
         Type targetType, string refId, CancellationToken cancellationToken)
     {
-        var generic = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionLoadAsync|{targetType.GetCacheKeyName()}",
-            () =>
+        var generic = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo>(
+            ("EntityMapper.SessionLoadAsync", targetType),
+            static k =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(
                     nameof(IAsyncDocumentSession.LoadAsync),
                     [typeof(string), typeof(CancellationToken)])
                     ?? throw new InvalidOperationException("Could not resolve IAsyncDocumentSession.LoadAsync<T>(string, CancellationToken).");
-                return method.MakeGenericMethod(targetType);
+                return method.MakeGenericMethod(k.Type);
             });
         var task = (Task)generic.Invoke(session, [refId, cancellationToken])!;
         await task.ConfigureAwait(false);

--- a/MintPlayer.Spark/Services/IndexRegistry.cs
+++ b/MintPlayer.Spark/Services/IndexRegistry.cs
@@ -1,4 +1,5 @@
 using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents.Indexes;
 
 namespace MintPlayer.Spark.Services;
@@ -142,21 +143,26 @@ internal partial class IndexRegistry : IIndexRegistry
 
     private static Type? GetCollectionTypeFromIndex(Type indexType)
     {
-        var current = indexType;
-        while (current != null && current != typeof(object))
-        {
-            if (current.IsGenericType)
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"indexCollectionType|{indexType.FullName ?? indexType.Name}",
+            () =>
             {
-                var genericDef = current.GetGenericTypeDefinition();
-                if (genericDef == typeof(AbstractIndexCreationTask<>) ||
-                    genericDef == typeof(AbstractMultiMapIndexCreationTask<>))
+                var current = indexType;
+                while (current != null && current != typeof(object))
                 {
-                    return current.GetGenericArguments()[0];
+                    if (current.IsGenericType)
+                    {
+                        var genericDef = current.GetGenericTypeDefinition();
+                        if (genericDef == typeof(AbstractIndexCreationTask<>) ||
+                            genericDef == typeof(AbstractMultiMapIndexCreationTask<>))
+                        {
+                            return current.GetGenericArguments()[0];
+                        }
+                    }
+                    current = current.BaseType;
                 }
-            }
-            current = current.BaseType;
-        }
-        return null;
+                return null;
+            });
     }
 
     private static string GetIndexName(Type indexType)

--- a/MintPlayer.Spark/Services/IndexRegistry.cs
+++ b/MintPlayer.Spark/Services/IndexRegistry.cs
@@ -144,7 +144,7 @@ internal partial class IndexRegistry : IIndexRegistry
     private static Type? GetCollectionTypeFromIndex(Type indexType)
     {
         return ReflectionCache.GetOrAdd<Type?>(
-            $"indexCollectionType|{indexType.FullName ?? indexType.Name}",
+            $"indexCollectionType|{indexType.GetCacheKeyName()}",
             () =>
             {
                 var current = indexType;

--- a/MintPlayer.Spark/Services/IndexRegistry.cs
+++ b/MintPlayer.Spark/Services/IndexRegistry.cs
@@ -143,11 +143,11 @@ internal partial class IndexRegistry : IIndexRegistry
 
     private static Type? GetCollectionTypeFromIndex(Type indexType)
     {
-        return ReflectionCache.GetOrAdd<Type?>(
-            $"indexCollectionType|{indexType.GetCacheKeyName()}",
-            () =>
+        return ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("IndexRegistry.IndexCollectionType", indexType),
+            static k =>
             {
-                var current = indexType;
+                var current = k.Type;
                 while (current != null && current != typeof(object))
                 {
                     if (current.IsGenericType)

--- a/MintPlayer.Spark/Services/LookupReferenceDiscoveryService.cs
+++ b/MintPlayer.Spark/Services/LookupReferenceDiscoveryService.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using System.Reflection;
 
 namespace MintPlayer.Spark.Services;
@@ -91,7 +92,9 @@ internal partial class LookupReferenceDiscoveryService : ILookupReferenceDiscove
         // For TransientLookupReference: get DisplayType from one of the Items
         if (typeof(TransientLookupReference).IsAssignableFrom(type))
         {
-            var itemsProp = type.GetProperty("Items", BindingFlags.Public | BindingFlags.Static);
+            var itemsProp = ReflectionCache.GetOrAdd<PropertyInfo?>(
+                $"staticProp|{type.FullName}|Items",
+                () => type.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
             if (itemsProp != null)
             {
                 var items = itemsProp.GetValue(null);
@@ -115,10 +118,10 @@ internal partial class LookupReferenceDiscoveryService : ILookupReferenceDiscove
                 var instance = Activator.CreateInstance(type);
                 if (instance != null)
                 {
-                    var prop = type.GetProperty("DisplayType", BindingFlags.Public | BindingFlags.Instance);
-                    if (prop != null)
+                    var prop = type.GetCachedProperty("DisplayType");
+                    if (prop is not null && prop.CanRead)
                     {
-                        var value = prop.GetValue(instance);
+                        var value = AccessorCache.GetGetter(prop)(instance);
                         if (value is ELookupDisplayType displayType)
                             return displayType;
                     }

--- a/MintPlayer.Spark/Services/LookupReferenceDiscoveryService.cs
+++ b/MintPlayer.Spark/Services/LookupReferenceDiscoveryService.cs
@@ -92,9 +92,9 @@ internal partial class LookupReferenceDiscoveryService : ILookupReferenceDiscove
         // For TransientLookupReference: get DisplayType from one of the Items
         if (typeof(TransientLookupReference).IsAssignableFrom(type))
         {
-            var itemsProp = ReflectionCache.GetOrAdd<PropertyInfo?>(
-                $"staticProp|{type.FullName}|Items",
-                () => type.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
+            var itemsProp = ReflectionCache.GetOrAdd<(string Op, Type Type), PropertyInfo?>(
+                ("LookupReferenceDiscoveryService.StaticItems", type),
+                static k => k.Type.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
             if (itemsProp != null)
             {
                 var items = itemsProp.GetValue(null);

--- a/MintPlayer.Spark/Services/LookupReferenceService.cs
+++ b/MintPlayer.Spark/Services/LookupReferenceService.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents;
 using System.Reflection;
 
@@ -227,8 +228,11 @@ internal partial class LookupReferenceService : ILookupReferenceService
 
     private System.Collections.IList? GetTransientItems(Type transientType)
     {
-        // Look for static Items property
-        var itemsProperty = transientType.GetProperty("Items", BindingFlags.Public | BindingFlags.Static);
+        // Static "Items" property — cached once per transient type. Static binding flags
+        // require a separate cache key (the GetCachedProperty helper scopes to Public+Instance).
+        var itemsProperty = ReflectionCache.GetOrAdd<PropertyInfo?>(
+            $"staticProp|{transientType.FullName}|Items",
+            () => transientType.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
         if (itemsProperty == null) return null;
 
         var value = itemsProperty.GetValue(null);
@@ -248,8 +252,8 @@ internal partial class LookupReferenceService : ILookupReferenceService
             return null;
 
         // Get the Key value via reflection (could be string, enum, or other TKey type)
-        var keyProp = transientItem.GetType().GetProperty("Key");
-        var keyValue = keyProp?.GetValue(transientItem);
+        var keyProp = transientItem.GetType().GetCachedProperty("Key");
+        var keyValue = keyProp is not null && keyProp.CanRead ? AccessorCache.GetGetter(keyProp)(transientItem) : null;
         var key = keyValue?.ToString() ?? string.Empty;
 
         // Get extra properties (properties beyond Key, Description, Values, DisplayType)
@@ -257,11 +261,11 @@ internal partial class LookupReferenceService : ILookupReferenceService
         var itemType = transientItem.GetType();
         var baseProps = new HashSet<string> { "Key", "Description", "Values", "DisplayType" };
 
-        foreach (var prop in itemType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach (var prop in itemType.GetCachedProperties())
         {
             if (!baseProps.Contains(prop.Name))
             {
-                var value = prop.GetValue(transientItem);
+                var value = prop.CanRead ? AccessorCache.GetGetter(prop)(transientItem) : null;
                 if (value != null)
                 {
                     extraProps[ToCamelCase(prop.Name)] = value;

--- a/MintPlayer.Spark/Services/LookupReferenceService.cs
+++ b/MintPlayer.Spark/Services/LookupReferenceService.cs
@@ -230,9 +230,9 @@ internal partial class LookupReferenceService : ILookupReferenceService
     {
         // Static "Items" property — cached once per transient type. Static binding flags
         // require a separate cache key (the GetCachedProperty helper scopes to Public+Instance).
-        var itemsProperty = ReflectionCache.GetOrAdd<PropertyInfo?>(
-            $"staticProp|{transientType.FullName}|Items",
-            () => transientType.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
+        var itemsProperty = ReflectionCache.GetOrAdd<(string Op, Type Type), PropertyInfo?>(
+            ("LookupReferenceService.StaticItems", transientType),
+            static k => k.Type.GetProperty("Items", BindingFlags.Public | BindingFlags.Static));
         if (itemsProperty == null) return null;
 
         var value = itemsProperty.GetValue(null);

--- a/MintPlayer.Spark/Services/ModelSynchronizer.cs
+++ b/MintPlayer.Spark/Services/ModelSynchronizer.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents.Linq;
 using System.Reflection;
 using System.Text.Encodings.Web;
@@ -39,7 +40,7 @@ internal partial class ModelSynchronizer : IModelSynchronizer
         var (existingEntityTypes, existingQueries) = LoadExistingEntityTypeFiles(modelPath);
 
         // Find all IRavenQueryable<T> properties on the SparkContext
-        var queryableProperties = contextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        var queryableProperties = contextType.GetCachedProperties()
             .Where(p => IsRavenQueryable(p.PropertyType))
             .ToList();
 
@@ -186,7 +187,7 @@ internal partial class ModelSynchronizer : IModelSynchronizer
 
     private void CollectEmbeddedTypes(Type entityType, Queue<Type> typesToProcess, HashSet<string> processedTypes)
     {
-        var properties = entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        var properties = entityType.GetCachedProperties()
             .Where(p => p.Name != "Id" && p.CanRead && p.CanWrite);
 
         foreach (var property in properties)
@@ -278,12 +279,12 @@ internal partial class ModelSynchronizer : IModelSynchronizer
         var existingAttrs = entityTypeDef.Attributes.ToDictionary(a => a.Name, a => a);
 
         // Get properties from collection type
-        var collectionProperties = entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        var collectionProperties = entityType.GetCachedProperties()
             .Where(p => p.Name != "Id" && p.CanRead && p.CanWrite)
             .ToDictionary(p => p.Name, p => p);
 
         // Get properties from projection type (if any)
-        var projectionProperties = projectionType?.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        var projectionProperties = projectionType?.GetCachedProperties()
             .Where(p => p.Name != "Id" && p.CanRead && p.CanWrite)
             .ToDictionary(p => p.Name, p => p)
             ?? new Dictionary<string, PropertyInfo>();
@@ -321,8 +322,8 @@ internal partial class ModelSynchronizer : IModelSynchronizer
                 }
             }
 
-            var referenceAttr = property.GetCustomAttribute<ReferenceAttribute>();
-            var lookupRefAttr = property.GetCustomAttribute<LookupReferenceAttribute>();
+            var referenceAttr = property.GetCachedCustomAttribute<ReferenceAttribute>();
+            var lookupRefAttr = property.GetCachedCustomAttribute<LookupReferenceAttribute>();
             var propType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
             var dataType = referenceAttr != null ? "Reference" : GetDataType(property.PropertyType);
             string? referenceType = referenceAttr?.TargetType.FullName ?? referenceAttr?.TargetType.Name;
@@ -515,6 +516,11 @@ internal partial class ModelSynchronizer : IModelSynchronizer
     /// Returns null if the type is not a collection.
     /// </summary>
     private static Type? GetCollectionElementType(Type type)
+        => ReflectionCache.GetOrAdd<Type?>(
+            $"modelSync.collElem|{type.FullName ?? type.Name}",
+            () => ResolveCollectionElementType(type));
+
+    private static Type? ResolveCollectionElementType(Type type)
     {
         // Handle arrays: T[]
         if (type.IsArray)
@@ -561,8 +567,7 @@ internal partial class ModelSynchronizer : IModelSynchronizer
             return false;
 
         // Check if it's a class with public properties
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        return properties.Length > 0;
+        return type.GetCachedProperties().Length > 0;
     }
 
     private bool IsNullable(Type type)

--- a/MintPlayer.Spark/Services/ModelSynchronizer.cs
+++ b/MintPlayer.Spark/Services/ModelSynchronizer.cs
@@ -516,9 +516,9 @@ internal partial class ModelSynchronizer : IModelSynchronizer
     /// Returns null if the type is not a collection.
     /// </summary>
     private static Type? GetCollectionElementType(Type type)
-        => ReflectionCache.GetOrAdd<Type?>(
-            $"modelSync.collElem|{type.GetCacheKeyName()}",
-            () => ResolveCollectionElementType(type));
+        => ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("ModelSynchronizer.CollectionElement", type),
+            static k => ResolveCollectionElementType(k.Type));
 
     private static Type? ResolveCollectionElementType(Type type)
     {

--- a/MintPlayer.Spark/Services/ModelSynchronizer.cs
+++ b/MintPlayer.Spark/Services/ModelSynchronizer.cs
@@ -517,7 +517,7 @@ internal partial class ModelSynchronizer : IModelSynchronizer
     /// </summary>
     private static Type? GetCollectionElementType(Type type)
         => ReflectionCache.GetOrAdd<Type?>(
-            $"modelSync.collElem|{type.FullName ?? type.Name}",
+            $"modelSync.collElem|{type.GetCacheKeyName()}",
             () => ResolveCollectionElementType(type));
 
     private static Type? ResolveCollectionElementType(Type type)

--- a/MintPlayer.Spark/Services/QueryExecutor.cs
+++ b/MintPlayer.Spark/Services/QueryExecutor.cs
@@ -363,7 +363,7 @@ internal partial class QueryExecutor : IQueryExecutor
     private static Type? ExtractQueryableElementType(Type type)
     {
         return ReflectionCache.GetOrAdd<Type?>(
-            $"queryableElement|{type.FullName ?? type.Name}",
+            $"queryableElement|{type.GetCacheKeyName()}",
             () =>
             {
                 // Check if the type itself is IQueryable<T>
@@ -400,7 +400,7 @@ internal partial class QueryExecutor : IQueryExecutor
     {
         // Call Queryable.ToList() on an in-memory IQueryable<T>
         var toListMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"enumerableToList|{elementType.FullName ?? elementType.Name}",
+            $"enumerableToList|{elementType.GetCacheKeyName()}",
             () => typeof(Enumerable).GetMethods()
                 .First(m => m.Name == nameof(Enumerable.ToList) && m.GetGenericArguments().Length == 1)
                 .MakeGenericMethod(elementType));
@@ -451,7 +451,7 @@ internal partial class QueryExecutor : IQueryExecutor
     private object ApplyIndexWithType(IAsyncDocumentSession session, Type resultType, Type indexType)
     {
         var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionQueryByIndexCreator|{resultType.FullName ?? resultType.Name}|{indexType.FullName ?? indexType.Name}",
+            $"sessionQueryByIndexCreator|{resultType.GetCacheKeyName()}|{indexType.GetCacheKeyName()}",
             () =>
             {
                 var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
@@ -476,7 +476,7 @@ internal partial class QueryExecutor : IQueryExecutor
     private object ApplyIndexByName(IAsyncDocumentSession session, Type entityType, string indexName)
     {
         var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionQueryByIndexName|{entityType.FullName ?? entityType.Name}",
+            $"sessionQueryByIndexName|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
@@ -503,7 +503,7 @@ internal partial class QueryExecutor : IQueryExecutor
     private object ApplyProjection(object queryable, Type resultType)
     {
         var genericProjectMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqProjectInto|{resultType.FullName ?? resultType.Name}",
+            $"linqProjectInto|{resultType.GetCacheKeyName()}",
             () =>
             {
                 var projectIntoMethod = typeof(LinqExtensions).GetMethods()
@@ -548,7 +548,7 @@ internal partial class QueryExecutor : IQueryExecutor
             var lambda = System.Linq.Expressions.Expression.Lambda(propertyAccess, parameter);
 
             var orderMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-                $"queryableOrder|{methodName}|{entityType.FullName ?? entityType.Name}|{propertyInfo.PropertyType.FullName ?? propertyInfo.PropertyType.Name}",
+                $"queryableOrder|{methodName}|{entityType.GetCacheKeyName()}|{propertyInfo.PropertyType.GetCacheKeyName()}",
                 () => typeof(Queryable).GetMethods()
                     .First(m => m.Name == methodName && m.GetParameters().Length == 2)
                     .MakeGenericMethod(entityType, propertyInfo.PropertyType));
@@ -567,7 +567,7 @@ internal partial class QueryExecutor : IQueryExecutor
     private async Task<IEnumerable<object>> ExecuteQueryableAsync(object queryable, Type entityType)
     {
         var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
+            $"linqToListAsync|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var toListMethod = typeof(LinqExtensions).GetMethods()

--- a/MintPlayer.Spark/Services/QueryExecutor.cs
+++ b/MintPlayer.Spark/Services/QueryExecutor.cs
@@ -1,11 +1,11 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Queries;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
-using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace MintPlayer.Spark.Services;
@@ -26,8 +26,6 @@ internal partial class QueryExecutor : IQueryExecutor
     [Inject] private readonly IPermissionService permissionService;
     [Inject] private readonly IActionsResolver actionsResolver;
     [Inject] private readonly IReferenceResolver referenceResolver;
-
-    private static readonly ConcurrentDictionary<string, CustomQueryMethodInfo?> customQueryMethodCache = new();
 
     public async Task<QueryResult> ExecuteQueryAsync(SparkQuery query, PersistentObject? parent = null, int skip = 0, int take = 50, string? search = null)
     {
@@ -98,14 +96,14 @@ internal partial class QueryExecutor : IQueryExecutor
         }
 
         var contextType = sparkContext.GetType();
-        var property = contextType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        var property = contextType.GetCachedProperty(propertyName);
 
-        if (property == null)
+        if (property == null || !property.CanRead)
         {
             return [];
         }
 
-        var queryable = property.GetValue(sparkContext);
+        var queryable = AccessorCache.GetGetter(property)(sparkContext);
         if (queryable == null)
         {
             return [];
@@ -308,8 +306,9 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private static CustomQueryMethodInfo? ResolveCustomQueryMethod(Type actionsType, string methodName)
     {
-        var cacheKey = $"{actionsType.FullName};{methodName}";
-        return customQueryMethodCache.GetOrAdd(cacheKey, _ =>
+        return ReflectionCache.GetOrAdd<CustomQueryMethodInfo?>(
+            $"customQueryMethod|{actionsType.FullName};{methodName}",
+            () =>
         {
             var method = actionsType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
             if (method == null)
@@ -363,41 +362,48 @@ internal partial class QueryExecutor : IQueryExecutor
 
     private static Type? ExtractQueryableElementType(Type type)
     {
-        // Check if the type itself is IQueryable<T>
-        if (type.IsGenericType)
-        {
-            var genericDef = type.GetGenericTypeDefinition();
-            if (genericDef == typeof(IQueryable<>) || genericDef == typeof(IEnumerable<>))
-                return type.GetGenericArguments()[0];
-        }
-
-        // Check implemented interfaces for IQueryable<T>
-        foreach (var iface in type.GetInterfaces())
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IQueryable<>))
-                return iface.GetGenericArguments()[0];
-        }
-
-        // Check for IEnumerable<T> as fallback
-        foreach (var iface in type.GetInterfaces())
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"queryableElement|{type.FullName ?? type.Name}",
+            () =>
             {
-                var elementType = iface.GetGenericArguments()[0];
-                if (elementType != typeof(object))
-                    return elementType;
-            }
-        }
+                // Check if the type itself is IQueryable<T>
+                if (type.IsGenericType)
+                {
+                    var genericDef = type.GetGenericTypeDefinition();
+                    if (genericDef == typeof(IQueryable<>) || genericDef == typeof(IEnumerable<>))
+                        return type.GetGenericArguments()[0];
+                }
 
-        return null;
+                // Check implemented interfaces for IQueryable<T>
+                foreach (var iface in type.GetInterfaces())
+                {
+                    if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IQueryable<>))
+                        return iface.GetGenericArguments()[0];
+                }
+
+                // Check for IEnumerable<T> as fallback
+                foreach (var iface in type.GetInterfaces())
+                {
+                    if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    {
+                        var elementType = iface.GetGenericArguments()[0];
+                        if (elementType != typeof(object))
+                            return elementType;
+                    }
+                }
+
+                return null;
+            });
     }
 
     private static IEnumerable<object> MaterializeQueryable(object queryable, Type elementType)
     {
         // Call Queryable.ToList() on an in-memory IQueryable<T>
-        var toListMethod = typeof(Enumerable).GetMethods()
-            .First(m => m.Name == nameof(Enumerable.ToList) && m.GetGenericArguments().Length == 1)
-            .MakeGenericMethod(elementType);
+        var toListMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"enumerableToList|{elementType.FullName ?? elementType.Name}",
+            () => typeof(Enumerable).GetMethods()
+                .First(m => m.Name == nameof(Enumerable.ToList) && m.GetGenericArguments().Length == 1)
+                .MakeGenericMethod(elementType));
 
         var result = toListMethod.Invoke(null, [queryable]);
         if (result is System.Collections.IEnumerable enumerable)
@@ -409,20 +415,25 @@ internal partial class QueryExecutor : IQueryExecutor
 
     private static Type? FindClrType(string clrTypeName)
     {
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            try
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"clrType|{clrTypeName}",
+            () =>
             {
-                var type = assembly.GetTypes()
-                    .FirstOrDefault(t => (t.FullName == clrTypeName || t.Name == clrTypeName) && !t.IsAbstract && !t.IsInterface);
-                if (type != null) return type;
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                continue;
-            }
-        }
-        return null;
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    try
+                    {
+                        var type = assembly.GetTypes()
+                            .FirstOrDefault(t => (t.FullName == clrTypeName || t.Name == clrTypeName) && !t.IsAbstract && !t.IsInterface);
+                        if (type != null) return type;
+                    }
+                    catch (ReflectionTypeLoadException)
+                    {
+                        continue;
+                    }
+                }
+                return null;
+            });
     }
 
     #endregion

--- a/MintPlayer.Spark/Services/QueryExecutor.cs
+++ b/MintPlayer.Spark/Services/QueryExecutor.cs
@@ -235,7 +235,7 @@ internal partial class QueryExecutor : IQueryExecutor
         if (methodInfo.IsAsync && result is Task task)
         {
             await task;
-            result = task.GetType().GetProperty("Result")?.GetValue(task);
+            result = task.GetCompletedTaskResult();
         }
 
         if (result == null)
@@ -450,15 +450,18 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <exception cref="InvalidOperationException">Thrown when the required generic Query&lt;T, TIndexCreator&gt; method cannot be found on the session.</exception>
     private object ApplyIndexWithType(IAsyncDocumentSession session, Type resultType, Type indexType)
     {
-        var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
-            .FirstOrDefault(m => m.Name == "Query"
-                && m.IsGenericMethod
-                && m.GetGenericArguments().Length == 2
-                && m.GetParameters().Length == 0)
-
-            ?? throw new InvalidOperationException("Could not find Query<T, TIndexCreator> method on IAsyncDocumentSession");
-
-        var genericMethod = sessionQueryMethod.MakeGenericMethod(resultType, indexType);
+        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"sessionQueryByIndexCreator|{resultType.FullName ?? resultType.Name}|{indexType.FullName ?? indexType.Name}",
+            () =>
+            {
+                var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
+                    .FirstOrDefault(m => m.Name == "Query"
+                        && m.IsGenericMethod
+                        && m.GetGenericArguments().Length == 2
+                        && m.GetParameters().Length == 0)
+                    ?? throw new InvalidOperationException("Could not find Query<T, TIndexCreator> method on IAsyncDocumentSession");
+                return sessionQueryMethod.MakeGenericMethod(resultType, indexType);
+            });
         return genericMethod.Invoke(session, [])!;
     }
 
@@ -472,18 +475,21 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <exception cref="InvalidOperationException"></exception>
     private object ApplyIndexByName(IAsyncDocumentSession session, Type entityType, string indexName)
     {
-        var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
-            .FirstOrDefault(m => m.Name == "Query"
-                && m.IsGenericMethod
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 3
-                && m.GetParameters()[0].ParameterType == typeof(string)
-                && m.GetParameters()[1].ParameterType == typeof(string)
-                && m.GetParameters()[2].ParameterType == typeof(bool))
-            
-            ?? throw new InvalidOperationException("Could not find Query<T>(string, string, bool) method on IAsyncDocumentSession");
-
-        var genericMethod = sessionQueryMethod.MakeGenericMethod(entityType);
+        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"sessionQueryByIndexName|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
+                    .FirstOrDefault(m => m.Name == "Query"
+                        && m.IsGenericMethod
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 3
+                        && m.GetParameters()[0].ParameterType == typeof(string)
+                        && m.GetParameters()[1].ParameterType == typeof(string)
+                        && m.GetParameters()[2].ParameterType == typeof(bool))
+                    ?? throw new InvalidOperationException("Could not find Query<T>(string, string, bool) method on IAsyncDocumentSession");
+                return sessionQueryMethod.MakeGenericMethod(entityType);
+            });
         var ravenIndexName = indexName.Replace("_", "/");
         return genericMethod.Invoke(session, [ravenIndexName, null, false])!;
     }
@@ -496,19 +502,24 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private object ApplyProjection(object queryable, Type resultType)
     {
-        var projectIntoMethod = typeof(LinqExtensions).GetMethods()
-            .FirstOrDefault(m => m.Name == "ProjectInto"
-                && m.IsGenericMethod
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 1
-                && m.GetParameters()[0].ParameterType == typeof(IQueryable));
+        var genericProjectMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"linqProjectInto|{resultType.FullName ?? resultType.Name}",
+            () =>
+            {
+                var projectIntoMethod = typeof(LinqExtensions).GetMethods()
+                    .FirstOrDefault(m => m.Name == "ProjectInto"
+                        && m.IsGenericMethod
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 1
+                        && m.GetParameters()[0].ParameterType == typeof(IQueryable));
+                return projectIntoMethod?.MakeGenericMethod(resultType);
+            });
 
-        if (projectIntoMethod == null)
+        if (genericProjectMethod == null)
         {
             return queryable;
         }
 
-        var genericProjectMethod = projectIntoMethod.MakeGenericMethod(resultType);
         return genericProjectMethod.Invoke(null, [queryable])!;
     }
 
@@ -524,7 +535,7 @@ internal partial class QueryExecutor : IQueryExecutor
         for (int i = 0; i < sortColumns.Length; i++)
         {
             var col = sortColumns[i];
-            var propertyInfo = entityType.GetProperty(col.Property, BindingFlags.Public | BindingFlags.Instance);
+            var propertyInfo = entityType.GetCachedProperty(col.Property);
             if (propertyInfo == null) continue;
 
             var isDescending = string.Equals(col.Direction, "desc", StringComparison.OrdinalIgnoreCase);
@@ -536,9 +547,11 @@ internal partial class QueryExecutor : IQueryExecutor
             var propertyAccess = System.Linq.Expressions.Expression.Property(parameter, propertyInfo);
             var lambda = System.Linq.Expressions.Expression.Lambda(propertyAccess, parameter);
 
-            var orderMethod = typeof(Queryable).GetMethods()
-                .First(m => m.Name == methodName && m.GetParameters().Length == 2)
-                .MakeGenericMethod(entityType, propertyInfo.PropertyType);
+            var orderMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+                $"queryableOrder|{methodName}|{entityType.FullName ?? entityType.Name}|{propertyInfo.PropertyType.FullName ?? propertyInfo.PropertyType.Name}",
+                () => typeof(Queryable).GetMethods()
+                    .First(m => m.Name == methodName && m.GetParameters().Length == 2)
+                    .MakeGenericMethod(entityType, propertyInfo.PropertyType));
 
             queryable = orderMethod.Invoke(null, [queryable, lambda])!;
         }
@@ -553,17 +566,22 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private async Task<IEnumerable<object>> ExecuteQueryableAsync(object queryable, Type entityType)
     {
-        var toListMethod = typeof(LinqExtensions).GetMethods()
-            .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
-                && m.GetGenericArguments().Length == 1
-                && m.GetParameters().Length == 2);
+        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"linqToListAsync|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var toListMethod = typeof(LinqExtensions).GetMethods()
+                    .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
+                        && m.GetGenericArguments().Length == 1
+                        && m.GetParameters().Length == 2);
+                return toListMethod?.MakeGenericMethod(entityType);
+            });
 
-        if (toListMethod == null)
+        if (genericToListMethod == null)
         {
             return [];
         }
 
-        var genericToListMethod = toListMethod.MakeGenericMethod(entityType);
         var task = genericToListMethod.Invoke(null, [queryable, CancellationToken.None]) as Task;
 
         if (task == null)
@@ -573,8 +591,7 @@ internal partial class QueryExecutor : IQueryExecutor
 
         await task;
 
-        var resultProperty = task.GetType().GetProperty("Result");
-        var result = resultProperty?.GetValue(task);
+        var result = task.GetCompletedTaskResult();
 
         if (result is System.Collections.IEnumerable enumerable)
         {

--- a/MintPlayer.Spark/Services/QueryExecutor.cs
+++ b/MintPlayer.Spark/Services/QueryExecutor.cs
@@ -306,11 +306,11 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private static CustomQueryMethodInfo? ResolveCustomQueryMethod(Type actionsType, string methodName)
     {
-        return ReflectionCache.GetOrAdd<CustomQueryMethodInfo?>(
-            $"customQueryMethod|{actionsType.FullName};{methodName}",
-            () =>
+        return ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), CustomQueryMethodInfo?>(
+            ("QueryExecutor.CustomQueryMethod", actionsType, methodName),
+            static k =>
         {
-            var method = actionsType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            var method = k.Type.GetMethod(k.Method, BindingFlags.Public | BindingFlags.Instance);
             if (method == null)
                 return null;
 
@@ -362,27 +362,28 @@ internal partial class QueryExecutor : IQueryExecutor
 
     private static Type? ExtractQueryableElementType(Type type)
     {
-        return ReflectionCache.GetOrAdd<Type?>(
-            $"queryableElement|{type.GetCacheKeyName()}",
-            () =>
+        return ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("QueryExecutor.QueryableElement", type),
+            static k =>
             {
+                var t = k.Type;
                 // Check if the type itself is IQueryable<T>
-                if (type.IsGenericType)
+                if (t.IsGenericType)
                 {
-                    var genericDef = type.GetGenericTypeDefinition();
+                    var genericDef = t.GetGenericTypeDefinition();
                     if (genericDef == typeof(IQueryable<>) || genericDef == typeof(IEnumerable<>))
-                        return type.GetGenericArguments()[0];
+                        return t.GetGenericArguments()[0];
                 }
 
                 // Check implemented interfaces for IQueryable<T>
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in t.GetInterfaces())
                 {
                     if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IQueryable<>))
                         return iface.GetGenericArguments()[0];
                 }
 
                 // Check for IEnumerable<T> as fallback
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in t.GetInterfaces())
                 {
                     if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                     {
@@ -399,11 +400,11 @@ internal partial class QueryExecutor : IQueryExecutor
     private static IEnumerable<object> MaterializeQueryable(object queryable, Type elementType)
     {
         // Call Queryable.ToList() on an in-memory IQueryable<T>
-        var toListMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"enumerableToList|{elementType.GetCacheKeyName()}",
-            () => typeof(Enumerable).GetMethods()
+        var toListMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo>(
+            ("QueryExecutor.EnumerableToList", elementType),
+            static k => typeof(Enumerable).GetMethods()
                 .First(m => m.Name == nameof(Enumerable.ToList) && m.GetGenericArguments().Length == 1)
-                .MakeGenericMethod(elementType));
+                .MakeGenericMethod(k.Type));
 
         var result = toListMethod.Invoke(null, [queryable]);
         if (result is System.Collections.IEnumerable enumerable)
@@ -450,9 +451,9 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <exception cref="InvalidOperationException">Thrown when the required generic Query&lt;T, TIndexCreator&gt; method cannot be found on the session.</exception>
     private object ApplyIndexWithType(IAsyncDocumentSession session, Type resultType, Type indexType)
     {
-        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionQueryByIndexCreator|{resultType.GetCacheKeyName()}|{indexType.GetCacheKeyName()}",
-            () =>
+        var genericMethod = ReflectionCache.GetOrAdd<(string Op, Type Result, Type Index), MethodInfo>(
+            ("QueryExecutor.SessionQueryByIndexCreator", resultType, indexType),
+            static k =>
             {
                 var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
                     .FirstOrDefault(m => m.Name == "Query"
@@ -460,7 +461,7 @@ internal partial class QueryExecutor : IQueryExecutor
                         && m.GetGenericArguments().Length == 2
                         && m.GetParameters().Length == 0)
                     ?? throw new InvalidOperationException("Could not find Query<T, TIndexCreator> method on IAsyncDocumentSession");
-                return sessionQueryMethod.MakeGenericMethod(resultType, indexType);
+                return sessionQueryMethod.MakeGenericMethod(k.Result, k.Index);
             });
         return genericMethod.Invoke(session, [])!;
     }
@@ -475,9 +476,9 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <exception cref="InvalidOperationException"></exception>
     private object ApplyIndexByName(IAsyncDocumentSession session, Type entityType, string indexName)
     {
-        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"sessionQueryByIndexName|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo>(
+            ("QueryExecutor.SessionQueryByIndexName", entityType),
+            static k =>
             {
                 var sessionQueryMethod = typeof(IAsyncDocumentSession).GetMethods()
                     .FirstOrDefault(m => m.Name == "Query"
@@ -488,7 +489,7 @@ internal partial class QueryExecutor : IQueryExecutor
                         && m.GetParameters()[1].ParameterType == typeof(string)
                         && m.GetParameters()[2].ParameterType == typeof(bool))
                     ?? throw new InvalidOperationException("Could not find Query<T>(string, string, bool) method on IAsyncDocumentSession");
-                return sessionQueryMethod.MakeGenericMethod(entityType);
+                return sessionQueryMethod.MakeGenericMethod(k.Type);
             });
         var ravenIndexName = indexName.Replace("_", "/");
         return genericMethod.Invoke(session, [ravenIndexName, null, false])!;
@@ -502,9 +503,9 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private object ApplyProjection(object queryable, Type resultType)
     {
-        var genericProjectMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqProjectInto|{resultType.GetCacheKeyName()}",
-            () =>
+        var genericProjectMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+            ("QueryExecutor.LinqProjectInto", resultType),
+            static k =>
             {
                 var projectIntoMethod = typeof(LinqExtensions).GetMethods()
                     .FirstOrDefault(m => m.Name == "ProjectInto"
@@ -512,7 +513,7 @@ internal partial class QueryExecutor : IQueryExecutor
                         && m.GetGenericArguments().Length == 1
                         && m.GetParameters().Length == 1
                         && m.GetParameters()[0].ParameterType == typeof(IQueryable));
-                return projectIntoMethod?.MakeGenericMethod(resultType);
+                return projectIntoMethod?.MakeGenericMethod(k.Type);
             });
 
         if (genericProjectMethod == null)
@@ -547,11 +548,11 @@ internal partial class QueryExecutor : IQueryExecutor
             var propertyAccess = System.Linq.Expressions.Expression.Property(parameter, propertyInfo);
             var lambda = System.Linq.Expressions.Expression.Lambda(propertyAccess, parameter);
 
-            var orderMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-                $"queryableOrder|{methodName}|{entityType.GetCacheKeyName()}|{propertyInfo.PropertyType.GetCacheKeyName()}",
-                () => typeof(Queryable).GetMethods()
-                    .First(m => m.Name == methodName && m.GetParameters().Length == 2)
-                    .MakeGenericMethod(entityType, propertyInfo.PropertyType));
+            var orderMethod = ReflectionCache.GetOrAdd<(string Op, string Method, Type Entity, Type Prop), MethodInfo>(
+                ("QueryExecutor.QueryableOrder", methodName, entityType, propertyInfo.PropertyType),
+                static k => typeof(Queryable).GetMethods()
+                    .First(m => m.Name == k.Method && m.GetParameters().Length == 2)
+                    .MakeGenericMethod(k.Entity, k.Prop));
 
             queryable = orderMethod.Invoke(null, [queryable, lambda])!;
         }
@@ -566,15 +567,15 @@ internal partial class QueryExecutor : IQueryExecutor
     /// <returns></returns>
     private async Task<IEnumerable<object>> ExecuteQueryableAsync(object queryable, Type entityType)
     {
-        var genericToListMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"linqToListAsync|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericToListMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+            ("QueryExecutor.LinqToListAsync", entityType),
+            static k =>
             {
                 var toListMethod = typeof(LinqExtensions).GetMethods()
                     .FirstOrDefault(m => m.Name == nameof(LinqExtensions.ToListAsync)
                         && m.GetGenericArguments().Length == 1
                         && m.GetParameters().Length == 2);
-                return toListMethod?.MakeGenericMethod(entityType);
+                return toListMethod?.MakeGenericMethod(k.Type);
             });
 
         if (genericToListMethod == null)

--- a/MintPlayer.Spark/Services/ReferenceResolver.cs
+++ b/MintPlayer.Spark/Services/ReferenceResolver.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents.Session;
 using System.Reflection;
 
@@ -33,11 +34,17 @@ internal partial class ReferenceResolver : IReferenceResolver
 {
     public List<(PropertyInfo Property, ReferenceAttribute Attribute)> GetReferenceProperties(Type entityType)
     {
-        return entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Select(p => (Property: p, Attribute: p.GetCustomAttribute<ReferenceAttribute>()))
-            .Where(x => x.Attribute != null)
-            .Select(x => (x.Property, x.Attribute!))
-            .ToList();
+        // Return a copy of the cached array as a List so callers can mutate (the
+        // overload below appends fallback entries). The underlying array itself
+        // is shared via ReflectionCache and must not be mutated.
+        var cached = ReflectionCache.GetOrAdd<(PropertyInfo Property, ReferenceAttribute Attribute)[]>(
+            entityType,
+            static t => t.GetCachedProperties()
+                .Select(p => (Property: p, Attribute: p.GetCachedCustomAttribute<ReferenceAttribute>()))
+                .Where(x => x.Attribute is not null)
+                .Select(x => (x.Property, x.Attribute!))
+                .ToArray());
+        return new List<(PropertyInfo, ReferenceAttribute)>(cached);
     }
 
     public List<(PropertyInfo Property, ReferenceAttribute Attribute)> GetReferenceProperties(Type entityType, Type fallbackType)
@@ -52,7 +59,7 @@ internal partial class ReferenceResolver : IReferenceResolver
         var fallbackProps = GetReferenceProperties(fallbackType);
         foreach (var (fallbackProp, refAttr) in fallbackProps)
         {
-            var matchingProp = entityType.GetProperty(fallbackProp.Name, BindingFlags.Public | BindingFlags.Instance);
+            var matchingProp = entityType.GetCachedProperty(fallbackProp.Name);
             if (matchingProp != null)
             {
                 result.Add((matchingProp, refAttr));
@@ -68,10 +75,15 @@ internal partial class ReferenceResolver : IReferenceResolver
         {
             var queryType = queryable.GetType();
 
-            var includeMethod = queryType.GetMethods()
-                .FirstOrDefault(m => m.Name == "Include"
-                    && m.GetParameters().Length == 1
-                    && m.GetParameters()[0].ParameterType == typeof(string));
+            // Cached per (queryType, "Include(string)"): the .Include(string) MethodInfo
+            // doesn't change for a given queryable type and is otherwise a fresh
+            // GetMethods() scan per reference property.
+            var includeMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+                $"includeMethod|{queryType.FullName}",
+                () => queryType.GetMethods()
+                    .FirstOrDefault(m => m.Name == "Include"
+                        && m.GetParameters().Length == 1
+                        && m.GetParameters()[0].ParameterType == typeof(string)));
 
             if (includeMethod != null)
             {
@@ -99,7 +111,7 @@ internal partial class ReferenceResolver : IReferenceResolver
         {
             foreach (var (property, refAttr) in referenceProperties)
             {
-                var refId = property.GetValue(entity) as string;
+                var refId = AccessorCache.GetGetter(property)(entity) as string;
                 if (string.IsNullOrEmpty(refId)) continue;
 
                 var targetType = refAttr.TargetType;
@@ -129,15 +141,22 @@ internal partial class ReferenceResolver : IReferenceResolver
 
     private static async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
-        var method = typeof(IAsyncDocumentSession).GetMethod(nameof(IAsyncDocumentSession.LoadAsync), [typeof(string), typeof(CancellationToken)]);
-        var genericMethod = method?.MakeGenericMethod(entityType);
+        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
+            $"sessionLoadAsync|{entityType.FullName ?? entityType.Name}",
+            () =>
+            {
+                var method = typeof(IAsyncDocumentSession).GetMethod(
+                    nameof(IAsyncDocumentSession.LoadAsync),
+                    [typeof(string), typeof(CancellationToken)]);
+                return method?.MakeGenericMethod(entityType);
+            });
         var task = genericMethod?.Invoke(session, [id, CancellationToken.None]) as Task;
 
         if (task == null) return null;
 
         await task;
 
-        var resultProperty = task.GetType().GetProperty("Result");
-        return resultProperty?.GetValue(task);
+        var resultProperty = task.GetType().GetCachedProperty("Result");
+        return resultProperty is not null ? AccessorCache.GetGetter(resultProperty)(task) : null;
     }
 }

--- a/MintPlayer.Spark/Services/ReferenceResolver.cs
+++ b/MintPlayer.Spark/Services/ReferenceResolver.cs
@@ -142,7 +142,7 @@ internal partial class ReferenceResolver : IReferenceResolver
     private static async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionLoadAsync|{entityType.FullName ?? entityType.Name}",
+            $"sessionLoadAsync|{entityType.GetCacheKeyName()}",
             () =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(

--- a/MintPlayer.Spark/Services/ReferenceResolver.cs
+++ b/MintPlayer.Spark/Services/ReferenceResolver.cs
@@ -37,7 +37,7 @@ internal partial class ReferenceResolver : IReferenceResolver
         // Return a copy of the cached array as a List so callers can mutate (the
         // overload below appends fallback entries). The underlying array itself
         // is shared via ReflectionCache and must not be mutated.
-        var cached = ReflectionCache.GetOrAdd<(PropertyInfo Property, ReferenceAttribute Attribute)[]>(
+        var cached = ReflectionCache.GetOrAdd<Type, (PropertyInfo Property, ReferenceAttribute Attribute)[]>(
             entityType,
             static t => t.GetCachedProperties()
                 .Select(p => (Property: p, Attribute: p.GetCachedCustomAttribute<ReferenceAttribute>()))
@@ -78,9 +78,9 @@ internal partial class ReferenceResolver : IReferenceResolver
             // Cached per (queryType, "Include(string)"): the .Include(string) MethodInfo
             // doesn't change for a given queryable type and is otherwise a fresh
             // GetMethods() scan per reference property.
-            var includeMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-                $"includeMethod|{queryType.FullName}",
-                () => queryType.GetMethods()
+            var includeMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+                ("ReferenceResolver.IncludeMethod", queryType),
+                static k => k.Type.GetMethods()
                     .FirstOrDefault(m => m.Name == "Include"
                         && m.GetParameters().Length == 1
                         && m.GetParameters()[0].ParameterType == typeof(string)));
@@ -141,14 +141,14 @@ internal partial class ReferenceResolver : IReferenceResolver
 
     private static async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
-        var genericMethod = ReflectionCache.GetOrAdd<MethodInfo?>(
-            $"sessionLoadAsync|{entityType.GetCacheKeyName()}",
-            () =>
+        var genericMethod = ReflectionCache.GetOrAdd<(string Op, Type Type), MethodInfo?>(
+            ("ReferenceResolver.SessionLoadAsync", entityType),
+            static k =>
             {
                 var method = typeof(IAsyncDocumentSession).GetMethod(
                     nameof(IAsyncDocumentSession.LoadAsync),
                     [typeof(string), typeof(CancellationToken)]);
-                return method?.MakeGenericMethod(entityType);
+                return method?.MakeGenericMethod(k.Type);
             });
         var task = genericMethod?.Invoke(session, [id, CancellationToken.None]) as Task;
 

--- a/MintPlayer.Spark/Services/SyncActionHandler.cs
+++ b/MintPlayer.Spark/Services/SyncActionHandler.cs
@@ -229,11 +229,11 @@ internal partial class SyncActionHandler : ISyncActionHandler
     private async Task<object> SaveEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, PersistentObject obj)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onSaveMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"actionsMethod|{actions.GetType().FullName}|OnSaveAsync",
-            () => actions.GetType().GetMethod("OnSaveAsync")
+        var onSaveMethod = ReflectionCache.GetOrAdd<(string Op, Type Actions), MethodInfo>(
+            ("SyncActionHandler.OnSaveAsync", actions.GetType()),
+            static k => k.Actions.GetMethod("OnSaveAsync")
                 ?? throw new InvalidOperationException(
-                    $"Actions type '{actions.GetType().FullName}' is missing required method 'OnSaveAsync'."));
+                    $"Actions type '{k.Actions.FullName}' is missing required method 'OnSaveAsync'."));
         var task = (Task)onSaveMethod.Invoke(actions, [session, obj])!;
         await task;
         return task.GetCompletedTaskResult()!;
@@ -242,11 +242,11 @@ internal partial class SyncActionHandler : ISyncActionHandler
     private async Task DeleteEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onDeleteMethod = ReflectionCache.GetOrAdd<MethodInfo>(
-            $"actionsMethod|{actions.GetType().FullName}|OnDeleteAsync",
-            () => actions.GetType().GetMethod("OnDeleteAsync")
+        var onDeleteMethod = ReflectionCache.GetOrAdd<(string Op, Type Actions), MethodInfo>(
+            ("SyncActionHandler.OnDeleteAsync", actions.GetType()),
+            static k => k.Actions.GetMethod("OnDeleteAsync")
                 ?? throw new InvalidOperationException(
-                    $"Actions type '{actions.GetType().FullName}' is missing required method 'OnDeleteAsync'."));
+                    $"Actions type '{k.Actions.FullName}' is missing required method 'OnDeleteAsync'."));
         var task = (Task)onDeleteMethod.Invoke(actions, [session, id])!;
         await task;
     }

--- a/MintPlayer.Spark/Services/SyncActionHandler.cs
+++ b/MintPlayer.Spark/Services/SyncActionHandler.cs
@@ -1,5 +1,6 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Abstractions.Reflection;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using System.Collections.Concurrent;
@@ -40,8 +41,10 @@ internal partial class SyncActionHandler : ISyncActionHandler
         var savedEntity = await SaveEntityViaActionsAsync(session, entityType, po);
 
         // Extract the generated/existing ID
-        var resultIdProperty = entityType.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        var resultId = resultIdProperty?.GetValue(savedEntity)?.ToString();
+        var resultIdProperty = entityType.GetCachedProperty("Id");
+        var resultId = resultIdProperty is not null && resultIdProperty.CanRead
+            ? AccessorCache.GetGetter(resultIdProperty)(savedEntity)?.ToString()
+            : null;
 
         logger.LogInformation("Sync action: saved {Collection}/{DocumentId} ({PropertyMode})",
             collection, resultId ?? documentId,
@@ -108,7 +111,7 @@ internal partial class SyncActionHandler : ISyncActionHandler
             Name = entityType.Name,
         };
 
-        foreach (var prop in entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach (var prop in entityType.GetCachedProperties())
         {
             if (string.Equals(prop.Name, "Id", StringComparison.Ordinal)) continue;
             if (!prop.CanRead || !prop.CanWrite) continue;
@@ -206,31 +209,44 @@ internal partial class SyncActionHandler : ISyncActionHandler
 
     private static Type? ResolveType(string clrType)
     {
-        var type = Type.GetType(clrType);
-        if (type != null) return type;
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"resolveType|{clrType}",
+            () =>
+            {
+                var type = Type.GetType(clrType);
+                if (type != null) return type;
 
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            type = assembly.GetType(clrType);
-            if (type != null) return type;
-        }
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    type = assembly.GetType(clrType);
+                    if (type != null) return type;
+                }
 
-        return null;
+                return null;
+            });
     }
 
     private async Task<object> SaveEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, PersistentObject obj)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onSaveMethod = actions.GetType().GetMethod("OnSaveAsync")!;
+        var onSaveMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"actionsMethod|{actions.GetType().FullName}|OnSaveAsync",
+            () => actions.GetType().GetMethod("OnSaveAsync")
+                ?? throw new InvalidOperationException(
+                    $"Actions type '{actions.GetType().FullName}' is missing required method 'OnSaveAsync'."));
         var task = (Task)onSaveMethod.Invoke(actions, [session, obj])!;
         await task;
-        return task.GetType().GetProperty("Result")!.GetValue(task)!;
+        return task.GetCompletedTaskResult()!;
     }
 
     private async Task DeleteEntityViaActionsAsync(IAsyncDocumentSession session, Type entityType, string id)
     {
         var actions = actionsResolver.ResolveForType(entityType);
-        var onDeleteMethod = actions.GetType().GetMethod("OnDeleteAsync")!;
+        var onDeleteMethod = ReflectionCache.GetOrAdd<MethodInfo>(
+            $"actionsMethod|{actions.GetType().FullName}|OnDeleteAsync",
+            () => actions.GetType().GetMethod("OnDeleteAsync")
+                ?? throw new InvalidOperationException(
+                    $"Actions type '{actions.GetType().FullName}' is missing required method 'OnDeleteAsync'."));
         var task = (Task)onDeleteMethod.Invoke(actions, [session, id])!;
         await task;
     }

--- a/MintPlayer.Spark/SparkMiddleware.cs
+++ b/MintPlayer.Spark/SparkMiddleware.cs
@@ -351,9 +351,9 @@ public static class SparkExtensions
             // Find and register all index types — Assembly.GetTypes() walks the assembly's
             // entire metadata tables; cache the filtered result so repeat AddSpark calls
             // (or hot-reload scenarios) don't re-scan.
-            var indexTypes = ReflectionCache.GetOrAdd<IReadOnlyList<Type>>(
-                $"indexTypes|{targetAssembly.FullName}",
-                () => targetAssembly.GetTypes()
+            var indexTypes = ReflectionCache.GetOrAdd<(string Op, Assembly Asm), IReadOnlyList<Type>>(
+                ("SparkMiddleware.IndexTypes", targetAssembly),
+                static k => k.Asm.GetTypes()
                     .Where(t => !t.IsAbstract && IsAbstractIndexCreationTask(t))
                     .ToArray());
 
@@ -363,9 +363,9 @@ public static class SparkExtensions
             }
 
             // Find and register all projection types with FromIndexAttribute
-            var projectionTypes = ReflectionCache.GetOrAdd<IReadOnlyList<Type>>(
-                $"projectionTypes|{targetAssembly.FullName}",
-                () => targetAssembly.GetTypes()
+            var projectionTypes = ReflectionCache.GetOrAdd<(string Op, Assembly Asm), IReadOnlyList<Type>>(
+                ("SparkMiddleware.ProjectionTypes", targetAssembly),
+                static k => k.Asm.GetTypes()
                     .Where(t => t.GetCachedCustomAttribute<FromIndexAttribute>() != null)
                     .ToArray());
 

--- a/MintPlayer.Spark/SparkMiddleware.cs
+++ b/MintPlayer.Spark/SparkMiddleware.cs
@@ -3,6 +3,7 @@ using MintPlayer.AspNetCore.Endpoints;
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Builder;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Actions;
 using MintPlayer.Spark.Configuration;
 using MintPlayer.Spark.Converters;
@@ -347,10 +348,14 @@ public static class SparkExtensions
 
         try
         {
-            // Find and register all index types
-            var indexTypes = targetAssembly.GetTypes()
-                .Where(t => !t.IsAbstract && IsAbstractIndexCreationTask(t))
-                .ToList();
+            // Find and register all index types — Assembly.GetTypes() walks the assembly's
+            // entire metadata tables; cache the filtered result so repeat AddSpark calls
+            // (or hot-reload scenarios) don't re-scan.
+            var indexTypes = ReflectionCache.GetOrAdd<IReadOnlyList<Type>>(
+                $"indexTypes|{targetAssembly.FullName}",
+                () => targetAssembly.GetTypes()
+                    .Where(t => !t.IsAbstract && IsAbstractIndexCreationTask(t))
+                    .ToArray());
 
             foreach (var indexType in indexTypes)
             {
@@ -358,13 +363,15 @@ public static class SparkExtensions
             }
 
             // Find and register all projection types with FromIndexAttribute
-            var projectionTypes = targetAssembly.GetTypes()
-                .Where(t => t.GetCustomAttribute<FromIndexAttribute>() != null)
-                .ToList();
+            var projectionTypes = ReflectionCache.GetOrAdd<IReadOnlyList<Type>>(
+                $"projectionTypes|{targetAssembly.FullName}",
+                () => targetAssembly.GetTypes()
+                    .Where(t => t.GetCachedCustomAttribute<FromIndexAttribute>() != null)
+                    .ToArray());
 
             foreach (var projectionType in projectionTypes)
             {
-                var attr = projectionType.GetCustomAttribute<FromIndexAttribute>()!;
+                var attr = projectionType.GetCachedCustomAttribute<FromIndexAttribute>()!;
                 indexRegistry.RegisterProjection(projectionType, attr.IndexType);
             }
 

--- a/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
+++ b/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
@@ -99,11 +99,11 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
     private static StreamingMethodInfo? ResolveStreamingMethod(Type actionsType, string methodName)
     {
-        return ReflectionCache.GetOrAdd<StreamingMethodInfo?>(
-            $"streamingMethod|{actionsType.FullName};{methodName}",
-            () =>
+        return ReflectionCache.GetOrAdd<(string Op, Type Type, string Method), StreamingMethodInfo?>(
+            ("StreamingQueryExecutor.ResolveStreamingMethod", actionsType, methodName),
+            static k =>
         {
-            var method = actionsType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            var method = k.Type.GetMethod(k.Method, BindingFlags.Public | BindingFlags.Instance);
             if (method is null) return null;
 
             var returnType = method.ReturnType;
@@ -146,15 +146,16 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
     }
 
     private static Type? ExtractAsyncEnumerableType(Type type)
-        => ReflectionCache.GetOrAdd<Type?>(
-            $"asyncEnumerableElem|{type.GetCacheKeyName()}",
-            () =>
+        => ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("StreamingQueryExecutor.AsyncEnumerableElement", type),
+            static k =>
             {
+                var t = k.Type;
                 // Check if type implements IAsyncEnumerable<T>
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                    return type.GetGenericArguments()[0];
+                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                    return t.GetGenericArguments()[0];
 
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in t.GetInterfaces())
                 {
                     if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
                         return iface.GetGenericArguments()[0];
@@ -164,15 +165,16 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
             });
 
     private static Type? ExtractReadOnlyListElementType(Type type)
-        => ReflectionCache.GetOrAdd<Type?>(
-            $"readOnlyListElem|{type.GetCacheKeyName()}",
-            () =>
+        => ReflectionCache.GetOrAdd<(string Op, Type Type), Type?>(
+            ("StreamingQueryExecutor.ReadOnlyListElement", type),
+            static k =>
             {
+                var t = k.Type;
                 // Check IReadOnlyList<T>
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-                    return type.GetGenericArguments()[0];
+                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+                    return t.GetGenericArguments()[0];
 
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in t.GetInterfaces())
                 {
                     if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
                         return iface.GetGenericArguments()[0];
@@ -188,11 +190,11 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
         // For single-item streams: IAsyncEnumerable<T>
         // Cache the closed IAsyncEnumerator<T> + its MoveNextAsync/Current MemberInfos per
         // (elementType, isSingleItem) pair — they're stable for the AppDomain.
-        var (getEnumeratorMethod, moveNextMethod, currentProperty) = ReflectionCache.GetOrAdd<(MethodInfo, MethodInfo, PropertyInfo)>(
-            $"asyncEnumeratorOps|{elementType.GetCacheKeyName()}|single={isSingleItem}",
-            () =>
+        var (getEnumeratorMethod, moveNextMethod, currentProperty) = ReflectionCache.GetOrAdd<(string Op, Type Element, bool Single), (MethodInfo, MethodInfo, PropertyInfo)>(
+            ("StreamingQueryExecutor.AsyncEnumeratorOps", elementType, isSingleItem),
+            static k =>
             {
-                var innerType = isSingleItem ? elementType : typeof(IReadOnlyList<>).MakeGenericType(elementType);
+                var innerType = k.Single ? k.Element : typeof(IReadOnlyList<>).MakeGenericType(k.Element);
                 var enumerableType = typeof(IAsyncEnumerable<>).MakeGenericType(innerType);
                 var enumeratorInterface = typeof(IAsyncEnumerator<>).MakeGenericType(innerType);
                 return (

--- a/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
+++ b/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
@@ -147,7 +147,7 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
     private static Type? ExtractAsyncEnumerableType(Type type)
         => ReflectionCache.GetOrAdd<Type?>(
-            $"asyncEnumerableElem|{type.FullName ?? type.Name}",
+            $"asyncEnumerableElem|{type.GetCacheKeyName()}",
             () =>
             {
                 // Check if type implements IAsyncEnumerable<T>
@@ -165,7 +165,7 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
     private static Type? ExtractReadOnlyListElementType(Type type)
         => ReflectionCache.GetOrAdd<Type?>(
-            $"readOnlyListElem|{type.FullName ?? type.Name}",
+            $"readOnlyListElem|{type.GetCacheKeyName()}",
             () =>
             {
                 // Check IReadOnlyList<T>
@@ -189,7 +189,7 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
         // Cache the closed IAsyncEnumerator<T> + its MoveNextAsync/Current MemberInfos per
         // (elementType, isSingleItem) pair — they're stable for the AppDomain.
         var (getEnumeratorMethod, moveNextMethod, currentProperty) = ReflectionCache.GetOrAdd<(MethodInfo, MethodInfo, PropertyInfo)>(
-            $"asyncEnumeratorOps|{elementType.FullName ?? elementType.Name}|single={isSingleItem}",
+            $"asyncEnumeratorOps|{elementType.GetCacheKeyName()}|single={isSingleItem}",
             () =>
             {
                 var innerType = isSingleItem ? elementType : typeof(IReadOnlyList<>).MakeGenericType(elementType);

--- a/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
+++ b/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs
@@ -1,10 +1,10 @@
 using MintPlayer.SourceGenerators.Attributes;
 using MintPlayer.Spark.Abstractions;
 using MintPlayer.Spark.Abstractions.Authorization;
+using MintPlayer.Spark.Abstractions.Reflection;
 using MintPlayer.Spark.Queries;
 using MintPlayer.Spark.Services;
 using Raven.Client.Documents;
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -19,8 +19,6 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
     [Inject] private readonly IPermissionService permissionService;
     [Inject] private readonly IActionsResolver actionsResolver;
     [Inject] private readonly IReferenceResolver referenceResolver;
-
-    private static readonly ConcurrentDictionary<string, StreamingMethodInfo?> streamingMethodCache = new();
 
     public async IAsyncEnumerable<PersistentObject[]> ExecuteStreamingQueryAsync(
         SparkQuery query, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -101,8 +99,9 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
     private static StreamingMethodInfo? ResolveStreamingMethod(Type actionsType, string methodName)
     {
-        var cacheKey = $"stream;{actionsType.FullName};{methodName}";
-        return streamingMethodCache.GetOrAdd(cacheKey, _ =>
+        return ReflectionCache.GetOrAdd<StreamingMethodInfo?>(
+            $"streamingMethod|{actionsType.FullName};{methodName}",
+            () =>
         {
             var method = actionsType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
             if (method is null) return null;
@@ -147,52 +146,63 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
     }
 
     private static Type? ExtractAsyncEnumerableType(Type type)
-    {
-        // Check if type implements IAsyncEnumerable<T>
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-            return type.GetGenericArguments()[0];
+        => ReflectionCache.GetOrAdd<Type?>(
+            $"asyncEnumerableElem|{type.FullName ?? type.Name}",
+            () =>
+            {
+                // Check if type implements IAsyncEnumerable<T>
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                    return type.GetGenericArguments()[0];
 
-        foreach (var iface in type.GetInterfaces())
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                return iface.GetGenericArguments()[0];
-        }
+                foreach (var iface in type.GetInterfaces())
+                {
+                    if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                        return iface.GetGenericArguments()[0];
+                }
 
-        return null;
-    }
+                return null;
+            });
 
     private static Type? ExtractReadOnlyListElementType(Type type)
-    {
-        // Check IReadOnlyList<T>
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-            return type.GetGenericArguments()[0];
+        => ReflectionCache.GetOrAdd<Type?>(
+            $"readOnlyListElem|{type.FullName ?? type.Name}",
+            () =>
+            {
+                // Check IReadOnlyList<T>
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+                    return type.GetGenericArguments()[0];
 
-        foreach (var iface in type.GetInterfaces())
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-                return iface.GetGenericArguments()[0];
-        }
+                foreach (var iface in type.GetInterfaces())
+                {
+                    if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+                        return iface.GetGenericArguments()[0];
+                }
 
-        return null;
-    }
+                return null;
+            });
 
     private static async IAsyncEnumerable<IReadOnlyList<object>> IterateAsyncEnumerable(
         object asyncEnumerable, Type elementType, bool isSingleItem, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // For batch streams: IAsyncEnumerable<IReadOnlyList<T>>
         // For single-item streams: IAsyncEnumerable<T>
-        var innerType = isSingleItem ? elementType : typeof(IReadOnlyList<>).MakeGenericType(elementType);
-        var asyncEnumerableType = typeof(IAsyncEnumerable<>).MakeGenericType(innerType);
+        // Cache the closed IAsyncEnumerator<T> + its MoveNextAsync/Current MemberInfos per
+        // (elementType, isSingleItem) pair — they're stable for the AppDomain.
+        var (getEnumeratorMethod, moveNextMethod, currentProperty) = ReflectionCache.GetOrAdd<(MethodInfo, MethodInfo, PropertyInfo)>(
+            $"asyncEnumeratorOps|{elementType.FullName ?? elementType.Name}|single={isSingleItem}",
+            () =>
+            {
+                var innerType = isSingleItem ? elementType : typeof(IReadOnlyList<>).MakeGenericType(elementType);
+                var enumerableType = typeof(IAsyncEnumerable<>).MakeGenericType(innerType);
+                var enumeratorInterface = typeof(IAsyncEnumerator<>).MakeGenericType(innerType);
+                return (
+                    enumerableType.GetMethod("GetAsyncEnumerator")!,
+                    enumeratorInterface.GetMethod("MoveNextAsync")!,
+                    enumeratorInterface.GetProperty("Current")!);
+            });
 
-        var getEnumeratorMethod = asyncEnumerableType.GetMethod("GetAsyncEnumerator")!;
         var enumerator = getEnumeratorMethod.Invoke(asyncEnumerable, [cancellationToken])!;
-
-        // Use the interface type to resolve methods — compiler-generated async enumerators
-        // use explicit interface implementation, so MoveNextAsync/Current won't be found
-        // on the concrete type.
-        var enumeratorInterfaceType = typeof(IAsyncEnumerator<>).MakeGenericType(innerType);
-        var moveNextMethod = enumeratorInterfaceType.GetMethod("MoveNextAsync")!;
-        var currentProperty = enumeratorInterfaceType.GetProperty("Current")!;
+        var currentGetter = AccessorCache.GetGetter(currentProperty);
 
         try
         {
@@ -211,7 +221,7 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
                 if (!hasMore) break;
 
-                var current = currentProperty.GetValue(enumerator);
+                var current = currentGetter(enumerator);
                 if (isSingleItem)
                 {
                     // Wrap single item in a list
@@ -236,20 +246,25 @@ internal partial class StreamingQueryExecutor : IStreamingQueryExecutor
 
     private static Type? FindClrType(string clrTypeName)
     {
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            try
+        return ReflectionCache.GetOrAdd<Type?>(
+            $"clrType|{clrTypeName}",
+            () =>
             {
-                var type = assembly.GetTypes()
-                    .FirstOrDefault(t => (t.FullName == clrTypeName || t.Name == clrTypeName) && !t.IsAbstract && !t.IsInterface);
-                if (type is not null) return type;
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                continue;
-            }
-        }
-        return null;
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    try
+                    {
+                        var type = assembly.GetTypes()
+                            .FirstOrDefault(t => (t.FullName == clrTypeName || t.Name == clrTypeName) && !t.IsAbstract && !t.IsInterface);
+                        if (type is not null) return type;
+                    }
+                    catch (ReflectionTypeLoadException)
+                    {
+                        continue;
+                    }
+                }
+                return null;
+            });
     }
 }
 

--- a/docs/PRD-ReflectionCache.md
+++ b/docs/PRD-ReflectionCache.md
@@ -1,0 +1,245 @@
+# PRD: ReflectionCache — Generic Any-Use Memoization Primitive
+
+| | |
+|---|---|
+| **Version** | 1.0 |
+| **Date** | 2026-05-03 |
+| **Status** | Proposed |
+| **Owner** | MintPlayer |
+| **Package** | `MintPlayer.Spark` |
+| **Issue** | [#151](https://github.com/MintPlayer/MintPlayer.Spark/issues/151) |
+| **Reference** | `C:\Repos\CronosCore\CronosCore.RavenDB\ReferenceObject\ReflectionCache.cs` |
+
+---
+
+## 1. Problem Statement
+
+Spark performs the same reflection lookups repeatedly on hot request paths. None of the heavy lookups are memoized today; each call walks `Type.GetProperties`, `GetCustomAttribute<T>`, `Assembly.GetTypes`, etc., from scratch. Reflection results are immutable for the lifetime of the AppDomain, so every repeat call after the first is wasted work.
+
+### Concrete hotspots (from codebase audit)
+
+**Tier 1 — per-request, currently uncached:**
+
+| Site | What it does | Frequency |
+|---|---|---|
+| `EntityMapper.PopulateAttributeValues` (`Services/EntityMapper.cs:178–228`) | `GetProperty(name)` + `GetValue` per attribute, per entity, per result row | 100s–1000s of calls/request |
+| `EntityMapper.GetEntityDisplayName` (`Services/EntityMapper.cs:902–918`) | `GetProperties()` scan per entity | per result row |
+| `EntityMapper.GetCollectionElementType` (`Services/EntityMapper.cs:296–314`) | `GetGenericArguments` + `GetInterfaces` per collection property | per AsDetail property per row |
+| `ReferenceResolver.GetReferenceProperties` (`Services/ReferenceResolver.cs:34–63`) | `GetProperties()` + `GetCustomAttribute<ReferenceAttribute>` per query | per query |
+| `ActionsResolver.FindActionsType` (`Services/ActionsResolver.cs:62–79`) | `Assembly.GetTypes()` walk per missed lookup; no negative caching | per entity-type resolution |
+
+**Tier 2 — moderately hot, partially cached:**
+
+- `QueryExecutor.customQueryMethodCache` (`Services/QueryExecutor.cs:30`) — already uses a `ConcurrentDictionary<string, ...>`; ad-hoc and should consolidate onto the new primitive.
+- `MessageBus.StoreMessageAsync` (`MintPlayer.Spark.Messaging/Services/MessageBus.cs:29–35`) — `GetCustomAttribute<MessageQueueAttribute>` per broadcast.
+- `ModelSynchronizer.CreateOrUpdateEntityTypeDefinition` (`Services/ModelSynchronizer.cs:281–325`) — startup-only but high redundancy across types.
+
+**Tier 3 — startup-only, already adequately cached:**
+
+- `LookupReferenceDiscoveryService`, `IndexRegistry`, `EtlScriptCollector`. Listed for completeness; no migration needed.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. **Generic any-use primitive** — a single static cache class that any caller can use to memoize *anything* keyed by a string (or by type). Not a domain-specific "GetAllPropertiesWith[Indexed]" helper class.
+2. **Two-tier cache** mirroring the CronosCore reference:
+   - **Per-type tier** (`Cache<T>`) — generic-static specialization, one dictionary per `T`, ideal for "all properties of T", "the [Foo] attribute on T", etc.
+   - **Global tier** — string-keyed, for cross-type lookups ("all types in assembly X derived from Y").
+3. **Thread-safe**, computation-runs-once-per-key semantics.
+4. **Zero new external dependencies** — no Vidyano `CacheLock` (used by the reference); use BCL primitives only.
+5. **Migrate Tier 1 hotspots** onto the new primitive in this PR; consolidate Tier 2 ad-hoc caches in follow-ups.
+
+### Non-Goals
+
+- **Eviction / TTL.** Reflection metadata is AppDomain-immutable; never evict.
+- **Cross-process / distributed cache.** In-process only.
+- **Compiled accessor delegates** (`Expression.Lambda` for getters/setters) are *not in initial scope* but the API must accommodate them as a pure consumer — i.e. caching `Func<object, object>` should be a one-liner from a caller, with no changes to `ReflectionCache` itself. (Tracked as a follow-up; see §7.)
+- **Replacing every reflection call site at once.** Audit-driven, tier-prioritized rollout.
+
+---
+
+## 3. Design
+
+### 3.1 Locking strategy — depart from the reference
+
+The CronosCore reference uses a `CacheLock` (a Vidyano-supplied wrapper around `ReaderWriterLockSlim`). We reject this for two reasons:
+
+1. **No external dep available.** Vidyano is not a Spark dependency, and we don't want to add it for a single helper.
+2. **`ConcurrentDictionary<TKey, Lazy<TValue>>.GetOrAdd` is strictly better** for this workload:
+   - Lock-free reads (the dominant case after warmup).
+   - `Lazy<T>` with `LazyThreadSafetyMode.ExecutionAndPublication` guarantees the factory runs exactly once per key, even under contention — no upgradeable-read dance, no TOCTOU window, no risk of duplicate factory execution.
+   - Standard idiom; every .NET developer recognizes it.
+
+The CronosCore upgradeable-read pattern is correct but heavier than necessary for a memoize-forever cache.
+
+### 3.2 API surface
+
+```csharp
+namespace MintPlayer.Spark.Reflection;
+
+public static class ReflectionCache
+{
+    // Per-type tier — one dictionary per TOwner, lock-free reads via ConcurrentDictionary.
+    // Use when the cache key naturally belongs to one type (properties of T, attribute on T, etc.).
+    public static TValue GetOrAdd<TOwner, TValue>(string key, Func<TValue> factory);
+
+    // Global tier — single string-keyed dictionary shared across the AppDomain.
+    // Use for cross-type lookups (assembly scans, name->type maps, etc.).
+    public static TValue GetOrAdd<TValue>(string key, Func<TValue> factory);
+
+    // Convenience overload — uses Type as the key without forcing callers to stringify.
+    public static TValue GetOrAdd<TValue>(Type key, Func<Type, TValue> factory);
+
+    // Diagnostics (debug builds / tests only).
+    internal static int Count { get; }
+    internal static void Clear(); // test-only
+}
+```
+
+**Implementation sketch:**
+
+```csharp
+public static class ReflectionCache
+{
+    private static class PerType<TOwner>
+    {
+        // ReSharper disable once StaticMemberInGenericType — that's the point.
+        internal static readonly ConcurrentDictionary<string, Lazy<object?>> Cache = new();
+    }
+
+    private static readonly ConcurrentDictionary<string, Lazy<object?>> globalCache = new();
+    private static readonly ConcurrentDictionary<Type, Lazy<object?>> typeKeyedCache = new();
+
+    public static TValue GetOrAdd<TOwner, TValue>(string key, Func<TValue> factory)
+    {
+        var lazy = PerType<TOwner>.Cache.GetOrAdd(
+            key,
+            _ => new Lazy<object?>(() => factory(), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+
+    public static TValue GetOrAdd<TValue>(string key, Func<TValue> factory)
+    {
+        var lazy = globalCache.GetOrAdd(
+            key,
+            _ => new Lazy<object?>(() => factory(), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+
+    public static TValue GetOrAdd<TValue>(Type key, Func<Type, TValue> factory)
+    {
+        var lazy = typeKeyedCache.GetOrAdd(
+            key,
+            t => new Lazy<object?>(() => factory(t), LazyThreadSafetyMode.ExecutionAndPublication));
+        return (TValue)lazy.Value!;
+    }
+}
+```
+
+### 3.3 Why three overloads, not one
+
+- `GetOrAdd<TOwner, TValue>(string, Func<TValue>)` — **per-type**. The generic-static `PerType<TOwner>` gives each `TOwner` its own dictionary at zero key-prefixing cost. Use for "properties of T with attribute X".
+- `GetOrAdd<TValue>(string, Func<TValue>)` — **global string-keyed**. Use when the key is naturally a string and not bound to one type ("all `IPersistentObject` types in `Assembly.GetExecutingAssembly()`").
+- `GetOrAdd<TValue>(Type, Func<Type, TValue>)` — **global type-keyed**. Avoids `type.FullName` boilerplate at every call site and is the natural shape for "given any Type, give me its X" lookups (e.g. `ActionsResolver.FindActionsType`).
+
+### 3.4 Caller patterns
+
+The cache is the *primitive*. Domain-specific helpers live near their callers, not inside `ReflectionCache`:
+
+```csharp
+// In EntityMapper:
+private static PropertyInfo[] GetMappedProperties(Type entityType) =>
+    ReflectionCache.GetOrAdd(entityType, t =>
+        t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
+
+// In ReferenceResolver:
+private static (PropertyInfo Prop, ReferenceAttribute Attr)[] GetReferenceProps<T>() =>
+    ReflectionCache.GetOrAdd<T, (PropertyInfo, ReferenceAttribute)[]>("references", () =>
+        typeof(T).GetProperties()
+            .Select(p => (p, p.GetCustomAttribute<ReferenceAttribute>()!))
+            .Where(x => x.Item2 != null)
+            .ToArray());
+
+// In ActionsResolver — note negative caching via nullable:
+private static Type? FindActionsType(string entityName) =>
+    ReflectionCache.GetOrAdd<Type?>($"actions:{entityName}", () =>
+        AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .FirstOrDefault(t => t.Name == $"{entityName}Actions"));
+```
+
+Negative caching (caching `null`) falls out for free because `Lazy<object?>` happily holds `null`.
+
+---
+
+## 4. Migration Plan
+
+### Phase 1 — primitive + Tier 1 (this PR)
+
+1. Add `MintPlayer.Spark/Reflection/ReflectionCache.cs` per §3.2.
+2. Migrate Tier 1 sites:
+   - `EntityMapper.PopulateAttributeValues` — cache `(Type, propertyName) → PropertyInfo`.
+   - `EntityMapper.GetEntityDisplayName` — cache `Type → PropertyInfo[]`.
+   - `EntityMapper.GetCollectionElementType` — cache `Type → Type?`.
+   - `ReferenceResolver.GetReferenceProperties` — cache `Type → (PropertyInfo, ReferenceAttribute)[]`.
+   - `ActionsResolver.FindActionsType` — cache `string → Type?`.
+3. Unit tests (see §6).
+
+### Phase 2 — Tier 2 consolidation (follow-up)
+
+4. Replace `QueryExecutor.customQueryMethodCache` ad-hoc dictionary with `ReflectionCache.GetOrAdd<...>("custom-query:" + key, ...)`.
+5. Migrate `MessageBus.StoreMessageAsync` attribute lookup.
+6. Migrate `ModelSynchronizer` per-type attribute reads.
+
+### Phase 3 — compiled accessor delegates (follow-up, optional)
+
+7. Add a separate `AccessorCache` static helper (consumes `ReflectionCache` — no changes to it) that builds and caches `Func<object, object>` getters / `Action<object, object>` setters via `Expression.Lambda` for properties read/written on hot paths (`EntityMapper.PopulateAttributeValues` is the prime candidate). Track separately; only ship if Phase 1 profiling shows getter/setter invocation is still hot after `PropertyInfo` lookups are cached.
+
+---
+
+## 5. Risks & Open Questions
+
+### Risks
+
+- **Memory growth.** Cache entries live forever. Bounded by `(num types) × (num distinct keys per type)` — finite and small for reflection metadata. Acceptable.
+- **Stale cache during hot reload.** .NET hot reload can replace types. Out of scope; if it bites, add a `MetadataUpdateHandler` later.
+- **Lazy factory exceptions.** A throwing factory under `ExecutionAndPublication` caches the *exception* and re-throws on every subsequent access. This is the correct behavior — a reflection lookup that fails will fail deterministically — but document it in xmldoc.
+
+### Open questions
+
+1. Should the cache live in `MintPlayer.Spark` or `MintPlayer.Spark.Abstractions`? **Recommendation:** `MintPlayer.Spark/Reflection/` for now — no abstraction needed; it's a static helper, not a service. Promote later if multiple packages need it.
+2. Diagnostic counters — emit anything via `Activity` / `Metrics`? **Recommendation:** no, defer until a real ask.
+
+---
+
+## 6. Testing
+
+- `ReflectionCacheTests`:
+  - `GetOrAdd_PerType_DifferentOwners_GetIsolatedCaches`
+  - `GetOrAdd_Global_SameKey_FactoryRunsOnce` (use a counter; assert `factory` invoked exactly once across N concurrent `Task.Run` callers).
+  - `GetOrAdd_NullValue_IsCachedAndReturned` (negative caching contract).
+  - `GetOrAdd_FactoryThrows_ExceptionIsCachedAndRethrown`.
+  - `GetOrAdd_TypeKeyed_DifferentTypes_AreIsolated`.
+- Migration sites: existing tests must still pass; add benchmarks (optional `BenchmarkDotNet` smoke run) for `EntityMapper.PopulateAttributeValues` before/after to validate the win.
+
+---
+
+## 7. Out of Scope (deferred)
+
+- Compiled property getters/setters (Phase 3 above — open if profiling justifies).
+- Eviction / TTL.
+- Cross-AppDomain / distributed sharing.
+- Replacing reflection inside source-generator-generated code (already compile-time).
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] `ReflectionCache` exists with the §3.2 API and §6 unit tests passing.
+- [ ] Tier 1 hotspots migrated; existing tests green.
+- [ ] No new external NuGet dependencies.
+- [ ] xmldoc on every public member, including the lazy-exception caching note.
+- [ ] Issue #151 description updated to reflect this design.

--- a/docs/PRD-ReflectionCache.md
+++ b/docs/PRD-ReflectionCache.md
@@ -2,13 +2,15 @@
 
 | | |
 |---|---|
-| **Version** | 1.0 |
+| **Version** | 1.1 |
 | **Date** | 2026-05-03 |
-| **Status** | Proposed |
+| **Status** | Implemented (PR #152) |
 | **Owner** | MintPlayer |
-| **Package** | `MintPlayer.Spark` |
+| **Package** | `MintPlayer.Spark.Abstractions` (promoted from `MintPlayer.Spark` so the messaging and replication-abstractions packages can consume it without a new dependency edge to `MintPlayer.Spark`) |
 | **Issue** | [#151](https://github.com/MintPlayer/MintPlayer.Spark/issues/151) |
 | **Reference** | `C:\Repos\CronosCore\CronosCore.RavenDB\ReferenceObject\ReflectionCache.cs` |
+
+> **v1.1** — design unchanged from v1.0. Implementation shipped in PR #152 includes Phase 3 (compiled accessor delegates) up-front; the Phase-2/Phase-3 split was collapsed at the user's request to ship comprehensive coverage in a single PR.
 
 ---
 
@@ -56,8 +58,11 @@ Spark performs the same reflection lookups repeatedly on hot request paths. None
 
 - **Eviction / TTL.** Reflection metadata is AppDomain-immutable; never evict.
 - **Cross-process / distributed cache.** In-process only.
-- **Compiled accessor delegates** (`Expression.Lambda` for getters/setters) are *not in initial scope* but the API must accommodate them as a pure consumer — i.e. caching `Func<object, object>` should be a one-liner from a caller, with no changes to `ReflectionCache` itself. (Tracked as a follow-up; see §7.)
-- **Replacing every reflection call site at once.** Audit-driven, tier-prioritized rollout.
+- **Replacing every reflection call site at once.** ~~Audit-driven, tier-prioritized rollout.~~ **Updated in v1.1**: comprehensive single-PR rollout (the user requested every reflection hotspot be migrated in this PR; see §4).
+
+### Goals expanded in v1.1
+
+- **Compiled accessor delegates included.** `AccessorCache.GetGetter(PropertyInfo) → Func<object, object?>` and `GetSetter → Action<object, object?>` build via `Expression.Lambda` and cache on top of `ReflectionCache`. Used by `EntityMapper.PopulateAttributeValues` (Tier 1 hot path) and the `task.GetType().GetProperty("Result").GetValue(task)` extraction pattern that recurs in 10+ reflective dispatch sites (folded into the `Task.GetCompletedTaskResult()` extension method).
 
 ---
 
@@ -175,28 +180,39 @@ Negative caching (caching `null`) falls out for free because `Lazy<object?>` hap
 
 ---
 
-## 4. Migration Plan
+## 4. Migration Plan (v1.1 — all phases shipped in PR #152)
 
-### Phase 1 — primitive + Tier 1 (this PR)
+### Phase 1 — primitive + Tier 1
 
-1. Add `MintPlayer.Spark/Reflection/ReflectionCache.cs` per §3.2.
-2. Migrate Tier 1 sites:
-   - `EntityMapper.PopulateAttributeValues` — cache `(Type, propertyName) → PropertyInfo`.
-   - `EntityMapper.GetEntityDisplayName` — cache `Type → PropertyInfo[]`.
-   - `EntityMapper.GetCollectionElementType` — cache `Type → Type?`.
-   - `ReferenceResolver.GetReferenceProperties` — cache `Type → (PropertyInfo, ReferenceAttribute)[]`.
-   - `ActionsResolver.FindActionsType` — cache `string → Type?`.
-3. Unit tests (see §6).
+1. `MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs` — three `GetOrAdd` overloads.
+2. `MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs` — compiled getter/setter delegates.
+3. `MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs` — `GetCachedProperties`, `GetCachedProperty`, `GetCachedCustomAttribute`, `GetCompletedTaskResult`.
+4. Tier 1 migrations: `EntityMapper.{PopulateAttributeValues, GetEntityDisplayName, ResolveDisplayFormat, GetCollectionElementType, IsComplexType, MergeTranslatedString, LoadReferenceAsync, ResolveType, TryWriteId, SetPropertyValue}`, `ReferenceResolver.{GetReferenceProperties, ApplyIncludes, LoadEntityAsync, ResolveReferencedDocumentsAsync}`, `ActionsResolver.{FindActionsType, ResolveForType}`.
 
-### Phase 2 — Tier 2 consolidation (follow-up)
+### Phase 2 — Tier 2 consolidation
 
-4. Replace `QueryExecutor.customQueryMethodCache` ad-hoc dictionary with `ReflectionCache.GetOrAdd<...>("custom-query:" + key, ...)`.
-5. Migrate `MessageBus.StoreMessageAsync` attribute lookup.
-6. Migrate `ModelSynchronizer` per-type attribute reads.
+5. `QueryExecutor` — replaces `customQueryMethodCache` ad-hoc dictionary with `ReflectionCache`; caches `ExtractQueryableElementType`, `FindClrType`, `MaterializeQueryable`, `ApplyIndexWithType`, `ApplyIndexByName`, `ApplyProjection`, `ApplySorting` per-(entity, property), `ExecuteQueryableAsync`.
+6. `MessageBus.StoreMessageAsync` — `GetCachedCustomAttribute<MessageQueueAttribute>`.
+7. `ModelSynchronizer` — `GetCachedProperties` and `GetCachedCustomAttribute` throughout, plus collection-element-type caching.
 
-### Phase 3 — compiled accessor delegates (follow-up, optional)
+### Phase 3 — compiled accessor delegates
 
-7. Add a separate `AccessorCache` static helper (consumes `ReflectionCache` — no changes to it) that builds and caches `Func<object, object>` getters / `Action<object, object>` setters via `Expression.Lambda` for properties read/written on hot paths (`EntityMapper.PopulateAttributeValues` is the prime candidate). Track separately; only ship if Phase 1 profiling shows getter/setter invocation is still hot after `PropertyInfo` lookups are cached.
+8. `AccessorCache.GetGetter` / `GetSetter` consumed by every property read/write previously calling `PropertyInfo.GetValue` / `SetValue` directly across `EntityMapper`, `ReferenceResolver`, `DatabaseAccess`, `SyncActionInterceptor`, `LookupReferenceService`, `LookupReferenceDiscoveryService`, `SyncAction`.
+
+### Phase 3.5 — comprehensive sweep across every remaining reflection site
+
+9. `DatabaseAccess` — caches all `IAsyncDocumentSession.LoadAsync<T>` / `Query<T>` (3-arg overload) / `LinqExtensions.ToListAsync<T>` / `LinqExtensions.ProjectInto<T>` generic-method instantiations; caches `OnLoadAsync`/`OnSaveAsync`/`OnQueryAsync`/`OnDeleteAsync`/`IsAllowedAsync` MethodInfos per actions type; caches `"Id"` PropertyInfo lookups.
+10. `SyncActionHandler` — same shape plus `GetCachedProperties` for the CLR-fallback property scan.
+11. `StreamingQueryExecutor` — replaces ad-hoc `streamingMethodCache`; caches `IAsyncEnumerator<T>.GetAsyncEnumerator`/`MoveNextAsync`/`Current` member-info per `(elementType, isSingleItem)`; caches `FindClrType`.
+12. `LookupReferenceService` / `LookupReferenceDiscoveryService` — caches static `Items` PropertyInfo per transient type, `DisplayType` lookup, transient-item per-property reads.
+13. `SparkMiddleware` — caches `Assembly.GetTypes()` filtered scans for index types and `[FromIndex]` projection types per assembly.
+14. `Endpoints/ProgramUnits/Get` — `GetCachedProperties` for the per-request SparkContext walk.
+15. `IndexRegistry.GetCollectionTypeFromIndex` — caches the base-type traversal per index type.
+16. `SyncActionInterceptor` — replaces `_replicatedCache` and `_propertyNamesCache` ad-hoc `ConcurrentDictionary`s with `ReflectionCache`.
+17. `EtlScriptCollector` — caches the per-assembly `[Replicated]`-annotated type scan.
+18. `MessageSubscriptionWorker` — caches `IRecipient<T>`/`ICheckpointRecipient<T>` closed generic types and their `HandleAsync` MethodInfos per CLR message type.
+19. `MessageSubscriptionManager` — `GetCachedCustomAttribute` for `[MessageQueue]` discovery.
+20. `SyncAction.EntityToDictionary` (Replication.Abstractions) — `GetCachedProperties` + `AccessorCache.GetGetter`. Required adding a project reference from `MintPlayer.Spark.Replication.Abstractions` to `MintPlayer.Spark.Abstractions`.
 
 ---
 
@@ -208,10 +224,14 @@ Negative caching (caching `null`) falls out for free because `Lazy<object?>` hap
 - **Stale cache during hot reload.** .NET hot reload can replace types. Out of scope; if it bites, add a `MetadataUpdateHandler` later.
 - **Lazy factory exceptions.** A throwing factory under `ExecutionAndPublication` caches the *exception* and re-throws on every subsequent access. This is the correct behavior — a reflection lookup that fails will fail deterministically — but document it in xmldoc.
 
-### Open questions
+### Open questions (resolved in v1.1)
 
-1. Should the cache live in `MintPlayer.Spark` or `MintPlayer.Spark.Abstractions`? **Recommendation:** `MintPlayer.Spark/Reflection/` for now — no abstraction needed; it's a static helper, not a service. Promote later if multiple packages need it.
-2. Diagnostic counters — emit anything via `Activity` / `Metrics`? **Recommendation:** no, defer until a real ask.
+1. ~~Should the cache live in `MintPlayer.Spark` or `MintPlayer.Spark.Abstractions`?~~ **Resolved**: lives in `MintPlayer.Spark.Abstractions/Reflection/`. Required because both `MintPlayer.Spark.Messaging` and `MintPlayer.Spark.Replication.Abstractions` need it and neither references `MintPlayer.Spark`.
+2. ~~Diagnostic counters — emit anything via `Activity` / `Metrics`?~~ **Deferred**, no real ask yet.
+
+### New footgun caught during implementation
+
+The original `GetOrAdd<TValue>(Type, Func<Type, TValue>)` overload used a `ConcurrentDictionary<Type, Lazy<object?>>` keyed only on `Type`. Two call sites that cache different things per Type (e.g. `MethodInfo` for `LoadAsync<T>` vs `Type?` for "collection element type of T") would have collided and hit `InvalidCastException` at the boundary. The cache key is now `(Type, ValueType)` — the value type is included automatically, so distinct `TValue` parameters never collide. Pinned by `GetOrAdd_type_keyed_isolates_distinct_value_types_for_same_Type` in `ReflectionCacheTests`.
 
 ---
 
@@ -227,19 +247,21 @@ Negative caching (caching `null`) falls out for free because `Lazy<object?>` hap
 
 ---
 
-## 7. Out of Scope (deferred)
+## 7. Out of Scope (still deferred in v1.1)
 
-- Compiled property getters/setters (Phase 3 above — open if profiling justifies).
-- Eviction / TTL.
+- Eviction / TTL — reflection metadata is AppDomain-immutable; never evict.
 - Cross-AppDomain / distributed sharing.
 - Replacing reflection inside source-generator-generated code (already compile-time).
+- Caching dynamic CLR-name resolutions (`ResolveType(string)` etc.) does cache *negative* results too. Spark's runtime doesn't dynamically load entity-type assemblies after startup, so a stale-null cached entry on a late-loaded assembly is a non-issue today; if hot reload becomes a target, revisit `ResolveType` with positive-only caching.
 
 ---
 
 ## 8. Acceptance Criteria
 
-- [ ] `ReflectionCache` exists with the §3.2 API and §6 unit tests passing.
-- [ ] Tier 1 hotspots migrated; existing tests green.
-- [ ] No new external NuGet dependencies.
-- [ ] xmldoc on every public member, including the lazy-exception caching note.
-- [ ] Issue #151 description updated to reflect this design.
+- [x] `ReflectionCache` exists with the §3.2 API and §6 unit tests passing (18 tests across `ReflectionCacheTests` + `AccessorCacheTests` + `ReflectedTypeExtensionsTests`).
+- [x] Tier 1 hotspots migrated; existing tests green (783 / 783 pass).
+- [x] Tier 2 ad-hoc caches consolidated.
+- [x] Tier 3 sweep across every remaining reflection call site.
+- [x] No new external NuGet dependencies.
+- [x] xmldoc on every public member, including the lazy-exception caching note and the `(Type, TValue)` collision note.
+- [x] Issue #151 description updated to reflect this design.

--- a/node_packages/ng-spark/query-list/src/spark-query-list.component.ts
+++ b/node_packages/ng-spark/query-list/src/spark-query-list.component.ts
@@ -93,6 +93,14 @@ export class SparkQueryListComponent {
   }
 
   private async onParamsChange(params: any): Promise<void> {
+    // Reset prior-route state so we render the spinner (not stale rows from
+    // the previous query) while the new query/entityType resolve.
+    this.entityType.set(null);
+    this.paginationData.set(undefined);
+    this.virtualDataSource.set(null);
+    this.allItems.set([]);
+    this.disconnectStreaming();
+
     const queryId = params.get('queryId');
     const typeParam = params.get('type');
 


### PR DESCRIPTION
Implements the ReflectionCache primitive from #151 and migrates every reflective hot path in the framework over to it.

## What's in this PR

- `MintPlayer.Spark.Abstractions/Reflection/ReflectionCache.cs` — generic memoization primitive (per-type, global-string, type-keyed tiers). `ConcurrentDictionary<TKey, Lazy<TValue>>` with `LazyThreadSafetyMode.ExecutionAndPublication`: lock-free reads, factory-runs-once-per-key.
- `MintPlayer.Spark.Abstractions/Reflection/AccessorCache.cs` — compiled `Expression.Lambda` getters/setters keyed on `PropertyInfo`. Replaces `PropertyInfo.GetValue/SetValue` in hot paths.
- `MintPlayer.Spark.Abstractions/Reflection/ReflectedTypeExtensions.cs` — `GetCachedProperty`, `GetCachedProperties`, `GetCachedCustomAttribute<T>`, `GetCompletedTaskResult`.
- `docs/PRD-ReflectionCache.md` — design doc (v1.1, marked implemented).

## Migrated call sites

- **Tier 1** — `EntityMapper.{PopulateAttributeValues, PopulateObjectValues, GetEntityDisplayName, GetCollectionElementType, ResolveType}`, `ReferenceResolver.GetReferenceProperties + ApplyIncludes + ResolveReferencedDocumentsAsync`, `ActionsResolver.FindActionsType`.
- **Tier 2** — `QueryExecutor.customQueryMethodCache` consolidated, `MessageBus`/`MessageSubscriptionWorker` attribute reads, `ModelSynchronizer`.
- **Tier 3** — `DatabaseAccess`, `SyncActionHandler`, `IndexRegistry`, `LookupReferenceDiscoveryService`, `LookupReferenceService`, `StreamingQueryExecutor`, `EtlScriptCollector`, `SyncActionInterceptor`, `SparkMiddleware`, `Endpoints/ProgramUnits/Get`.

## Test coverage

- **Unit:** `ReflectionCacheTests` (18 facts), `AccessorCacheTests`, `ReflectedTypeExtensionsTests` — pin factory-runs-once, isolation, null caching, exception caching, type-keyed value-type discriminator, ArgumentNullException guards, value-type round-trip.
- **Integration:** `EntityMapperDisplayNameTests`, `ReferenceResolverTests`, `ActionsResolverTests`, `DatabaseAccessIntegrationTests`, `QueryExecutorAdvancedIntegrationTests`, `SyncActionHandlerIntegrationTests`, `EtlTaskManagerTests` — exercise migrated paths end-to-end against an embedded RavenDB.
- All tests pass under `nx test` (.NET + Angular).

## Out of scope / noted in code

- Global string-keyed tier shares one keyspace across the process. Callers prefix their keys (`prop|`, `attr|`, `set|`, `get|`, `resolveType|`, `sessionLoadAsync|`); convention is now documented in `ReflectionCache.cs`.
- String-keyed property/accessor caches use `Type.FullName ?? Type.Name`. For Spark's single-AssemblyLoadContext usage this is fine; a follow-up could swap to `(Type, string)`-tuple keys to eliminate the theoretical collision when two assemblies declare the same FullName.

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)