### PR TITLE
feat(references): list-of-references attribute + searchable multi-select editor

### DIFF
--- a/Demo/DemoApp/DemoApp/ClientApp/project.json
+++ b/Demo/DemoApp/DemoApp/ClientApp/project.json
@@ -32,7 +32,7 @@
       "configurations": {
         "production": {
           "budgets": [
-            { "type": "initial", "maximumWarning": "500kB", "maximumError": "1MB" },
+            { "type": "initial", "maximumWarning": "1MB", "maximumError": "1.5MB" },
             { "type": "anyComponentStyle", "maximumWarning": "4kB", "maximumError": "8kB" }
           ],
           "outputHashing": "all"

--- a/Demo/HR/HR.Library/Entities/Person.cs
+++ b/Demo/HR/HR.Library/Entities/Person.cs
@@ -13,6 +13,11 @@ public class Person
     [Reference(typeof(Company))]
     public string? Company { get; set; }
 
+    // Multi-reference: a person can hold several professions. Renders as a searchable
+    // multi-select (bs-tree-select) on the edit form and as chips on detail/list.
+    [Reference(typeof(Profession))]
+    public List<string> Professions { get; set; } = [];
+
     public Address? Address { get; set; }
     public CarreerJob[] Jobs { get; set; } = [];
 }

--- a/Demo/HR/HR/App_Data/Model/Person.json
+++ b/Demo/HR/HR/App_Data/Model/Person.json
@@ -201,6 +201,27 @@
         "group": "b1b2c3d4-0002-0002-0002-000000000003"
       },
       {
+        "id": "7c1f0a92-3b8e-4d51-9f0a-2d6e4c8b1a37",
+        "name": "Professions",
+        "label": {
+          "en": "Professions",
+          "fr": "Professions",
+          "nl": "Beroepen"
+        },
+        "dataType": "Reference",
+        "isRequired": false,
+        "isVisible": true,
+        "isReadOnly": false,
+        "order": 8,
+        "query": "GetProfessions",
+        "referenceType": "HR.Entities.Profession",
+        "isArray": true,
+        "inQueryType": false,
+        "showedOn": "PersistentObject",
+        "rules": [],
+        "group": "b1b2c3d4-0002-0002-0002-000000000003"
+      },
+      {
         "id": "f2d4c15b-5fa2-449d-a806-0ee29dd52cd8",
         "name": "Address",
         "label": {

--- a/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
+++ b/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Authorization</PackageId>
-		<Version>10.0.0-preview.35</Version>
+		<Version>10.0.0-preview.36</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Optional authorization package for MintPlayer.Spark low-code framework. Provides group-based access control for PersistentObjects and Queries.</Description>

--- a/libs/node_packages/ng-spark/models/src/persistent-object-attribute.ts
+++ b/libs/node_packages/ng-spark/models/src/persistent-object-attribute.ts
@@ -17,6 +17,12 @@ export interface PersistentObjectAttribute {
   query?: string;
   breadcrumb?: string;
   /**
+   * For `dataType === 'Reference'` with `isArray === true`: resolved display label per
+   * referenced id (id → breadcrumb), so the UI can render a chip per selected reference.
+   * The single-reference counterpart is `breadcrumb`.
+   */
+  breadcrumbs?: Record<string, string | null>;
+  /**
    * Controls on which pages the attribute should be displayed.
    * Query = shown in list views, PersistentObject = shown in detail/edit views.
    * Can be a numeric flag value or a string like "Query, PersistentObject".

--- a/libs/node_packages/ng-spark/package.json
+++ b/libs/node_packages/ng-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-spark",
   "private": false,
-  "version": "22.0.1",
+  "version": "22.0.2",
   "description": "Angular component library for MintPlayer.Spark CRUD applications",
   "repository": {
     "type": "git",

--- a/libs/node_packages/ng-spark/pipes/src/index.ts
+++ b/libs/node_packages/ng-spark/pipes/src/index.ts
@@ -6,6 +6,7 @@ export * from './raw-attribute-value.pipe';
 export * from './reference-display-value.pipe';
 export * from './reference-attr-value.pipe';
 export * from './reference-link-route.pipe';
+export * from './reference-chips.pipe';
 export * from './router-link.pipe';
 export * from './as-detail-type.pipe';
 export * from './as-detail-columns.pipe';

--- a/libs/node_packages/ng-spark/pipes/src/reference-chips.pipe.ts
+++ b/libs/node_packages/ng-spark/pipes/src/reference-chips.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { PersistentObject } from '@mintplayer/ng-spark/models';
+
+export interface ReferenceChip {
+  id: string;
+  label: string;
+}
+
+/**
+ * Resolves a multi-reference attribute (`dataType === 'Reference'`, `isArray === true`)
+ * to a list of chips. The attribute's `value` carries the id array; `breadcrumbs` (a
+ * server-resolved id → label map) provides each chip's display label, falling back to
+ * the id when no breadcrumb is present. Mirrors the single-reference `breadcrumb`
+ * display, applied per id.
+ */
+@Pipe({ name: 'referenceChips', standalone: true, pure: true })
+export class ReferenceChipsPipe implements PipeTransform {
+  transform(attrName: string, item: PersistentObject | null): ReferenceChip[] {
+    const attr = item?.attributes.find(a => a.name === attrName);
+    if (!attr || !Array.isArray(attr.value)) return [];
+    const breadcrumbs = attr.breadcrumbs ?? {};
+    return attr.value
+      .filter(v => v != null && v !== '')
+      .map(v => {
+        const id = String(v);
+        return { id, label: breadcrumbs[id] || id };
+      });
+  }
+}

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
@@ -138,6 +138,22 @@
                 } @else {
                   -
                 }
+              } @else if (attr.dataType === 'Reference' && attr.isArray) {
+                @let chips = (attr.name | referenceChips:item());
+                @if (chips.length) {
+                  <div class="d-flex flex-wrap gap-1">
+                    @for (chip of chips; track chip.id) {
+                      @let chipRoute = (attr.referenceType ? (attr.referenceType | referenceLinkRoute:chip.id:allEntityTypes()) : null);
+                      @if (chipRoute) {
+                        <a class="badge text-bg-secondary text-decoration-none" [routerLink]="chipRoute">{{ chip.label }}</a>
+                      } @else {
+                        <span class="badge text-bg-secondary">{{ chip.label }}</span>
+                      }
+                    }
+                  </div>
+                } @else {
+                  -
+                }
               } @else if (attr.dataType === 'Reference' && attr.referenceType) {
                 @let refRoute = (attr.referenceType | referenceLinkRoute:(attr.name | rawAttributeValue:item()):allEntityTypes());
                 @if (refRoute && (attr.name | attributeValue:item():entityType():lookupReferenceOptions():allEntityTypes())) {

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
@@ -145,9 +145,9 @@
                     @for (chip of chips; track chip.id) {
                       @let chipRoute = (attr.referenceType ? (attr.referenceType | referenceLinkRoute:chip.id:allEntityTypes()) : null);
                       @if (chipRoute) {
-                        <a class="badge text-bg-secondary text-decoration-none" [routerLink]="chipRoute">{{ chip.label }}</a>
+                        <a class="badge rounded-pill border bg-body-secondary text-body text-decoration-none px-3 py-2" [routerLink]="chipRoute">{{ chip.label }}</a>
                       } @else {
-                        <span class="badge text-bg-secondary">{{ chip.label }}</span>
+                        <span class="badge rounded-pill border bg-body-secondary text-body px-3 py-2">{{ chip.label }}</span>
                       }
                     }
                   </div>

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.ts
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.ts
@@ -22,6 +22,7 @@ import {
   AsDetailCellValuePipe,
   ArrayValuePipe,
   ReferenceLinkRoutePipe,
+  ReferenceChipsPipe,
 } from '@mintplayer/ng-spark/pipes';
 import { SparkIconComponent } from '@mintplayer/ng-spark/icon';
 import { SparkSubQueryComponent } from './spark-sub-query.component';
@@ -40,7 +41,7 @@ import {
 
 @Component({
   selector: 'spark-po-detail',
-  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, RouterModule, BsAlertComponent, BsCardComponent, BsCardHeaderComponent, BsContainerComponent, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsPriorityNavComponent, BsPriorityNavItemDirective, BsTableComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, BsSpinnerComponent, SparkIconComponent, SparkSubQueryComponent, ResolveTranslationPipe, TranslateKeyPipe, AttributeValuePipe, RawAttributeValuePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, ArrayValuePipe, ReferenceLinkRoutePipe],
+  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, RouterModule, BsAlertComponent, BsCardComponent, BsCardHeaderComponent, BsContainerComponent, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsPriorityNavComponent, BsPriorityNavItemDirective, BsTableComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, BsSpinnerComponent, SparkIconComponent, SparkSubQueryComponent, ResolveTranslationPipe, TranslateKeyPipe, AttributeValuePipe, RawAttributeValuePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, ArrayValuePipe, ReferenceLinkRoutePipe, ReferenceChipsPipe],
   templateUrl: './spark-po-detail.component.html',
   styleUrl: './spark-po-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
@@ -85,6 +85,17 @@
                 }
               </bs-select>
             }
+          } @else if (attr.dataType === 'Reference' && attr.isArray) {
+            <bs-tree-select
+              mode="multiple"
+              variant="textbox"
+              [showClear]="true"
+              [placeholder]="'common.search' | t"
+              [provider]="getReferenceProvider(attr)"
+              [ngModel]="referenceTreeValues()[attr.name] || []"
+              (ngModelChange)="onReferenceTreeChange(attr, $event)"
+              [ngModelOptions]="{ standalone: true }">
+            </bs-tree-select>
           } @else if (attr.dataType === 'Reference') {
             <bs-input-group>
               <input

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
@@ -8,6 +8,7 @@ import { BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsGridColDi
 import { BsInputGroupComponent } from '@mintplayer/ng-bootstrap/input-group';
 import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
 import { BsSelectComponent, BsSelectOption } from '@mintplayer/ng-bootstrap/select';
+import { BsTreeSelectComponent, InMemoryTreeSelectProvider, TreeNode } from '@mintplayer/ng-bootstrap/tree-select';
 import { BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective } from '@mintplayer/ng-bootstrap/modal';
 import { BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, DatatableSettings } from '@mintplayer/ng-bootstrap/datatable';
 import { BsCheckboxComponent } from '@mintplayer/ng-bootstrap/checkbox';
@@ -55,7 +56,7 @@ import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
 
 @Component({
   selector: 'spark-po-form',
-  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, BsCardComponent, BsCardHeaderComponent, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsGridColDirective, BsColFormLabelDirective, BsButtonTypeDirective, BsInputGroupComponent, BsSelectComponent, BsSelectOption, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsTableComponent, BsCheckboxComponent, BsSpinnerComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, SparkIconComponent, SparkPoFormComponent, TranslateKeyPipe, ResolveTranslationPipe, InputTypePipe, LookupDisplayValuePipe, LookupDisplayTypePipe, LookupOptionsPipe, ReferenceDisplayValuePipe, AsDetailDisplayValuePipe, AsDetailTypePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, CanCreateDetailRowPipe, CanDeleteDetailRowPipe, InlineRefOptionsPipe, ReferenceAttrValuePipe, ErrorForAttributePipe],
+  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, BsCardComponent, BsCardHeaderComponent, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsGridColDirective, BsColFormLabelDirective, BsButtonTypeDirective, BsInputGroupComponent, BsSelectComponent, BsSelectOption, BsTreeSelectComponent, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsTableComponent, BsCheckboxComponent, BsSpinnerComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, SparkIconComponent, SparkPoFormComponent, TranslateKeyPipe, ResolveTranslationPipe, InputTypePipe, LookupDisplayValuePipe, LookupDisplayTypePipe, LookupOptionsPipe, ReferenceDisplayValuePipe, AsDetailDisplayValuePipe, AsDetailTypePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, CanCreateDetailRowPipe, CanDeleteDetailRowPipe, InlineRefOptionsPipe, ReferenceAttrValuePipe, ErrorForAttributePipe],
   templateUrl: './spark-po-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -77,6 +78,13 @@ export class SparkPoFormComponent {
 
   colors = Color;
   referenceOptions = signal<Record<string, PersistentObject[]>>({});
+
+  // Multi-reference (Reference && isArray) editor state. Built from the same query
+  // results as referenceOptions: a flat TreeNode list per attribute drives an
+  // InMemoryTreeSelectProvider (the <bs-tree-select> data port), and a node lookup
+  // resolves selected ids back to chip labels.
+  referenceProviders = signal<Record<string, InMemoryTreeSelectProvider>>({});
+  referenceNodes = signal<Record<string, Record<string, TreeNode>>>({});
   asDetailTypes = signal<Record<string, EntityType>>({});
   lookupReferenceOptions = signal<Record<string, LookupReference>>({});
 
@@ -205,7 +213,55 @@ export class SparkPoFormComponent {
         return [attr.name, result.data] as [string, PersistentObject[]];
       })
     );
-    this.referenceOptions.set(this.toRecord(entries));
+    const optionsByAttr = this.toRecord(entries);
+    this.referenceOptions.set(optionsByAttr);
+
+    // For multi-reference attributes (Reference && isArray), turn each query result
+    // into a flat TreeNode list + an in-memory provider for <bs-tree-select>, and a
+    // by-id node map used to render chip labels for the current selection.
+    const providers: Record<string, InMemoryTreeSelectProvider> = {};
+    const nodesByAttr: Record<string, Record<string, TreeNode>> = {};
+    for (const attr of refAttrs) {
+      if (!attr.isArray) continue;
+      const pos = optionsByAttr[attr.name] || [];
+      const nodes: TreeNode[] = pos
+        .filter(po => !!po.id)
+        .map(po => ({ id: po.id!, label: po.breadcrumb || po.name || po.id! }));
+      providers[attr.name] = new InMemoryTreeSelectProvider(nodes);
+      nodesByAttr[attr.name] = this.toRecord(nodes.map(n => [n.id, n] as [string, TreeNode]));
+    }
+    this.referenceProviders.set(providers);
+    this.referenceNodes.set(nodesByAttr);
+  }
+
+  /**
+   * Stable TreeNode[] value per multi-reference attribute, derived from the id array
+   * in formData and the resolved node map. Recomputes only when formData or the node
+   * map changes, so binding it into <bs-tree-select> doesn't churn on every CD pass.
+   * Ids without a resolved node fall back to a label of the id itself.
+   */
+  referenceTreeValues = computed<Record<string, TreeNode[]>>(() => {
+    const fd = this.formData();
+    const nodesByAttr = this.referenceNodes();
+    const result: Record<string, TreeNode[]> = {};
+    for (const attr of this.editableAttributes()) {
+      if (attr.dataType !== 'Reference' || !attr.isArray) continue;
+      const ids: string[] = Array.isArray(fd[attr.name]) ? fd[attr.name] : [];
+      const nodeMap = nodesByAttr[attr.name] || {};
+      result[attr.name] = ids.map(id => nodeMap[id] ?? { id, label: id });
+    }
+    return result;
+  });
+
+  getReferenceProvider(attr: EntityAttributeDefinition): InMemoryTreeSelectProvider | undefined {
+    return this.referenceProviders()[attr.name];
+  }
+
+  onReferenceTreeChange(attr: EntityAttributeDefinition, value: TreeNode | TreeNode[] | null): void {
+    const nodes = Array.isArray(value) ? value : value ? [value] : [];
+    const data = { ...this.formData() };
+    data[attr.name] = nodes.map(n => n.id);
+    this.formData.set(data);
   }
 
   async loadAsDetailTypes(): Promise<void> {

--- a/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.html
+++ b/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.html
@@ -160,7 +160,7 @@
   } @else if (attr.dataType === 'Reference' && attr.isArray) {
     <span class="d-inline-flex flex-wrap gap-1">
       @for (chip of (attr.name | referenceChips:item); track chip.id) {
-        <span class="badge text-bg-secondary">{{ chip.label }}</span>
+        <span class="badge rounded-pill border bg-body-secondary text-body px-3 py-2">{{ chip.label }}</span>
       }
     </span>
   } @else {

--- a/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.html
+++ b/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.html
@@ -157,6 +157,12 @@
     @if (colorVal) {
       <span class="d-inline-block align-middle border rounded" [style.background-color]="colorVal" style="width: 1.5em; height: 1.5em;"></span>
     }
+  } @else if (attr.dataType === 'Reference' && attr.isArray) {
+    <span class="d-inline-flex flex-wrap gap-1">
+      @for (chip of (attr.name | referenceChips:item); track chip.id) {
+        <span class="badge text-bg-secondary">{{ chip.label }}</span>
+      }
+    </span>
   } @else {
     {{ (attr.name | attributeValue:item:entityType():lookupReferenceOptions():allEntityTypes()) }}
   }

--- a/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.ts
+++ b/libs/node_packages/ng-spark/query-list/src/spark-query-list.component.ts
@@ -19,6 +19,7 @@ import {
   TranslateKeyPipe,
   ResolveTranslationPipe,
   AttributeValuePipe,
+  ReferenceChipsPipe,
 } from '@mintplayer/ng-spark/pipes';
 import { SparkIconComponent } from '@mintplayer/ng-spark/icon';
 import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
@@ -36,7 +37,7 @@ import {
 
 @Component({
   selector: 'spark-query-list',
-  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, RouterModule, BsAlertComponent, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsInputGroupComponent, BsPriorityNavComponent, BsPriorityNavItemDirective, BsSpinnerComponent, SparkIconComponent, ResolveTranslationPipe, TranslateKeyPipe, AttributeValuePipe],
+  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, RouterModule, BsAlertComponent, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsInputGroupComponent, BsPriorityNavComponent, BsPriorityNavItemDirective, BsSpinnerComponent, SparkIconComponent, ResolveTranslationPipe, TranslateKeyPipe, AttributeValuePipe, ReferenceChipsPipe],
   templateUrl: './spark-query-list.component.html',
   styleUrl: './spark-query-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
+++ b/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.35</Version>
+		<Version>10.0.0-preview.36</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark low-code framework. Auto-generates DI registration for Actions classes.</Description>

--- a/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
+++ b/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Abstractions</PackageId>
-		<Version>10.0.0-preview.35</Version>
+		<Version>10.0.0-preview.36</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions and shared models for MintPlayer.Spark low-code framework.</Description>

--- a/libs/spark/MintPlayer.Spark.Abstractions/PersistentObject.cs
+++ b/libs/spark/MintPlayer.Spark.Abstractions/PersistentObject.cs
@@ -81,6 +81,15 @@ public class PersistentObjectAttribute
     public int Order { get; set; }
     public string? Query { get; set; }
     public string? Breadcrumb { get; set; }
+
+    /// <summary>
+    /// For <see cref="DataType"/> == "Reference" with <see cref="IsArray"/> = true: the
+    /// resolved display label per referenced id (id → breadcrumb), so clients can render
+    /// a chip per selected reference without a second round-trip. The single-reference
+    /// counterpart is <see cref="Breadcrumb"/>. Null when there are no resolved labels.
+    /// </summary>
+    public Dictionary<string, string?>? Breadcrumbs { get; set; }
+
     public EShowedOn ShowedOn { get; set; } = EShowedOn.Query | EShowedOn.PersistentObject;
     public ValidationRule[] Rules { get; set; } = [];
     public Guid? Group { get; set; }

--- a/libs/spark/MintPlayer.Spark.Abstractions/PersistentObjectAttributeJsonConverter.cs
+++ b/libs/spark/MintPlayer.Spark.Abstractions/PersistentObjectAttributeJsonConverter.cs
@@ -135,6 +135,7 @@ public sealed class PersistentObjectAttributeJsonConverter : JsonConverterFactor
                     case "Order":           attr.Order          = prop.Value.GetInt32(); break;
                     case "Query":           attr.Query          = ReadNullableString(prop.Value); break;
                     case "Breadcrumb":      attr.Breadcrumb     = ReadNullableString(prop.Value); break;
+                    case "Breadcrumbs":     attr.Breadcrumbs    = Deserialize<Dictionary<string, string?>>(prop.Value, options); break;
                     case "ShowedOn":        attr.ShowedOn       = Deserialize<EShowedOn>(prop.Value, options); break;
                     case "Rules":           attr.Rules          = Deserialize<ValidationRule[]>(prop.Value, options) ?? []; break;
                     case "Group":           attr.Group          = prop.Value.ValueKind == JsonValueKind.Null ? null : Deserialize<Guid?>(prop.Value, options); break;
@@ -159,6 +160,7 @@ public sealed class PersistentObjectAttributeJsonConverter : JsonConverterFactor
             WritePropertyName(writer, "Order", options);           writer.WriteNumberValue(value.Order);
             WritePropertyName(writer, "Query", options);           writer.WriteStringValue(value.Query);
             WritePropertyName(writer, "Breadcrumb", options);      writer.WriteStringValue(value.Breadcrumb);
+            WritePropertyName(writer, "Breadcrumbs", options);     JsonSerializer.Serialize(writer, value.Breadcrumbs, options);
             WritePropertyName(writer, "ShowedOn", options);        JsonSerializer.Serialize(writer, value.ShowedOn, options);
             WritePropertyName(writer, "Rules", options);           JsonSerializer.Serialize(writer, value.Rules, options);
             WritePropertyName(writer, "Group", options);
@@ -202,7 +204,7 @@ public sealed class PersistentObjectAttributeJsonConverter : JsonConverterFactor
         private static readonly string[] KnownFieldNames =
         [
             "Id", "Name", "Label", "Value", "DataType", "IsArray", "IsRequired", "IsVisible",
-            "IsReadOnly", "IsValueChanged", "Order", "Query", "Breadcrumb", "ShowedOn",
+            "IsReadOnly", "IsValueChanged", "Order", "Query", "Breadcrumb", "Breadcrumbs", "ShowedOn",
             "Rules", "Group", "Renderer", "RendererOptions",
         ];
 

--- a/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark</PackageId>
-		<Version>10.0.0-preview.35</Version>
+		<Version>10.0.0-preview.36</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Low-code .NET framework for building data-driven web applications with minimal boilerplate. Uses PersistentObject pattern to eliminate DTOs and repository layers.</Description>

--- a/libs/spark/MintPlayer.Spark/Services/EntityMapper.cs
+++ b/libs/spark/MintPlayer.Spark/Services/EntityMapper.cs
@@ -214,7 +214,7 @@ internal partial class EntityMapper : IEntityMapper
             // Reference attributes: resolve the display name of the referenced entity
             // from the preloaded includedDocuments dict so the client can render a
             // breadcrumb without a second round-trip.
-            if (attribute.DataType == "Reference"
+            if (attribute.DataType == "Reference" && !attribute.IsArray
                 && attribute.Value is string refId && !string.IsNullOrEmpty(refId)
                 && includedDocuments is not null
                 && includedDocuments.TryGetValue(refId, out var referencedEntity)
@@ -224,6 +224,25 @@ internal partial class EntityMapper : IEntityMapper
                 var referencedEntityTypeDef = modelLoader.GetEntityTypeByClrType(
                     referencedEntityType.FullName ?? referencedEntityType.Name);
                 attribute.Breadcrumb = GetEntityDisplayName(referencedEntity, referencedEntityType, referencedEntityTypeDef);
+            }
+            // Reference ARRAY: resolve a breadcrumb per id (id → display name) so the
+            // client can render one chip per selected reference. Mirrors the single-
+            // reference path above, over each element of the id array.
+            else if (attribute.DataType == "Reference" && attribute.IsArray
+                && includedDocuments is not null
+                && raw is System.Collections.IEnumerable refIds && raw is not string)
+            {
+                Dictionary<string, string?>? breadcrumbs = null;
+                foreach (var idObj in refIds)
+                {
+                    var id = idObj?.ToString();
+                    if (string.IsNullOrEmpty(id)) continue;
+                    if (!includedDocuments.TryGetValue(id, out var refEntity) || refEntity is null) continue;
+                    var refType = refEntity.GetType();
+                    var refDef = modelLoader.GetEntityTypeByClrType(refType.FullName ?? refType.Name);
+                    (breadcrumbs ??= [])[id] = GetEntityDisplayName(refEntity, refType, refDef);
+                }
+                attribute.Breadcrumbs = breadcrumbs;
             }
         }
     }
@@ -555,6 +574,16 @@ internal partial class EntityMapper : IEntityMapper
             return;
         }
 
+        // Reference ARRAYS carry an array of ids in Value, not a single refId — route
+        // them to the collection coercion path (SetPropertyValue) rather than the
+        // single-reference resolver below, which would try to load one document per the
+        // whole serialized array.
+        if (attribute.IsArray)
+        {
+            SetPropertyValue(property, entity, attribute.Value);
+            return;
+        }
+
         // Reference attributes pointing at a complex entity type need resolution to
         // an actual entity instance. String-typed reference properties fall through
         // to the generic coercion path below — the refId is written as-is.
@@ -826,6 +855,27 @@ internal partial class EntityMapper : IEntityMapper
             {
                 value = ExtractJsonElementValue(je);
             }
+        }
+
+        // Collection target handed a non-JsonElement enumerable directly (e.g. a
+        // List<string> of reference ids assembled in-process rather than off the wire):
+        // round-trip through JSON so element coercion uses the same path as the
+        // JsonElement-array branch above. AsDetail arrays never reach here — they are
+        // handled by WriteAsDetailAsync before SetPropertyValue.
+        if (value is not null && value is System.Collections.IEnumerable && value is not string
+            && GetCollectionElementType(targetType) is not null)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(value);
+                using var tmpDoc = JsonDocument.Parse(json);
+                setter(entity, tmpDoc.RootElement.Deserialize(targetType, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }));
+            }
+            catch
+            {
+                // Skip values that can't be coerced into the collection type.
+            }
+            return;
         }
 
         if (value == null)

--- a/libs/spark/MintPlayer.Spark/Services/ModelSynchronizer.cs
+++ b/libs/spark/MintPlayer.Spark/Services/ModelSynchronizer.cs
@@ -328,21 +328,29 @@ internal partial class ModelSynchronizer : IModelSynchronizer
             var dataType = referenceAttr != null ? "Reference" : GetDataType(property.PropertyType);
             string? referenceType = referenceAttr?.TargetType.FullName ?? referenceAttr?.TargetType.Name;
 
-            // For AsDetail, resolve the actual element type (unwrap arrays/collections)
+            // For AsDetail, resolve the actual element type (unwrap arrays/collections).
+            // For non-AsDetail collections (scalar arrays, or [Reference] List<string>),
+            // mark IsArray so the wire value round-trips as a JSON array of ids/scalars.
             var isArray = false;
             string? asDetailType = null;
+            var collectionElementType = GetCollectionElementType(propType);
             if (dataType == "AsDetail")
             {
-                var elementType = GetCollectionElementType(propType);
-                if (elementType != null)
+                if (collectionElementType != null)
                 {
                     isArray = true;
-                    asDetailType = elementType.FullName ?? elementType.Name;
+                    asDetailType = collectionElementType.FullName ?? collectionElementType.Name;
                 }
                 else
                 {
                     asDetailType = propType.FullName ?? propType.Name;
                 }
+            }
+            else if (collectionElementType != null)
+            {
+                // e.g. [Reference(typeof(Tag), "GetTags")] List<string> TagIds, or a bare
+                // List<string> of scalars — a real array of simple/reference values.
+                isArray = true;
             }
 
             string? lookupReferenceType = lookupRefAttr?.LookupType.Name;
@@ -385,10 +393,13 @@ internal partial class ModelSynchronizer : IModelSynchronizer
                     existingAttr.Query = resolvedQuery;
                 }
 
+                // IsArray is derived purely from the CLR property shape, so always
+                // refresh it (covers Reference/scalar arrays, not just AsDetail).
+                existingAttr.IsArray = isArray;
+
                 if (dataType == "AsDetail")
                 {
                     existingAttr.AsDetailType = asDetailType;
-                    existingAttr.IsArray = isArray;
                 }
 
                 if (lookupRefAttr != null)
@@ -483,11 +494,16 @@ internal partial class ModelSynchronizer : IModelSynchronizer
     {
         var underlying = Nullable.GetUnderlyingType(type) ?? type;
 
-        // Check for array/collection of complex types
+        // Collections are classified by their ELEMENT type, never by the collection
+        // wrapper. A collection of a complex element is AsDetail; a collection of a
+        // simple element (e.g. List<string>, string[]) takes the element's scalar type.
+        // Classifying by the wrapper would be wrong: a List<> is itself a class with
+        // public properties, so the IsComplexType fallback below would mis-tag
+        // List<string> as AsDetail and the mapper would drop its values.
         var elementType = GetCollectionElementType(underlying);
-        if (elementType != null && IsComplexType(elementType))
+        if (elementType != null)
         {
-            return "AsDetail";
+            return IsComplexType(elementType) ? "AsDetail" : GetDataType(elementType);
         }
 
         return underlying switch

--- a/libs/spark/MintPlayer.Spark/Services/ReferenceResolver.cs
+++ b/libs/spark/MintPlayer.Spark/Services/ReferenceResolver.cs
@@ -113,15 +113,20 @@ internal partial class ReferenceResolver : IReferenceResolver
         {
             foreach (var (property, refAttr) in referenceProperties)
             {
-                var refId = AccessorCache.GetGetter(property)(entity) as string;
-                if (string.IsNullOrEmpty(refId)) continue;
+                var rawValue = AccessorCache.GetGetter(property)(entity);
 
-                var targetType = refAttr.TargetType;
-                if (!refIdsByType.ContainsKey(targetType))
+                // A reference property is either a single id (string) or an array of ids
+                // ([Reference] List<string>/string[]). Both round-trip through .Include();
+                // here we collect every referenced id so its document is resolved.
+                foreach (var refId in ExtractReferenceIds(rawValue))
                 {
-                    refIdsByType[targetType] = [];
+                    var targetType = refAttr.TargetType;
+                    if (!refIdsByType.TryGetValue(targetType, out var set))
+                    {
+                        refIdsByType[targetType] = set = [];
+                    }
+                    set.Add(refId);
                 }
-                refIdsByType[targetType].Add(refId);
             }
         }
 
@@ -162,6 +167,32 @@ internal partial class ReferenceResolver : IReferenceResolver
         await task;
         var resultProperty = task.GetType().GetProperty("Result");
         return (bool)resultProperty!.GetValue(task)!;
+    }
+
+    /// <summary>
+    /// Normalizes a reference property value to its referenced id(s): a single id for a
+    /// string property, or each non-empty id for a collection property
+    /// (<c>[Reference] List&lt;string&gt;</c> / <c>string[]</c>). A <c>string</c> is checked
+    /// before <see cref="System.Collections.IEnumerable"/> because string itself enumerates
+    /// its chars.
+    /// </summary>
+    private static IEnumerable<string> ExtractReferenceIds(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                yield break;
+            case string s:
+                if (!string.IsNullOrEmpty(s)) yield return s;
+                yield break;
+            case System.Collections.IEnumerable enumerable:
+                foreach (var item in enumerable)
+                {
+                    var id = item?.ToString();
+                    if (!string.IsNullOrEmpty(id)) yield return id;
+                }
+                yield break;
+        }
     }
 
     private static async Task<object?> LoadEntityAsync(IAsyncDocumentSession session, Type entityType, string id)

--- a/tests/MintPlayer.Spark.Tests/EntityMapperReferenceArrayTests.cs
+++ b/tests/MintPlayer.Spark.Tests/EntityMapperReferenceArrayTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Services;
+using NSubstitute;
+
+namespace MintPlayer.Spark.Tests;
+
+/// <summary>
+/// Covers the list-of-references mapping: a <c>[Reference] List&lt;string&gt;</c> attribute
+/// (dataType "Reference", IsArray true) round-trips its id array through <c>attr.Value</c>
+/// and resolves a per-id breadcrumb on the forward path; a bare <c>List&lt;string&gt;</c>
+/// (scalar array) round-trips without breadcrumbs.
+/// </summary>
+public class EntityMapperReferenceArrayTests
+{
+    private static readonly Guid TaggedTypeId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid TagTypeId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private readonly EntityMapper _mapper;
+
+    public EntityMapperReferenceArrayTests()
+    {
+        var modelLoader = Substitute.For<IModelLoader>();
+
+        var taggedDef = new EntityTypeDefinition
+        {
+            Id = TaggedTypeId,
+            Name = "Tagged",
+            ClrType = typeof(EM_Tagged).FullName!,
+            DisplayAttribute = "Title",
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Title", DataType = "string" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "TagIds", DataType = "Reference", IsArray = true, ReferenceType = typeof(EM_Tag).FullName, Query = "GetTags" },
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Labels", DataType = "string", IsArray = true },
+            ],
+        };
+
+        var tagDef = new EntityTypeDefinition
+        {
+            Id = TagTypeId,
+            Name = "Tag",
+            ClrType = typeof(EM_Tag).FullName!,
+            DisplayAttribute = "Name",
+            Attributes = [new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Name", DataType = "string" }],
+        };
+
+        modelLoader.GetEntityType(TaggedTypeId).Returns(taggedDef);
+        modelLoader.GetEntityType(TagTypeId).Returns(tagDef);
+        modelLoader.GetEntityTypeByClrType(typeof(EM_Tagged).FullName!).Returns(taggedDef);
+        modelLoader.GetEntityTypeByClrType(typeof(EM_Tag).FullName!).Returns(tagDef);
+
+        _mapper = new EntityMapper(modelLoader);
+    }
+
+    [Fact]
+    public void Forward_reference_array_carries_id_array_and_per_id_breadcrumbs()
+    {
+        var tagged = new EM_Tagged { Id = "Tagged/1", Title = "Post", TagIds = ["Tags/1", "Tags/2"] };
+        var included = new Dictionary<string, object>
+        {
+            ["Tags/1"] = new EM_Tag { Id = "Tags/1", Name = "news" },
+            ["Tags/2"] = new EM_Tag { Id = "Tags/2", Name = "sports" },
+        };
+
+        var po = _mapper.ToPersistentObject(tagged, TaggedTypeId, included);
+
+        var tagIds = po.Attributes.Single(a => a.Name == "TagIds");
+        tagIds.Value.Should().BeAssignableTo<IEnumerable<string>>();
+        ((IEnumerable<string>)tagIds.Value!).Should().Equal("Tags/1", "Tags/2");
+        tagIds.Breadcrumb.Should().BeNull("array references use Breadcrumbs, not the single Breadcrumb");
+        tagIds.Breadcrumbs.Should().NotBeNull();
+        tagIds.Breadcrumbs!["Tags/1"].Should().Be("news");
+        tagIds.Breadcrumbs!["Tags/2"].Should().Be("sports");
+    }
+
+    [Fact]
+    public void Forward_reference_array_without_included_documents_has_no_breadcrumbs()
+    {
+        var tagged = new EM_Tagged { Id = "Tagged/1", Title = "Post", TagIds = ["Tags/1"] };
+
+        var po = _mapper.ToPersistentObject(tagged, TaggedTypeId);
+
+        var tagIds = po.Attributes.Single(a => a.Name == "TagIds");
+        ((IEnumerable<string>)tagIds.Value!).Should().Equal("Tags/1");
+        tagIds.Breadcrumbs.Should().BeNull();
+    }
+
+    [Fact]
+    public void Reverse_reference_array_writes_id_array_onto_entity()
+    {
+        var po = new PersistentObject
+        {
+            Id = "Tagged/1",
+            Name = "Tagged",
+            ObjectTypeId = TaggedTypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = "TagIds", DataType = "Reference", IsArray = true, Value = JsonArray("Tags/1", "Tags/2") },
+            ],
+        };
+        var entity = new EM_Tagged();
+
+        _mapper.PopulateObjectValues(po, entity);
+
+        entity.TagIds.Should().Equal("Tags/1", "Tags/2");
+    }
+
+    [Fact]
+    public void Reverse_scalar_array_writes_values_onto_entity()
+    {
+        var po = new PersistentObject
+        {
+            Id = "Tagged/1",
+            Name = "Tagged",
+            ObjectTypeId = TaggedTypeId,
+            Attributes =
+            [
+                new PersistentObjectAttribute { Name = "Labels", DataType = "string", IsArray = true, Value = JsonArray("a", "b", "c") },
+            ],
+        };
+        var entity = new EM_Tagged();
+
+        _mapper.PopulateObjectValues(po, entity);
+
+        entity.Labels.Should().Equal("a", "b", "c");
+    }
+
+    private static JsonElement JsonArray(params string[] values)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(values));
+        return doc.RootElement.Clone();
+    }
+
+    public class EM_Tag
+    {
+        public string? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class EM_Tagged
+    {
+        public string? Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public List<string> TagIds { get; set; } = [];
+        public List<string> Labels { get; set; } = [];
+    }
+}

--- a/tests/MintPlayer.Spark.Tests/Services/ModelSynchronizerTests.cs
+++ b/tests/MintPlayer.Spark.Tests/Services/ModelSynchronizerTests.cs
@@ -127,6 +127,36 @@ public sealed class ModelSynchronizerTests : IDisposable
     }
 
     [Fact]
+    public void Reference_collection_property_is_typed_Reference_array()
+    {
+        var ctx = new TaggedContext();
+        var sync = CreateSynchronizer();
+
+        sync.SynchronizeModels(ctx);
+
+        var file = Read<EntityTypeFile>(ModelFile("MS_TestTagged"));
+        var tagIds = file.PersistentObject.Attributes.Single(a => a.Name == "TagIds");
+        tagIds.DataType.Should().Be("Reference", "[Reference] List<string> is a multi-reference, not AsDetail");
+        tagIds.IsArray.Should().BeTrue("a collection reference round-trips as an array of ids");
+        tagIds.ReferenceType.Should().Be(typeof(MS_TestTag).FullName);
+    }
+
+    [Fact]
+    public void Bare_list_of_primitive_is_scalar_array_not_AsDetail()
+    {
+        var ctx = new TaggedContext();
+        var sync = CreateSynchronizer();
+
+        sync.SynchronizeModels(ctx);
+
+        var file = Read<EntityTypeFile>(ModelFile("MS_TestTagged"));
+        var labels = file.PersistentObject.Attributes.Single(a => a.Name == "Labels");
+        labels.DataType.Should().Be("string", "List<string> takes its element's scalar type, not AsDetail");
+        labels.IsArray.Should().BeTrue();
+        labels.AsDetailType.Should().BeNull("a list of primitives scaffolds no nested PO type");
+    }
+
+    [Fact]
     public void Removes_stale_projection_model_files_listed_in_IndexRegistry()
     {
         // Pre-create a stale Vehicle.json model file. Then register a projection that maps
@@ -191,6 +221,22 @@ public class MS_TestVehicle
     public string DisplayName { get; set; } = string.Empty;
 }
 
+public class MS_TestTag
+{
+    public string? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class MS_TestTagged
+{
+    public string? Id { get; set; }
+
+    [Reference(typeof(MS_TestTag))]
+    public List<string> TagIds { get; set; } = [];
+
+    public List<string> Labels { get; set; } = [];
+}
+
 public class EmptyContext : SparkContext { }
 
 public class SinglePersonContext : SparkContext
@@ -207,4 +253,10 @@ public class TwoEntityContext : SparkContext
 public class ProjectionOnlyContext : SparkContext
 {
     public IRavenQueryable<MS_TestVehicle> Vehicles => Session.Query<MS_TestVehicle>();
+}
+
+public class TaggedContext : SparkContext
+{
+    public IRavenQueryable<MS_TestTagged> Tagged => Session.Query<MS_TestTagged>();
+    public IRavenQueryable<MS_TestTag> Tags => Session.Query<MS_TestTag>();
 }

--- a/tests/MintPlayer.Spark.Tests/Services/MultiReferenceIntegrationTests.cs
+++ b/tests/MintPlayer.Spark.Tests/Services/MultiReferenceIntegrationTests.cs
@@ -1,0 +1,153 @@
+using MintPlayer.Spark.Abstractions;
+using MintPlayer.Spark.Actions;
+using MintPlayer.Spark.Services;
+using MintPlayer.Spark.Testing;
+using Raven.Client.Documents.Linq;
+
+namespace MintPlayer.Spark.Tests.Services;
+
+/// <summary>
+/// End-to-end coverage for the list-of-references feature through the real
+/// <see cref="IDatabaseAccess"/> pipeline (SparkTestDriver in-memory RavenDB +
+/// SparkEndpointFactory host). Exercises the three .NET pieces together:
+/// <list type="bullet">
+///   <item>ReferenceResolver includes + resolves a breadcrumb per id in the array.</item>
+///   <item>EntityMapper forward path carries the id array in Value and a per-id Breadcrumbs map.</item>
+///   <item>EntityMapper inverse path persists an id array back onto the <c>List&lt;string&gt;</c> property.</item>
+/// </list>
+/// </summary>
+public class MultiReferenceIntegrationTests : SparkTestDriver
+{
+    private static readonly Guid TaggedTypeId = Guid.Parse("aa11bb22-cc33-dd44-ee55-ff6677889900");
+    private static readonly Guid TagTypeId = Guid.Parse("bb22cc33-dd44-ee55-ff66-778899001122");
+
+    private SparkEndpointFactory<MultiRefContext> _factory = null!;
+    private IDatabaseAccess _dbAccess = null!;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _factory = new SparkEndpointFactory<MultiRefContext>(Store, [TagModel(), TaggedModel()]);
+        _dbAccess = _factory.GetService<IDatabaseAccess>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task SeedAsync()
+    {
+        using var session = Store.OpenAsyncSession();
+        await session.StoreAsync(new MR_Tag { Id = "tags/1", Name = "news" });
+        await session.StoreAsync(new MR_Tag { Id = "tags/2", Name = "sports" });
+        await session.StoreAsync(new MR_Tagged { Id = "taggeds/1", Title = "Post", TagIds = ["tags/1", "tags/2"] });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Get_resolves_reference_array_value_and_per_id_breadcrumbs()
+    {
+        await SeedAsync();
+
+        var po = await _dbAccess.GetPersistentObjectAsync(TaggedTypeId, "taggeds/1");
+
+        po.Should().NotBeNull();
+        var tagIds = po!.Attributes.Single(a => a.Name == "TagIds");
+        tagIds.IsArray.Should().BeTrue();
+        ((IEnumerable<string>)tagIds.Value!).Should().Equal("tags/1", "tags/2");
+        tagIds.Breadcrumbs.Should().NotBeNull();
+        tagIds.Breadcrumbs!["tags/1"].Should().Be("news");
+        tagIds.Breadcrumbs!["tags/2"].Should().Be("sports");
+    }
+
+    [Fact]
+    public async Task Save_persists_reference_id_array_onto_the_entity()
+    {
+        await SeedAsync();
+
+        var po = new PersistentObject
+        {
+            Id = "taggeds/1",
+            Name = "Tagged",
+            ObjectTypeId = TaggedTypeId,
+        };
+        po.AddAttribute(new PersistentObjectAttribute { Name = "Title", DataType = "string", Value = "Post", IsValueChanged = true });
+        po.AddAttribute(new PersistentObjectAttribute { Name = "TagIds", DataType = "Reference", IsArray = true, Value = new List<string> { "tags/2" }, IsValueChanged = true });
+
+        await _dbAccess.SavePersistentObjectAsync(po);
+
+        using var session = Store.OpenAsyncSession();
+        var reloaded = await session.LoadAsync<MR_Tagged>("taggeds/1");
+        // The update replaced the two-tag selection with a single tag.
+        reloaded.TagIds.Should().Equal("tags/2");
+    }
+
+    private static EntityTypeFile TagModel() => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = TagTypeId,
+            Name = "Tag",
+            ClrType = typeof(MR_Tag).FullName!,
+            DisplayAttribute = "Name",
+            Attributes = [new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Name", DataType = "string" }],
+        },
+    };
+
+    private static EntityTypeFile TaggedModel() => new()
+    {
+        PersistentObject = new EntityTypeDefinition
+        {
+            Id = TaggedTypeId,
+            Name = "Tagged",
+            ClrType = typeof(MR_Tagged).FullName!,
+            DisplayAttribute = "Title",
+            Attributes =
+            [
+                new EntityAttributeDefinition { Id = Guid.NewGuid(), Name = "Title", DataType = "string" },
+                new EntityAttributeDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "TagIds",
+                    DataType = "Reference",
+                    IsArray = true,
+                    ReferenceType = typeof(MR_Tag).FullName,
+                    Query = "GetTags",
+                },
+            ],
+        },
+    };
+}
+
+public class MR_Tag
+{
+    public string? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class MR_Tagged
+{
+    public string? Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+
+    [Reference(typeof(MR_Tag))]
+    public List<string> TagIds { get; set; } = [];
+}
+
+public class MR_TagActions : DefaultPersistentObjectActions<MR_Tag>
+{
+    public MR_TagActions(IEntityMapper entityMapper) : base(entityMapper) { }
+}
+
+public class MR_TaggedActions : DefaultPersistentObjectActions<MR_Tagged>
+{
+    public MR_TaggedActions(IEntityMapper entityMapper) : base(entityMapper) { }
+}
+
+public class MultiRefContext : SparkContext
+{
+    public IRavenQueryable<MR_Tag> Tags => Session.Query<MR_Tag>();
+    public IRavenQueryable<MR_Tagged> Taggeds => Session.Query<MR_Tagged>();
+}


### PR DESCRIPTION
## What

First-class **list-of-references** support, end to end. A property like

```csharp
[Reference(typeof(Profession), "GetProfessions")] public List<string> Professions { get; set; } = [];
```

now behaves as a multi-reference: `dataType:"Reference"`, `isArray:true`, its id array round-trips through `attr.Value`, each id resolves a display breadcrumb, and it is edited with a built-in **searchable multi-select** (chips) — no app-specific renderer required.

### Why
Previously `[Reference] List<string>` was typed `Reference` but `isArray` stayed `false`, and a bare `List<string>` was mis-typed as `AsDetail<System.String>` whose values the mapper silently dropped (`objects:[]`, `value:null`). ng-spark had no multi-reference editor.

## Changes

### .NET (`MintPlayer.Spark*` → `10.0.0-preview.36`)
- **ModelSynchronizer** — classify collections by their **element** type. `[Reference] List<string>` → multi-reference (`isArray`); bare `List<string>` → scalar array (element's type), not `AsDetail`. `IsArray` is now refreshed for every collection property, not only AsDetail.
- **EntityMapper** — round-trip an `isArray` non-AsDetail attribute as a JSON array (the single-reference resolver is guarded against arrays so they fall through to collection coercion); forward path resolves a **per-id breadcrumb map**.
- **ReferenceResolver** — `ResolveReferencedDocumentsAsync` handles reference **arrays** (a property value that is an `IEnumerable<string>` of ids, not a single string).
- **PersistentObjectAttribute.Breadcrumbs** (`id → label`) added, with hand-written JSON converter read/write support. Single references keep using `Breadcrumb`.

### ng-spark (`@mintplayer/ng-spark` → `22.0.2`)
- **po-form** — new editor branch for `Reference && isArray`: `<bs-tree-select mode="multiple" variant="textbox">` (select2-style), backed by an `InMemoryTreeSelectProvider` built from the reference query results; selection binds as a `string[]` of ids.
- **po-detail + query-list** — render the resolved breadcrumbs as chips (new `referenceChips` pipe). Detail chips link to the referenced entity.

### Demo
- HR `Person` gains a multi-reference `Professions` (`List<string>`) + synced model, demonstrating the editor (edit form) and chips (detail page).

## Tests
- **ModelSynchronizer** — `[Reference] List<string>` typed as Reference array; bare `List<string>` typed as scalar array (not AsDetail).
- **EntityMapper** — forward (id array + per-id `Breadcrumbs`) and inverse (id array → `List<string>`) round-trips.
- **MultiReferenceIntegrationTests** — `SparkTestDriver` (in-memory RavenDB) + `SparkEndpointFactory` driving the real `IDatabaseAccess` pipeline: include + per-id breadcrumb resolution on GET, and id-array persistence on save.

Full suite: 933/934 passing (the one failure is a pre-existing flaky timing-based cron scheduler test, unrelated to this change — passes in isolation). `MintPlayer.Spark`, ng-spark library, and the HR demo all build.

## Publishing
On merge to `master`, CI publishes automatically: `MintPlayer.Spark{,.Abstractions,.Authorization,.SourceGenerators}@10.0.0-preview.36` to nuget.org + GitHub, and `@mintplayer/ng-spark@22.0.2` to npmjs + GitHub Packages (all skip-duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
