### PR TITLE
feat(ng-spark): apply custom attribute renderers in AsDetail sub-tables

### DIFF
--- a/libs/node_packages/ng-spark/package.json
+++ b/libs/node_packages/ng-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-spark",
   "private": false,
-  "version": "22.0.2",
+  "version": "22.0.3",
   "description": "Angular component library for MintPlayer.Spark CRUD applications",
   "repository": {
     "type": "git",

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
@@ -101,7 +101,9 @@
                       <tr>
                         @for (col of (attr | asDetailColumns:asDetailTypes()); track col.name) {
                           <td>
-                            @if (col.dataType === 'Reference' && col.referenceType) {
+                            @if (getAsDetailCellRendererComponent(col); as cellRenderer) {
+                              <ng-container *ngComponentOutlet="cellRenderer; inputs: getAsDetailCellRendererInputs(row, col)"></ng-container>
+                            } @else if (col.dataType === 'Reference' && col.referenceType) {
                               @let route = (col.referenceType | referenceLinkRoute:row[col.name]:allEntityTypes());
                               @if (route) {
                                 <a [routerLink]="route">{{ (row | asDetailCellValue:attr:col:asDetailReferenceOptions()) }}</a>

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.ts
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.ts
@@ -168,6 +168,20 @@ export class SparkPoDetailComponent {
     };
   }
 
+  /** Column renderer for a cell of an AsDetail sub-table (so embedded rows honor `col.renderer` too). */
+  getAsDetailCellRendererComponent(col: EntityAttributeDefinition): Type<any> | null {
+    if (!col.renderer) return null;
+    return this.rendererRegistry.find(r => r.name === col.renderer)?.columnComponent ?? null;
+  }
+
+  getAsDetailCellRendererInputs(row: Record<string, any>, col: EntityAttributeDefinition): Record<string, any> {
+    return {
+      value: row[col.name],
+      attribute: col,
+      options: col.rendererOptions,
+    };
+  }
+
   private async loadLookupReferenceOptions(): Promise<void> {
     const lookupAttrs = this.visibleAttributes().filter(a => a.lookupReferenceType);
     if (lookupAttrs.length === 0) return;

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
@@ -189,7 +189,13 @@
                 @for (row of formData()[attr.name] || []; track $index) {
                   <tr>
                     @for (col of (attr | asDetailColumns:asDetailTypes()); track col.name) {
-                      <td>{{ row | asDetailCellValue:attr:col:asDetailReferenceOptions() }}</td>
+                      <td>
+                        @if (getAsDetailCellRendererComponent(col); as cellRenderer) {
+                          <ng-container *ngComponentOutlet="cellRenderer; inputs: getAsDetailCellRendererInputs(row, col)"></ng-container>
+                        } @else {
+                          {{ row | asDetailCellValue:attr:col:asDetailReferenceOptions() }}
+                        }
+                      </td>
                     }
                     <td class="text-nowrap">
                       <button type="button" class="btn btn-sm btn-outline-secondary me-1" (click)="editArrayItem(attr, $index)">

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
@@ -366,6 +366,20 @@ export class SparkPoFormComponent {
     };
   }
 
+  /** Column renderer for a cell of an AsDetail sub-table (so embedded rows honor `col.renderer` too). */
+  getAsDetailCellRendererComponent(col: EntityAttributeDefinition): Type<any> | null {
+    if (!col.renderer) return null;
+    return this.rendererRegistry.find(r => r.name === col.renderer)?.columnComponent ?? null;
+  }
+
+  getAsDetailCellRendererInputs(row: Record<string, any>, col: EntityAttributeDefinition): Record<string, any> {
+    return {
+      value: row[col.name],
+      attribute: col,
+      options: col.rendererOptions,
+    };
+  }
+
   hasError(attrName: string): boolean {
     return this.validationErrors().some(e => e.attributeName === attrName);
   }


### PR DESCRIPTION
## What

Custom attribute renderers registered via `provideSparkAttributeRenderers([{ name, columnComponent, detailComponent, editComponent }])` already apply to **top-level** attributes (query-list → `columnComponent`, po-detail → `detailComponent`, po-form → `editComponent`). They were **not** applied inside **AsDetail** embedded sub-tables — those cells rendered only through the `asDetailCellValue` pipe and never consulted `col.renderer`.

This makes the AsDetail **read** tables resolve `col.renderer` → `columnComponent` (via the existing `SPARK_ATTRIBUTE_RENDERERS` registry) and render it with `*ngComponentOutlet`, falling back to the current pipe / reference-link output when no renderer is set.

## Where

- `SparkPoDetailComponent` — detail-page AsDetail read table
- `SparkPoFormComponent` — modal-edit AsDetail read grid

Each gains `getAsDetailCellRendererComponent(col)` + `getAsDetailCellRendererInputs(row, col)` mirroring the existing top-level renderer helpers. No new imports — both components already inject `SPARK_ATTRIBUTE_RENDERERS`, import `Type`/`NgComponentOutlet`, and use `*ngComponentOutlet` elsewhere.

## Out of scope

The **inline-edit** AsDetail grid is intentionally untouched — those entities use modal edit, and the modal recursively instantiates `spark-po-form`, which already honors `editComponent`.

## Release

Bumps `@mintplayer/ng-spark` 22.0.2 → 22.0.3; CI publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
