### PR TITLE
feat(ng-spark): inline AsDetail Reference/Lookup cells can opt into the modal picker (#189)

### DIFF
--- a/Demo/HR/HR/App_Data/Model/CarreerJob.json
+++ b/Demo/HR/HR/App_Data/Model/CarreerJob.json
@@ -22,6 +22,7 @@
         "order": 1,
         "query": "GetProfessions",
         "referenceType": "HR.Entities.Profession",
+        "referenceDisplayType": "Modal",
         "isArray": false,
         "showedOn": "Query, PersistentObject",
         "rules": []

--- a/README.md
+++ b/README.md
@@ -218,6 +218,25 @@ dotnet run
 
 The application will be available at `https://localhost:5001`.
 
+> **RavenDB note:** the demos connect to `http://localhost:8080` (`appsettings.json` → `Spark:RavenDb:Urls`). If you point them at a **standalone/local RavenDB** instead of the Docker container above, make sure its `PublicServerUrl` is `http://localhost:8080` — *not* `http://host.docker.internal:8080`. RavenDB advertises `PublicServerUrl` through its cluster topology and the client routes **all** subsequent requests there (caching it under `Demo/**/bin/**/*.raven-cluster-topology`); a `host.docker.internal` value the host can't reach makes every request fail with `ServiceUnavailable`. `host.docker.internal` is only correct when a *container* must reach a host-installed database.
+
+#### Running multiple modules together (SlnLaunch)
+
+The cross-module demos (HR + Fleet, which replicate data to each other) are launched together with the [`MintPlayer.SlnLaunch`](https://www.nuget.org/packages/MintPlayer.SlnLaunch) dotnet tool, driven by the `MintPlayer.Spark.slnLaunch` profile in the repo root:
+
+```bash
+dnx MintPlayer.SlnLaunch        # runs the "HR + Fleet" profile
+```
+
+Use **10.0.1+**, which builds the projects sequentially before launching them in parallel (earlier versions could fail intermittently because the concurrent `dotnet run` builds raced on the MSBuild server pipe / shared output DLLs). The ASP.NET hosts come up on:
+
+| Module | Host (Spark API + app) |
+| --- | --- |
+| Fleet | `https://localhost:5003` |
+| HR | `https://localhost:5005` |
+
+> The `/spark/*` endpoints live on the **host** port above. Each host also spawns its own Angular dev server on a separate random port (printed as `➜ Local: http://localhost:<port>/`); hitting that dev-server port directly serves `index.html` for every path, so a request like `/spark/program-units` looks like a 404. Always use the host port for API/middleware requests.
+
 **Library HMR:** edit any file under `libs/node_packages/ng-spark/src/**` or `libs/node_packages/ng-spark-auth/src/**` while a demo is running — changes reflect in the browser without a restart, with component state preserved. Libraries are consumed as **source** during dev (tsconfig path aliases resolve directly to `.ts` files). The ng-packagr `build` target on each library produces the publishable dist for `npm publish`; dev never consumes dist.
 
 ### Model Synchronization

--- a/libs/all_features/MintPlayer.Spark.AllFeatures.SourceGenerators/MintPlayer.Spark.AllFeatures.SourceGenerators.csproj
+++ b/libs/all_features/MintPlayer.Spark.AllFeatures.SourceGenerators/MintPlayer.Spark.AllFeatures.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.AllFeatures.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark.AllFeatures. Auto-generates AddSparkFull/UseSparkFull/MapSparkFull convenience methods.</Description>

--- a/libs/all_features/MintPlayer.Spark.AllFeatures/MintPlayer.Spark.AllFeatures.csproj
+++ b/libs/all_features/MintPlayer.Spark.AllFeatures/MintPlayer.Spark.AllFeatures.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.AllFeatures</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>All-in-one package for MintPlayer.Spark. References all Spark libraries and source-generates AddSparkFull/UseSparkFull/MapSparkFull convenience methods.</Description>

--- a/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
+++ b/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Authorization</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Optional authorization package for MintPlayer.Spark low-code framework. Provides group-based access control for PersistentObjects and Queries.</Description>

--- a/libs/client/MintPlayer.Spark.Client.Authorization/MintPlayer.Spark.Client.Authorization.csproj
+++ b/libs/client/MintPlayer.Spark.Client.Authorization/MintPlayer.Spark.Client.Authorization.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Client.Authorization</PackageId>
-    <Version>10.0.0-preview.39</Version>
+    <Version>10.0.0-preview.40</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Authorization extensions for the MintPlayer.Spark typed C# client.</Description>

--- a/libs/client/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
+++ b/libs/client/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Client</PackageId>
-    <Version>10.0.0-preview.39</Version>
+    <Version>10.0.0-preview.40</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Typed C# client for consuming MintPlayer.Spark backend APIs.</Description>

--- a/libs/cron/MintPlayer.Spark.Cron/MintPlayer.Spark.Cron.csproj
+++ b/libs/cron/MintPlayer.Spark.Cron/MintPlayer.Spark.Cron.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Cron</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cron-scheduled background jobs for MintPlayer.Spark. Define jobs by implementing ISparkCronJob, declare the schedule with a static abstract CronSchedule, and let the scheduler run them. Multi-node safe via RavenDB compare-exchange locking.</Description>

--- a/libs/messaging/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
+++ b/libs/messaging/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging.Abstractions</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Messaging: IMessageBus, IRecipient, and MessageQueueAttribute.</Description>

--- a/libs/messaging/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
+++ b/libs/messaging/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Durable message bus for MintPlayer.Spark with RavenDB persistence, scoped recipients, queue isolation, and retry logic.</Description>

--- a/libs/migrations/MintPlayer.Spark.Migrations/MintPlayer.Spark.Migrations.csproj
+++ b/libs/migrations/MintPlayer.Spark.Migrations/MintPlayer.Spark.Migrations.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Migrations</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Database migrations for MintPlayer.Spark. Define migrations by implementing ISparkMigration with a static abstract Version; they run once, in version order, at startup. Multi-node safe via RavenDB compare-exchange locking, idempotent via per-version marker documents.</Description>

--- a/libs/node_packages/ng-spark/models/src/entity-type.ts
+++ b/libs/node_packages/ng-spark/models/src/entity-type.ts
@@ -2,6 +2,17 @@ import { ShowedOn } from './showed-on';
 import { TranslatedString } from './translated-string';
 import { ValidationRule } from './validation-rule';
 
+/**
+ * Controls how a Reference attribute is picked in the PO-edit form.
+ * Serialized as a string by the server (mirrors the .NET EReferenceDisplayType).
+ */
+export enum EReferenceDisplayType {
+  /** Renders as a `<bs-select>` listing every referenced item. */
+  Dropdown = 'Dropdown',
+  /** Renders a readonly textbox + "…" button that opens a searchable modal grid picker. */
+  Modal = 'Modal',
+}
+
 export interface EntityAttributeDefinition {
   id: string;
   name: string;
@@ -20,6 +31,11 @@ export interface EntityAttributeDefinition {
   isArray?: boolean;
   /** For array AsDetail attributes: "modal" (default) or "inline" */
   editMode?: 'inline' | 'modal';
+  /**
+   * For Reference attributes: 'Modal' renders the "…" + modal query-grid picker;
+   * 'Dropdown'/absent (default) renders a `<bs-select>`. Hand-set in the model JSON.
+   */
+  referenceDisplayType?: EReferenceDisplayType;
   /** For array AsDetail attributes: when true, rows can be drag-reordered (order = array position) */
   isSortable?: boolean;
   /** For LookupReference attributes, specifies the lookup reference type name */

--- a/libs/node_packages/ng-spark/package.json
+++ b/libs/node_packages/ng-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-spark",
   "private": false,
-  "version": "22.0.6",
+  "version": "22.0.7",
   "description": "Angular component library for MintPlayer.Spark CRUD applications",
   "repository": {
     "type": "git",

--- a/libs/node_packages/ng-spark/po-form/src/index.ts
+++ b/libs/node_packages/ng-spark/po-form/src/index.ts
@@ -1,1 +1,3 @@
 export * from './spark-po-form.component';
+export * from './spark-reference-picker.component';
+export * from './spark-lookup-picker.component';

--- a/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.html
@@ -1,0 +1,77 @@
+<bs-input-group>
+  <input
+    type="text"
+    [id]="inputId()"
+    [value]="displayValue()"
+    readonly
+    [class.is-invalid]="isInvalid()">
+  <button
+    type="button"
+    bsInputGroupBtn
+    [color]="colors.secondary"
+    (click)="open()">
+    ...
+  </button>
+</bs-input-group>
+
+<bs-modal [isOpen]="showModal()" (isOpenChange)="!$event && close()">
+  <div *bsModal>
+    <div bsModalHeader>
+      <h5 class="modal-title">{{ 'common.select' | t }} {{ title() }}</h5>
+    </div>
+
+    <div bsModalBody>
+      <!-- bs-modal portals its content into a CDK overlay outside the host form, so the
+           modal needs its own <bs-form> context for inputs to pick up .form-control styles. -->
+      <bs-form>
+      <!-- Search box -->
+      <bs-grid>
+        <div bsRow class="mb-3">
+          <div [col]>
+            <bs-input-group>
+              <span class="input-group-text">
+                <spark-icon name="search" />
+              </span>
+              <input
+                type="text"
+                [placeholder]="'common.search' | t"
+                [ngModel]="searchTerm()"
+                (ngModelChange)="searchTerm.set($event)">
+              @if (searchTerm()) {
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  (click)="searchTerm.set('')">
+                  <spark-icon name="x-lg" />
+                </button>
+              }
+            </bs-input-group>
+          </div>
+        </div>
+      </bs-grid>
+
+      <!-- List of items -->
+      <bs-table [striped]="true" [hover]="true">
+        <tbody class="align-middle">
+          @for (item of filteredItems(); track item.key) {
+            <tr
+              [class.table-primary]="value() === item.key"
+              (click)="select(item)"
+              style="cursor: pointer;">
+              <td>{{ item.values | resolveTranslation:item.key }}</td>
+            </tr>
+          } @empty {
+            <tr>
+              <td class="text-center text-muted">{{ 'common.noItemsFound' | t }}</td>
+            </tr>
+          }
+        </tbody>
+      </bs-table>
+      </bs-form>
+    </div>
+
+    <div bsModalFooter>
+      <button type="button" [color]="colors.secondary" (click)="close()">{{ 'common.cancel' | t }}</button>
+    </div>
+  </div>
+</bs-modal>

--- a/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.spec.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkLookupPickerComponent } from './spark-lookup-picker.component';
+import { LookupReferenceValue } from '@mintplayer/ng-spark/models';
+
+const roles: LookupReferenceValue[] = [
+  { key: 'admin', values: { en: 'Administrator' } as any, isActive: true },
+  { key: 'user', values: { en: 'Standard User' } as any, isActive: true },
+];
+
+function createComponent() {
+  TestBed.configureTestingModule({ providers: [provideNoopAnimations()] });
+  const fixture = TestBed.createComponent(SparkLookupPickerComponent);
+  return { fixture, component: fixture.componentInstance };
+}
+
+describe('SparkLookupPickerComponent', () => {
+  it('displayValue resolves the translated label, falls back to the key, and is empty when unset', () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', roles);
+
+    fixture.componentRef.setInput('value', 'admin');
+    expect(component.displayValue()).toBe('Administrator');
+
+    fixture.componentRef.setInput('value', 'unknown');
+    expect(component.displayValue()).toBe('unknown');
+
+    fixture.componentRef.setInput('value', null);
+    expect(component.displayValue()).toBe('');
+  });
+
+  it('filteredItems narrows by search term (case-insensitive, matches key or translation)', () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', roles);
+
+    component.searchTerm.set('admin');
+    expect(component.filteredItems().map(i => i.key)).toEqual(['admin']);
+
+    component.searchTerm.set('standard');
+    expect(component.filteredItems().map(i => i.key)).toEqual(['user']);
+
+    component.searchTerm.set('nope');
+    expect(component.filteredItems()).toHaveLength(0);
+  });
+
+  it('select emits the picked key via valueChange and closes the modal', () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', roles);
+    component.open();
+
+    const emitted = vi.fn();
+    component.valueChange.subscribe(emitted);
+    component.select(roles[0]);
+
+    expect(emitted).toHaveBeenCalledWith('admin');
+    expect(component.showModal()).toBe(false);
+  });
+});

--- a/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-lookup-picker.component.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Color } from '@mintplayer/ng-bootstrap';
+import { BsFormComponent, BsFormControlDirective } from '@mintplayer/ng-bootstrap/form';
+import { BsGridComponent, BsGridRowDirective, BsGridColDirective } from '@mintplayer/ng-bootstrap/grid';
+import { BsInputGroupComponent } from '@mintplayer/ng-bootstrap/input-group';
+import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
+import { BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective } from '@mintplayer/ng-bootstrap/modal';
+import { BsTableComponent } from '@mintplayer/ng-bootstrap/table';
+import { LookupReferenceValue, resolveTranslation } from '@mintplayer/ng-spark/models';
+import { TranslateKeyPipe, ResolveTranslationPipe } from '@mintplayer/ng-spark/pipes';
+import { SparkIconComponent } from '@mintplayer/ng-spark/icon';
+
+/**
+ * Reusable LookupReference value picker: a readonly textbox showing the current selection's
+ * translated label plus a "…" button that opens a searchable modal list over the active
+ * `options`. Per-instance state, so it serves both top-level lookup attributes (display type
+ * Modal) and individual inline AsDetail lookup cells. Emits the picked key via `valueChange`.
+ */
+@Component({
+  selector: 'spark-lookup-picker',
+  imports: [FormsModule, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColDirective, BsInputGroupComponent, BsButtonTypeDirective, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsTableComponent, SparkIconComponent, TranslateKeyPipe, ResolveTranslationPipe],
+  templateUrl: './spark-lookup-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SparkLookupPickerComponent {
+  /** Currently selected lookup key (or null when unset). */
+  value = input<string | null>(null);
+  /** Active lookup values to pick from. */
+  options = input<LookupReferenceValue[]>([]);
+  /** Renders the field with the Bootstrap is-invalid state. */
+  isInvalid = input(false);
+  /** Optional id forwarded to the readonly input (for label association). */
+  inputId = input<string | undefined>(undefined);
+  /** Optional resolved label appended to the modal header ("Select {title}"). */
+  title = input<string>('');
+
+  valueChange = output<string | null>();
+
+  colors = Color;
+
+  showModal = signal(false);
+  searchTerm = signal('');
+
+  displayValue = computed(() => {
+    const key = this.value();
+    if (key == null || key === '') return '';
+    const selected = this.options().find(o => o.key === String(key));
+    if (!selected) return String(key);
+    return resolveTranslation(selected.values) || selected.key;
+  });
+
+  filteredItems = computed(() => {
+    if (!this.searchTerm().trim()) {
+      return this.options();
+    }
+    const term = this.searchTerm().toLowerCase().trim();
+    return this.options().filter(item => {
+      const translation = resolveTranslation(item.values);
+      return translation.toLowerCase().includes(term) || item.key.toLowerCase().includes(term);
+    });
+  });
+
+  open(): void {
+    this.searchTerm.set('');
+    this.showModal.set(true);
+  }
+
+  select(item: LookupReferenceValue): void {
+    this.valueChange.emit(item.key);
+    this.close();
+  }
+
+  close(): void {
+    this.showModal.set(false);
+    this.searchTerm.set('');
+  }
+}

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
@@ -56,21 +56,14 @@
             </bs-checkbox>
           } @else if (attr.lookupReferenceType) {
             @if ((attr | lookupDisplayType:lookupReferenceOptions()) === ELookupDisplayType.Modal) {
-              <bs-input-group>
-                <input
-                  type="text"
-                  [id]="attr.name"
-                  [value]="attr | lookupDisplayValue:formData():lookupReferenceOptions()"
-                  readonly
-                  [class.is-invalid]="hasError(attr.name)">
-                <button
-                  type="button"
-                  bsInputGroupBtn
-                  [color]="colors.secondary"
-                  (click)="openLookupSelector(attr)">
-                  ...
-                </button>
-              </bs-input-group>
+              <spark-lookup-picker
+                [value]="formData()[attr.name]"
+                [options]="getLookupOptions(attr)"
+                [inputId]="attr.name"
+                [title]="attr.label | resolveTranslation:attr.name"
+                [isInvalid]="hasError(attr.name)"
+                (valueChange)="onLookupValueChange(attr, $event)">
+              </spark-lookup-picker>
             } @else {
               <bs-select
                 [ngModel]="formData()[attr.name]"
@@ -97,21 +90,15 @@
               [ngModelOptions]="{ standalone: true }">
             </bs-tree-select>
           } @else if (attr.dataType === 'Reference') {
-            <bs-input-group>
-              <input
-                type="text"
-                [id]="attr.name"
-                [value]="attr | referenceDisplayValue:formData():referenceOptions()"
-                readonly
-                [class.is-invalid]="hasError(attr.name)">
-              <button
-                type="button"
-                bsInputGroupBtn
-                [color]="colors.secondary"
-                (click)="openReferenceSelector(attr)">
-                ...
-              </button>
-            </bs-input-group>
+            <spark-reference-picker
+              [value]="formData()[attr.name]"
+              [options]="referenceOptions()[attr.name] || []"
+              [referenceType]="attr.referenceType"
+              [inputId]="attr.name"
+              [title]="attr.label | resolveTranslation:attr.name"
+              [isInvalid]="hasError(attr.name)"
+              (valueChange)="onReferenceValueChange(attr, $event)">
+            </spark-reference-picker>
           } @else if (attr.dataType === 'AsDetail' && attr.isArray && attr.editMode === 'inline') {
             <!-- One source of truth for an inline cell, reused by the row and by the drag
                  preview. The preview is a live Angular view (not a cloneNode), so its
@@ -137,29 +124,50 @@
                     (ngModelChange)="onFieldChange()">
                   </bs-checkbox>
                 } @else if (col.dataType === 'Reference' && col.query) {
-                  <bs-select
-                    [(ngModel)]="row[col.name]"
-                    (ngModelChange)="onFieldChange()"
-                    [class.is-invalid]="hasInlineError(attr, rowIndex, col)">
-                    <option [ngValue]="null">{{ 'common.selectPlaceholder' | t }}</option>
-                    @for (option of (attr | inlineRefOptions:col:asDetailReferenceOptions()); track option.id) {
-                      <option [ngValue]="option.id">
-                        {{ option.breadcrumb || option.name || option.id }}
-                      </option>
-                    }
-                  </bs-select>
+                  @if (col.referenceDisplayType === EReferenceDisplayType.Modal) {
+                    <spark-reference-picker
+                      [value]="row[col.name]"
+                      [options]="(attr | inlineRefOptions:col:asDetailReferenceOptions())"
+                      [referenceType]="col.referenceType"
+                      [title]="col.label | resolveTranslation:col.name"
+                      [isInvalid]="hasInlineError(attr, rowIndex, col)"
+                      (valueChange)="row[col.name] = $event; onFieldChange()">
+                    </spark-reference-picker>
+                  } @else {
+                    <bs-select
+                      [(ngModel)]="row[col.name]"
+                      (ngModelChange)="onFieldChange()"
+                      [class.is-invalid]="hasInlineError(attr, rowIndex, col)">
+                      <option [ngValue]="null">{{ 'common.selectPlaceholder' | t }}</option>
+                      @for (option of (attr | inlineRefOptions:col:asDetailReferenceOptions()); track option.id) {
+                        <option [ngValue]="option.id">
+                          {{ option.breadcrumb || option.name || option.id }}
+                        </option>
+                      }
+                    </bs-select>
+                  }
                 } @else if (col.lookupReferenceType) {
-                  <bs-select
-                    [(ngModel)]="row[col.name]"
-                    (ngModelChange)="onFieldChange()"
-                    [class.is-invalid]="hasInlineError(attr, rowIndex, col)">
-                    <option [ngValue]="null">{{ 'common.selectPlaceholder' | t }}</option>
-                    @for (option of getLookupOptions(col); track option.key) {
-                      <option [ngValue]="option.key">
-                        {{ option.values | resolveTranslation:option.key }}
-                      </option>
-                    }
-                  </bs-select>
+                  @if ((col | lookupDisplayType:lookupReferenceOptions()) === ELookupDisplayType.Modal) {
+                    <spark-lookup-picker
+                      [value]="row[col.name]"
+                      [options]="getLookupOptions(col)"
+                      [title]="col.label | resolveTranslation:col.name"
+                      [isInvalid]="hasInlineError(attr, rowIndex, col)"
+                      (valueChange)="row[col.name] = $event; onFieldChange()">
+                    </spark-lookup-picker>
+                  } @else {
+                    <bs-select
+                      [(ngModel)]="row[col.name]"
+                      (ngModelChange)="onFieldChange()"
+                      [class.is-invalid]="hasInlineError(attr, rowIndex, col)">
+                      <option [ngValue]="null">{{ 'common.selectPlaceholder' | t }}</option>
+                      @for (option of getLookupOptions(col); track option.key) {
+                        <option [ngValue]="option.key">
+                          {{ option.values | resolveTranslation:option.key }}
+                        </option>
+                      }
+                    </bs-select>
+                  }
                 } @else {
                   <input
                     [type]="col.dataType | inputType"
@@ -370,136 +378,6 @@
     <div bsModalFooter>
       <button type="button" [color]="colors.secondary" (click)="closeAsDetailModal()">{{ 'common.cancel' | t }}</button>
       <button type="button" [color]="colors.primary" (click)="saveAsDetailObject()">{{ 'common.save' | t }}</button>
-    </div>
-  </div>
-</bs-modal>
-
-<!-- Modal for selecting Reference items -->
-<bs-modal [isOpen]="showReferenceModal()" (isOpenChange)="!$event && closeReferenceModal()">
-  <div *bsModal class="reference-modal">
-    <div bsModalHeader>
-      <h5 class="modal-title">{{ 'common.select' | t }} {{ editingReferenceAttr()?.label | resolveTranslation:editingReferenceAttr()?.name }}</h5>
-    </div>
-
-    <div bsModalBody>
-      @if (referenceModalEntityType()) {
-        <!-- Search box -->
-        <bs-grid>
-          <div bsRow class="mb-3">
-            <div [md]="6">
-              <bs-input-group>
-                <span class="input-group-text">
-                  <spark-icon name="search" />
-                </span>
-                <input
-                  type="text"
-                  [placeholder]="'common.search' | t"
-                  [(ngModel)]="referenceSearchTerm"
-                  (ngModelChange)="onReferenceSearchChange()">
-                @if (referenceSearchTerm) {
-                  <button
-                    type="button"
-                    class="btn btn-outline-secondary"
-                    (click)="clearReferenceSearch()">
-                    <spark-icon name="x-lg" />
-                  </button>
-                }
-              </bs-input-group>
-            </div>
-            <div [md]="6" class="text-end">
-              @if (referenceSearchTerm && referenceModalPagination()) {
-                <span class="text-muted">
-                  {{ referenceModalPagination()!.totalRecords }} {{ referenceModalPagination()!.totalRecords === 1 ? ('common.resultFound' | t) : ('common.resultsFound' | t) }}
-                </span>
-              }
-            </div>
-          </div>
-        </bs-grid>
-
-        <bs-datatable
-          [(settings)]="referenceModalSettings"
-          [data]="referenceModalRows()"
-          (rowClick)="selectReferenceItem($event.row)">
-          @for (attr of referenceVisibleAttributes(); track attr.id) {
-            <div *bsDatatableColumn="attr.name; sortable: true">
-              {{ attr.label | resolveTranslation:attr.name }}
-            </div>
-          }
-
-          <ng-container *bsRowTemplate="let item">
-            @for (attr of referenceVisibleAttributes(); track attr.id) {
-              <td>{{ $any(item) | referenceAttrValue:attr.name }}</td>
-            }
-          </ng-container>
-        </bs-datatable>
-      } @else {
-        <div class="text-center p-3">
-          <bs-spinner />
-        </div>
-      }
-    </div>
-
-    <div bsModalFooter>
-      <button type="button" [color]="colors.secondary" (click)="closeReferenceModal()">{{ 'common.cancel' | t }}</button>
-    </div>
-  </div>
-</bs-modal>
-
-<!-- Modal for selecting LookupReference items -->
-<bs-modal [isOpen]="showLookupModal()" (isOpenChange)="!$event && closeLookupModal()">
-  <div *bsModal>
-    <div bsModalHeader>
-      <h5 class="modal-title">{{ 'common.select' | t }} {{ editingLookupAttr()?.label | resolveTranslation:editingLookupAttr()?.name }}</h5>
-    </div>
-
-    <div bsModalBody>
-      <!-- Search box -->
-      <bs-grid>
-        <div bsRow class="mb-3">
-          <div [col]>
-            <bs-input-group>
-              <span class="input-group-text">
-                <spark-icon name="search" />
-              </span>
-              <input
-                type="text"
-                [placeholder]="'common.search' | t"
-                [ngModel]="lookupSearchTerm()"
-                (ngModelChange)="lookupSearchTerm.set($event)">
-              @if (lookupSearchTerm()) {
-                <button
-                  type="button"
-                  class="btn btn-outline-secondary"
-                  (click)="lookupSearchTerm.set('')">
-                  <spark-icon name="x-lg" />
-                </button>
-              }
-            </bs-input-group>
-          </div>
-        </div>
-      </bs-grid>
-
-      <!-- List of items -->
-      <bs-table [striped]="true" [hover]="true">
-        <tbody class="align-middle">
-          @for (item of filteredLookupItems(); track item.key) {
-            <tr
-              [class.table-primary]="formData()[editingLookupAttr()?.name ?? ''] === item.key"
-              (click)="selectLookupItem(item)"
-              style="cursor: pointer;">
-              <td>{{ item.values | resolveTranslation:item.key }}</td>
-            </tr>
-          } @empty {
-            <tr>
-              <td class="text-center text-muted">{{ 'common.noItemsFound' | t }}</td>
-            </tr>
-          }
-        </tbody>
-      </bs-table>
-    </div>
-
-    <div bsModalFooter>
-      <button type="button" [color]="colors.secondary" (click)="closeLookupModal()">{{ 'common.cancel' | t }}</button>
     </div>
   </div>
 </bs-modal>

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.spec.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.spec.ts
@@ -8,6 +8,7 @@ import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
 import {
   EntityAttributeDefinition,
   EntityType,
+  EReferenceDisplayType,
   LookupReference,
   LookupReferenceValue,
   PersistentObject,
@@ -60,7 +61,7 @@ const allCompanies: PersistentObject[] = [
 const rolesLookup: LookupReference = {
   name: 'Roles',
   isTransient: false,
-  displayType: 1,
+  displayType: 0,
   values: [
     { key: 'admin', values: { en: 'Admin' } as any, isActive: true },
     { key: 'legacy', values: { en: 'Legacy' } as any, isActive: false },
@@ -195,84 +196,28 @@ describe('SparkPoFormComponent', () => {
     });
   });
 
-  describe('lookup modal', () => {
-    it('openLookupSelector seeds items and opens the modal; selectLookupItem updates formData and closes', async () => {
-      const { fixture, component } = createComponent();
-      await setEntityType(fixture, personType);
-      const roleAttr = personType.attributes.find(a => a.name === 'Role')!;
-
-      component.openLookupSelector(roleAttr);
-      expect(component.showLookupModal()).toBe(true);
-      expect(component.lookupModalItems()).toHaveLength(1);
-
-      component.selectLookupItem({ key: 'admin', values: { en: 'Admin' } as any, isActive: true });
-
-      expect(component.formData()['Role']).toBe('admin');
-      expect(component.showLookupModal()).toBe(false);
-      expect(component.editingLookupAttr()).toBeNull();
-    });
-
-    it('filteredLookupItems narrows items by search term (case-insensitive, matches key or translation)', async () => {
-      const { fixture, component } = createComponent();
-      await setEntityType(fixture, personType);
-      const roleAttr = personType.attributes.find(a => a.name === 'Role')!;
-
-      component.openLookupSelector(roleAttr);
-      component.lookupSearchTerm.set('adm');
-
-      expect(component.filteredLookupItems().map(i => i.key)).toEqual(['admin']);
-
-      component.lookupSearchTerm.set('nope');
-      expect(component.filteredLookupItems()).toHaveLength(0);
-    });
-  });
-
-  describe('reference modal', () => {
-    it('openReferenceSelector loads the matching entity type and seeds paginationData', async () => {
-      const companyType: EntityType = { id: 't-company', name: 'Company', clrType: 'Test.Company', attributes: [] };
-      const { fixture, component, service } = createComponent({
-        getEntityTypes: vi.fn().mockResolvedValue([personType, companyType]),
-      });
-      await setEntityType(fixture, personType);
-      const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
-
-      await component.openReferenceSelector(companyAttr);
-
-      expect(service.getEntityTypes).toHaveBeenCalled();
-      expect(component.referenceModalEntityType()?.clrType).toBe('Test.Company');
-      expect(component.showReferenceModal()).toBe(true);
-      expect(component.referenceModalPagination()?.totalRecords).toBe(1);
-    });
-
-    it('selectReferenceItem writes the item id into formData and closes the modal', async () => {
+  describe('picker value-change handlers', () => {
+    // The modal pick UI now lives in spark-reference-picker / spark-lookup-picker;
+    // the form's job is only to write the emitted value back into formData.
+    it('onReferenceValueChange writes the emitted id into formData', async () => {
       const { fixture, component } = createComponent();
       await setEntityType(fixture, personType);
       const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
-      await component.openReferenceSelector(companyAttr);
 
-      component.selectReferenceItem(allCompanies[0]);
-
+      component.onReferenceValueChange(companyAttr, 'companies/1');
       expect(component.formData()['Company']).toBe('companies/1');
-      expect(component.showReferenceModal()).toBe(false);
+
+      component.onReferenceValueChange(companyAttr, null);
+      expect(component.formData()['Company']).toBeNull();
     });
 
-    it('onReferenceSearchChange narrows paginationData to matching items by name', async () => {
-      const more = [
-        { id: 'companies/1', name: 'Acme', objectTypeId: 't-company', attributes: [] } as any,
-        { id: 'companies/2', name: 'Globex', objectTypeId: 't-company', attributes: [] } as any,
-      ];
-      const { fixture, component } = createComponent({
-        executeQueryByName: vi.fn().mockResolvedValue({ data: more, totalRecords: 2 }),
-      });
+    it('onLookupValueChange writes the emitted key into formData', async () => {
+      const { fixture, component } = createComponent();
       await setEntityType(fixture, personType);
-      const companyAttr = personType.attributes.find(a => a.name === 'Company')!;
-      await component.openReferenceSelector(companyAttr);
+      const roleAttr = personType.attributes.find(a => a.name === 'Role')!;
 
-      component.referenceSearchTerm = 'glob';
-      component.onReferenceSearchChange();
-
-      expect(component.referenceModalPagination()?.data).toHaveLength(1);
-      expect(component.referenceModalPagination()?.data[0].name).toBe('Globex');
+      component.onLookupValueChange(roleAttr, 'admin');
+      expect(component.formData()['Role']).toBe('admin');
     });
   });
 
@@ -497,6 +442,67 @@ describe('SparkPoFormComponent', () => {
       expect(component.hasInlineError(items, 0, label)).toBe(false);
       expect(component.inlineErrorMessage(items, 1, label)).toBe('Label required');
       expect(component.inlineErrorMessage(items, 0, label)).toBeNull();
+    });
+
+    it('B6: an inline Reference column flagged Modal renders the reference picker, not a <bs-select>', async () => {
+      const refChild: EntityType = {
+        id: 't-refchild', name: 'RefChild', clrType: 'Test.RefChild',
+        attributes: [attr({ id: 'c-co', name: 'CompanyId', dataType: 'Reference', order: 1, query: 'CompanyQuery', referenceType: 'Test.Company', referenceDisplayType: EReferenceDisplayType.Modal })],
+      };
+      const refParent: EntityType = {
+        id: 't-refparent', name: 'RefParent', clrType: 'Test.RefParent',
+        attributes: [attr({ id: 'a-rows', name: 'Rows', dataType: 'AsDetail', isArray: true, editMode: 'inline', asDetailType: 'Test.RefChild', order: 1 })],
+      };
+      const { fixture, component } = createComponent({
+        getEntityTypes: vi.fn().mockResolvedValue([refParent, refChild]),
+      });
+      component.formData.set({ Rows: [{ CompanyId: null }] });
+      await setEntityType(fixture, refParent);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('spark-reference-picker')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('tbody bs-select')).toBeFalsy();
+    });
+
+    it('B6: an inline Reference column without the flag still renders a <bs-select>', async () => {
+      const refChild: EntityType = {
+        id: 't-refchild2', name: 'RefChild2', clrType: 'Test.RefChild2',
+        attributes: [attr({ id: 'c-co', name: 'CompanyId', dataType: 'Reference', order: 1, query: 'CompanyQuery', referenceType: 'Test.Company' })],
+      };
+      const refParent: EntityType = {
+        id: 't-refparent2', name: 'RefParent2', clrType: 'Test.RefParent2',
+        attributes: [attr({ id: 'a-rows', name: 'Rows', dataType: 'AsDetail', isArray: true, editMode: 'inline', asDetailType: 'Test.RefChild2', order: 1 })],
+      };
+      const { fixture, component } = createComponent({
+        getEntityTypes: vi.fn().mockResolvedValue([refParent, refChild]),
+      });
+      component.formData.set({ Rows: [{ CompanyId: null }] });
+      await setEntityType(fixture, refParent);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('spark-reference-picker')).toBeFalsy();
+      expect(fixture.nativeElement.querySelector('tbody bs-select')).toBeTruthy();
+    });
+
+    it('B7: an inline lookup column with a Modal-display lookup renders the lookup picker', async () => {
+      const modalLookup = { ...rolesLookup, displayType: 1 } as LookupReference;
+      const lkChild: EntityType = {
+        id: 't-lkchild', name: 'LkChild', clrType: 'Test.LkChild',
+        attributes: [attr({ id: 'c-role', name: 'Role', lookupReferenceType: 'Roles', order: 1 })],
+      };
+      const lkParent: EntityType = {
+        id: 't-lkparent', name: 'LkParent', clrType: 'Test.LkParent',
+        attributes: [attr({ id: 'a-rows', name: 'Rows', dataType: 'AsDetail', isArray: true, editMode: 'inline', asDetailType: 'Test.LkChild', order: 1 })],
+      };
+      const { fixture, component } = createComponent({
+        getEntityTypes: vi.fn().mockResolvedValue([lkParent, lkChild]),
+        getLookupReference: vi.fn().mockResolvedValue(modalLookup),
+      });
+      component.formData.set({ Rows: [{ Role: null }] });
+      await setEntityType(fixture, lkParent);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('spark-lookup-picker')).toBeTruthy();
     });
   });
 

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.ts
@@ -11,21 +11,17 @@ import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
 import { BsSelectComponent, BsSelectOption } from '@mintplayer/ng-bootstrap/select';
 import { BsTreeSelectComponent, InMemoryTreeSelectProvider, TreeNode } from '@mintplayer/ng-bootstrap/tree-select';
 import { BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective } from '@mintplayer/ng-bootstrap/modal';
-import { BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, DatatableSettings } from '@mintplayer/ng-bootstrap/datatable';
 import { BsCheckboxComponent } from '@mintplayer/ng-bootstrap/checkbox';
 import { BsSpinnerComponent } from '@mintplayer/ng-bootstrap/spinner';
 import { BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective } from '@mintplayer/ng-bootstrap/tab-control';
 import { BsTableComponent } from '@mintplayer/ng-bootstrap/table';
-import { PaginationResponse } from '@mintplayer/pagination';
 import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
 import {
   TranslateKeyPipe,
   ResolveTranslationPipe,
   InputTypePipe,
-  LookupDisplayValuePipe,
   LookupDisplayTypePipe,
   LookupOptionsPipe,
-  ReferenceDisplayValuePipe,
   AsDetailDisplayValuePipe,
   AsDetailTypePipe,
   AsDetailColumnsPipe,
@@ -33,11 +29,11 @@ import {
   CanCreateDetailRowPipe,
   CanDeleteDetailRowPipe,
   InlineRefOptionsPipe,
-  ReferenceAttrValuePipe,
   ErrorForAttributePipe,
 } from '@mintplayer/ng-spark/pipes';
 import {
   ELookupDisplayType,
+  EReferenceDisplayType,
   EntityPermissions,
   EntityType,
   EntityAttributeDefinition,
@@ -46,7 +42,6 @@ import {
   LookupReference,
   LookupReferenceValue,
   PersistentObject,
-  PersistentObjectAttribute,
   ValidationError,
   ShowedOn,
   hasShowedOnFlag,
@@ -54,10 +49,12 @@ import {
 } from '@mintplayer/ng-spark/models';
 import { SparkIconComponent } from '@mintplayer/ng-spark/icon';
 import { SPARK_ATTRIBUTE_RENDERERS } from '@mintplayer/ng-spark/renderers';
+import { SparkReferencePickerComponent } from './spark-reference-picker.component';
+import { SparkLookupPickerComponent } from './spark-lookup-picker.component';
 
 @Component({
   selector: 'spark-po-form',
-  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPreview, BsCardComponent, BsCardHeaderComponent, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsGridColDirective, BsColFormLabelDirective, BsButtonTypeDirective, BsInputGroupComponent, BsSelectComponent, BsSelectOption, BsTreeSelectComponent, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsTableComponent, BsCheckboxComponent, BsSpinnerComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, SparkIconComponent, SparkPoFormComponent, TranslateKeyPipe, ResolveTranslationPipe, InputTypePipe, LookupDisplayValuePipe, LookupDisplayTypePipe, LookupOptionsPipe, ReferenceDisplayValuePipe, AsDetailDisplayValuePipe, AsDetailTypePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, CanCreateDetailRowPipe, CanDeleteDetailRowPipe, InlineRefOptionsPipe, ReferenceAttrValuePipe, ErrorForAttributePipe],
+  imports: [CommonModule, NgTemplateOutlet, NgComponentOutlet, FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPreview, BsCardComponent, BsCardHeaderComponent, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsGridColDirective, BsColFormLabelDirective, BsButtonTypeDirective, BsInputGroupComponent, BsSelectComponent, BsSelectOption, BsTreeSelectComponent, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsTableComponent, BsCheckboxComponent, BsSpinnerComponent, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, SparkIconComponent, SparkPoFormComponent, SparkReferencePickerComponent, SparkLookupPickerComponent, TranslateKeyPipe, ResolveTranslationPipe, InputTypePipe, LookupDisplayTypePipe, LookupOptionsPipe, AsDetailDisplayValuePipe, AsDetailTypePipe, AsDetailColumnsPipe, AsDetailCellValuePipe, CanCreateDetailRowPipe, CanDeleteDetailRowPipe, InlineRefOptionsPipe, ErrorForAttributePipe],
   templateUrl: './spark-po-form.component.html',
   // The CDK drag placeholder is a clone of the dragged row (so it keeps the exact row
   // height). Hide its contents but keep it occupying space, so the drop gap is blank and
@@ -105,25 +102,11 @@ export class SparkPoFormComponent {
   // Reference options for columns within array AsDetail types (keyed by parent attr name, then column name)
   asDetailReferenceOptions = signal<Record<string, Record<string, PersistentObject[]>>>({});
 
-  // Modal state for Reference selection
-  editingReferenceAttr = signal<EntityAttributeDefinition | null>(null);
-  showReferenceModal = signal(false);
-  referenceModalItems = signal<PersistentObject[]>([]);
-  referenceModalEntityType = signal<EntityType | null>(null);
-  referenceModalPagination = signal<PaginationResponse<PersistentObject> | undefined>(undefined);
-  referenceModalSettings = signal(new DatatableSettings({
-    perPage: { values: [10, 25, 50], selected: 10 },
-    page: { values: [1], selected: 1 },
-    sortColumns: []
-  }));
-  referenceSearchTerm = '';
-
-  // Modal state for LookupReference selection (Modal display type)
-  editingLookupAttr = signal<EntityAttributeDefinition | null>(null);
-  showLookupModal = signal(false);
-  lookupModalItems = signal<LookupReferenceValue[]>([]);
-  lookupSearchTerm = signal('');
+  // Reference/Lookup picking is owned by the standalone spark-reference-picker /
+  // spark-lookup-picker components (per-instance modal state); the form just feeds them
+  // options and writes the emitted value back into formData / the row.
   ELookupDisplayType = ELookupDisplayType;
+  EReferenceDisplayType = EReferenceDisplayType;
 
   editableAttributes = computed(() => {
     return this.entityType()?.attributes
@@ -162,27 +145,6 @@ export class SparkPoFormComponent {
   attrsForGroup(group: AttributeGroup): EntityAttributeDefinition[] {
     return this.editableAttributes().filter(a => a.group === group.id);
   }
-
-  referenceVisibleAttributes = computed(() => {
-    return this.referenceModalEntityType()?.attributes
-      .filter(a => a.isVisible)
-      .sort((a, b) => a.order - b.order) || [];
-  });
-
-  // Typed rows for the reference-modal datatable so its generic infers
-  // PersistentObject (a `?? []` inline binding would degrade to `unknown`).
-  referenceModalRows = computed<PersistentObject[]>(() => this.referenceModalPagination()?.data ?? []);
-
-  filteredLookupItems = computed(() => {
-    if (!this.lookupSearchTerm().trim()) {
-      return this.lookupModalItems();
-    }
-    const term = this.lookupSearchTerm().toLowerCase().trim();
-    return this.lookupModalItems().filter(item => {
-      const translation = resolveTranslation(item.values);
-      return translation.toLowerCase().includes(term) || item.key.toLowerCase().includes(term);
-    });
-  });
 
   constructor() {
     effect(() => {
@@ -329,38 +291,23 @@ export class SparkPoFormComponent {
     this.lookupReferenceOptions.set(this.toRecord(entries));
   }
 
-  getReferenceOptions(attr: EntityAttributeDefinition): PersistentObject[] {
-    return this.referenceOptions()[attr.name] || [];
-  }
-
   getLookupOptions(attr: EntityAttributeDefinition): LookupReferenceValue[] {
     const lookupRef = attr.lookupReferenceType ? this.lookupReferenceOptions()[attr.lookupReferenceType] : null;
     return lookupRef?.values.filter(v => v.isActive) || [];
   }
 
-  // LookupReference modal methods
-  openLookupSelector(attr: EntityAttributeDefinition): void {
-    this.editingLookupAttr.set(attr);
-    this.lookupSearchTerm.set('');
-    this.lookupModalItems.set(this.getLookupOptions(attr));
-    this.showLookupModal.set(true);
+  // Write the value emitted by a top-level spark-reference-picker / spark-lookup-picker
+  // back into formData (the same write the old in-form modal selectors performed).
+  onReferenceValueChange(attr: EntityAttributeDefinition, id: string | null): void {
+    const data = { ...this.formData() };
+    data[attr.name] = id;
+    this.formData.set(data);
   }
 
-  selectLookupItem(item: LookupReferenceValue): void {
-    const attr = this.editingLookupAttr();
-    if (attr) {
-      const data = { ...this.formData() };
-      data[attr.name] = item.key;
-      this.formData.set(data);
-    }
-    this.closeLookupModal();
-  }
-
-  closeLookupModal(): void {
-    this.showLookupModal.set(false);
-    this.editingLookupAttr.set(null);
-    this.lookupModalItems.set([]);
-    this.lookupSearchTerm.set('');
+  onLookupValueChange(attr: EntityAttributeDefinition, key: string | null): void {
+    const data = { ...this.formData() };
+    data[attr.name] = key;
+    this.formData.set(data);
   }
 
   getEditRendererComponent(attr: EntityAttributeDefinition): Type<any> | null {
@@ -526,82 +473,5 @@ export class SparkPoFormComponent {
     moveItemInArray(arr, event.previousIndex, event.currentIndex);
     data[attr.name] = arr;
     this.formData.set(data);
-  }
-
-  // Reference modal methods
-  async openReferenceSelector(attr: EntityAttributeDefinition): Promise<void> {
-    this.editingReferenceAttr.set(attr);
-    this.referenceSearchTerm = '';
-    this.referenceModalItems.set(this.getReferenceOptions(attr));
-
-    const types = await this.sparkService.getEntityTypes();
-    this.referenceModalEntityType.set(types.find(t => t.clrType === attr.referenceType) || null);
-    this.referenceModalSettings.set(new DatatableSettings({
-      perPage: { values: [10, 25, 50], selected: 10 },
-      page: { values: [1], selected: 1 },
-      sortColumns: []
-    }));
-    this.applyReferenceFilter();
-    this.showReferenceModal.set(true);
-  }
-
-  onReferenceSearchChange(): void {
-    this.referenceModalSettings().page.selected = 1;
-    this.applyReferenceFilter();
-  }
-
-  applyReferenceFilter(): void {
-    let filteredItems = this.referenceModalItems();
-
-    if (this.referenceSearchTerm.trim()) {
-      const term = this.referenceSearchTerm.toLowerCase().trim();
-      filteredItems = this.referenceModalItems().filter(item => {
-        if (item.name?.toLowerCase().includes(term)) return true;
-        if (item.breadcrumb?.toLowerCase().includes(term)) return true;
-        return item.attributes.some(attr => {
-          const value = attr.breadcrumb || attr.value;
-          if (value == null) return false;
-          return String(value).toLowerCase().includes(term);
-        });
-      });
-    }
-
-    const totalPages = Math.ceil(filteredItems.length / this.referenceModalSettings().perPage.selected) || 1;
-    this.referenceModalPagination.set({
-      data: filteredItems,
-      totalRecords: filteredItems.length,
-      totalPages: totalPages,
-      perPage: this.referenceModalSettings().perPage.selected,
-      page: this.referenceModalSettings().page.selected
-    });
-
-    this.referenceModalSettings().page.values = Array.from({ length: totalPages }, (_, i) => i + 1);
-
-    if (this.referenceModalSettings().page.selected > totalPages) {
-      this.referenceModalSettings().page.selected = 1;
-    }
-  }
-
-  clearReferenceSearch(): void {
-    this.referenceSearchTerm = '';
-    this.onReferenceSearchChange();
-  }
-
-  selectReferenceItem(item: PersistentObject): void {
-    const attr = this.editingReferenceAttr();
-    if (attr) {
-      const data = { ...this.formData() };
-      data[attr.name] = item.id;
-      this.formData.set(data);
-    }
-    this.closeReferenceModal();
-  }
-
-  closeReferenceModal(): void {
-    this.showReferenceModal.set(false);
-    this.editingReferenceAttr.set(null);
-    this.referenceModalItems.set([]);
-    this.referenceModalEntityType.set(null);
-    this.referenceSearchTerm = '';
   }
 }

--- a/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.html
@@ -1,0 +1,89 @@
+<bs-input-group>
+  <input
+    type="text"
+    [id]="inputId()"
+    [value]="displayValue()"
+    readonly
+    [class.is-invalid]="isInvalid()">
+  <button
+    type="button"
+    bsInputGroupBtn
+    [color]="colors.secondary"
+    (click)="open()">
+    ...
+  </button>
+</bs-input-group>
+
+<bs-modal [isOpen]="showModal()" (isOpenChange)="!$event && close()">
+  <div *bsModal class="reference-modal">
+    <div bsModalHeader>
+      <h5 class="modal-title">{{ 'common.select' | t }} {{ title() }}</h5>
+    </div>
+
+    <div bsModalBody>
+      <!-- bs-modal portals its content into a CDK overlay outside the host form, so the
+           modal needs its own <bs-form> context for inputs to pick up .form-control styles. -->
+      <bs-form>
+      @if (entityType()) {
+        <!-- Search box -->
+        <bs-grid>
+          <div bsRow class="mb-3">
+            <div [md]="6">
+              <bs-input-group>
+                <span class="input-group-text">
+                  <spark-icon name="search" />
+                </span>
+                <input
+                  type="text"
+                  [placeholder]="'common.search' | t"
+                  [(ngModel)]="searchTerm"
+                  (ngModelChange)="onSearchChange()">
+                @if (searchTerm) {
+                  <button
+                    type="button"
+                    class="btn btn-outline-secondary"
+                    (click)="clearSearch()">
+                    <spark-icon name="x-lg" />
+                  </button>
+                }
+              </bs-input-group>
+            </div>
+            <div [md]="6" class="text-end">
+              @if (searchTerm && pagination()) {
+                <span class="text-muted">
+                  {{ pagination()!.totalRecords }} {{ pagination()!.totalRecords === 1 ? ('common.resultFound' | t) : ('common.resultsFound' | t) }}
+                </span>
+              }
+            </div>
+          </div>
+        </bs-grid>
+
+        <bs-datatable
+          [(settings)]="settings"
+          [data]="rows()"
+          (rowClick)="select($event.row)">
+          @for (attr of visibleAttributes(); track attr.id) {
+            <div *bsDatatableColumn="attr.name; sortable: true">
+              {{ attr.label | resolveTranslation:attr.name }}
+            </div>
+          }
+
+          <ng-container *bsRowTemplate="let item">
+            @for (attr of visibleAttributes(); track attr.id) {
+              <td>{{ $any(item) | referenceAttrValue:attr.name }}</td>
+            }
+          </ng-container>
+        </bs-datatable>
+      } @else {
+        <div class="text-center p-3">
+          <bs-spinner />
+        </div>
+      }
+      </bs-form>
+    </div>
+
+    <div bsModalFooter>
+      <button type="button" [color]="colors.secondary" (click)="close()">{{ 'common.cancel' | t }}</button>
+    </div>
+  </div>
+</bs-modal>

--- a/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.spec.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SparkReferencePickerComponent } from './spark-reference-picker.component';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { EntityType, PersistentObject } from '@mintplayer/ng-spark/models';
+
+const companyType: EntityType = { id: 't-company', name: 'Company', clrType: 'Test.Company', attributes: [] };
+
+const companies: PersistentObject[] = [
+  { id: 'companies/1', name: 'Acme', breadcrumb: 'Acme Corp', objectTypeId: 't-company', attributes: [] } as any,
+  { id: 'companies/2', name: 'Globex', objectTypeId: 't-company', attributes: [] } as any,
+];
+
+function createComponent(serviceOverrides: Partial<SparkService> = {}) {
+  const service: any = {
+    getEntityTypes: vi.fn().mockResolvedValue([companyType]),
+    ...serviceOverrides,
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      provideNoopAnimations(),
+      { provide: SparkService, useValue: service },
+      { provide: SparkLanguageService, useValue: { t: (k: string) => k } },
+    ],
+  });
+  const fixture = TestBed.createComponent(SparkReferencePickerComponent);
+  return { fixture, component: fixture.componentInstance, service };
+}
+
+describe('SparkReferencePickerComponent', () => {
+  it('displayValue prefers breadcrumb, then name, then the raw id, and shows notSelected when unset', () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', companies);
+
+    fixture.componentRef.setInput('value', 'companies/1');
+    expect(component.displayValue()).toBe('Acme Corp');
+
+    fixture.componentRef.setInput('value', 'companies/2');
+    expect(component.displayValue()).toBe('Globex');
+
+    fixture.componentRef.setInput('value', 'companies/missing');
+    expect(component.displayValue()).toBe('companies/missing');
+
+    fixture.componentRef.setInput('value', null);
+    expect(component.displayValue()).toBe('notSelected');
+  });
+
+  it('open lazily loads the target entity type for the grid columns and seeds pagination', async () => {
+    const { fixture, component, service } = createComponent();
+    fixture.componentRef.setInput('options', companies);
+    fixture.componentRef.setInput('referenceType', 'Test.Company');
+
+    await component.open();
+
+    expect(service.getEntityTypes).toHaveBeenCalled();
+    expect(component.entityType()?.clrType).toBe('Test.Company');
+    expect(component.showModal()).toBe(true);
+    expect(component.pagination()?.totalRecords).toBe(2);
+  });
+
+  it('applyFilter narrows pagination data by name (case-insensitive)', async () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', companies);
+    fixture.componentRef.setInput('referenceType', 'Test.Company');
+    await component.open();
+
+    component.searchTerm = 'glob';
+    component.onSearchChange();
+
+    expect(component.pagination()?.data).toHaveLength(1);
+    expect(component.pagination()?.data[0].name).toBe('Globex');
+  });
+
+  it('select emits the picked id via valueChange and closes the modal', async () => {
+    const { fixture, component } = createComponent();
+    fixture.componentRef.setInput('options', companies);
+    fixture.componentRef.setInput('referenceType', 'Test.Company');
+    await component.open();
+
+    const emitted = vi.fn();
+    component.valueChange.subscribe(emitted);
+    component.select(companies[0]);
+
+    expect(emitted).toHaveBeenCalledWith('companies/1');
+    expect(component.showModal()).toBe(false);
+  });
+});

--- a/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.ts
+++ b/libs/node_packages/ng-spark/po-form/src/spark-reference-picker.component.ts
@@ -1,0 +1,150 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Color } from '@mintplayer/ng-bootstrap';
+import { BsFormComponent, BsFormControlDirective } from '@mintplayer/ng-bootstrap/form';
+import { BsGridComponent, BsGridRowDirective, BsGridColumnDirective } from '@mintplayer/ng-bootstrap/grid';
+import { BsInputGroupComponent } from '@mintplayer/ng-bootstrap/input-group';
+import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
+import { BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective } from '@mintplayer/ng-bootstrap/modal';
+import { BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, DatatableSettings } from '@mintplayer/ng-bootstrap/datatable';
+import { BsSpinnerComponent } from '@mintplayer/ng-bootstrap/spinner';
+import { PaginationResponse } from '@mintplayer/pagination';
+import { SparkService, SparkLanguageService } from '@mintplayer/ng-spark/services';
+import { EntityType, PersistentObject } from '@mintplayer/ng-spark/models';
+import { TranslateKeyPipe, ResolveTranslationPipe, ReferenceAttrValuePipe } from '@mintplayer/ng-spark/pipes';
+import { SparkIconComponent } from '@mintplayer/ng-spark/icon';
+
+/**
+ * Reusable Reference value picker: a readonly textbox showing the current selection's
+ * breadcrumb/name plus a "…" button that opens a searchable modal grid over the candidate
+ * `options`. Per-instance state (no single top-level slot), so it works for top-level
+ * reference attributes and for individual inline AsDetail reference cells alike.
+ *
+ * The parent pre-loads `options` (the query result) and passes `referenceType` (the target
+ * CLR type); the component lazily loads that EntityType's metadata on first open to render
+ * the grid's column headers. Emits the picked id via `valueChange`.
+ */
+@Component({
+  selector: 'spark-reference-picker',
+  imports: [FormsModule, BsFormComponent, BsFormControlDirective, BsGridComponent, BsGridRowDirective, BsGridColumnDirective, BsInputGroupComponent, BsButtonTypeDirective, BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalFooterDirective, BsDatatableComponent, BsDatatableColumnDirective, BsRowTemplateDirective, BsSpinnerComponent, SparkIconComponent, TranslateKeyPipe, ResolveTranslationPipe, ReferenceAttrValuePipe],
+  templateUrl: './spark-reference-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SparkReferencePickerComponent {
+  private readonly sparkService = inject(SparkService);
+  private readonly lang = inject(SparkLanguageService);
+
+  /** Currently selected referenced id (or null when unset). */
+  value = input<string | null>(null);
+  /** Candidate items to pick from (the full query result, pre-loaded by the parent). */
+  options = input<PersistentObject[]>([]);
+  /** Target entity type's CLR type name; used to load the grid's column headers. */
+  referenceType = input<string | undefined>(undefined);
+  /** Renders the field with the Bootstrap is-invalid state. */
+  isInvalid = input(false);
+  /** Optional id forwarded to the readonly input (for label association). */
+  inputId = input<string | undefined>(undefined);
+  /** Optional resolved label appended to the modal header ("Select {title}"). */
+  title = input<string>('');
+
+  valueChange = output<string | null>();
+
+  colors = Color;
+
+  showModal = signal(false);
+  entityType = signal<EntityType | null>(null);
+  pagination = signal<PaginationResponse<PersistentObject> | undefined>(undefined);
+  settings = signal(new DatatableSettings({
+    perPage: { values: [10, 25, 50], selected: 10 },
+    page: { values: [1], selected: 1 },
+    sortColumns: []
+  }));
+  searchTerm = '';
+
+  visibleAttributes = computed(() => {
+    return this.entityType()?.attributes
+      .filter(a => a.isVisible)
+      .sort((a, b) => a.order - b.order) || [];
+  });
+
+  // Typed rows so the datatable generic infers PersistentObject.
+  rows = computed<PersistentObject[]>(() => this.pagination()?.data ?? []);
+
+  displayValue = computed(() => {
+    const id = this.value();
+    if (!id) return this.lang.t('notSelected');
+    const selected = this.options().find(o => o.id === id);
+    return selected?.breadcrumb || selected?.name || id;
+  });
+
+  async open(): Promise<void> {
+    this.searchTerm = '';
+    this.settings.set(new DatatableSettings({
+      perPage: { values: [10, 25, 50], selected: 10 },
+      page: { values: [1], selected: 1 },
+      sortColumns: []
+    }));
+
+    // Lazily resolve the target entity type for the grid's column headers.
+    const refType = this.referenceType();
+    if (!this.entityType() && refType) {
+      const types = await this.sparkService.getEntityTypes();
+      this.entityType.set(types.find(t => t.clrType === refType) || null);
+    }
+
+    this.applyFilter();
+    this.showModal.set(true);
+  }
+
+  onSearchChange(): void {
+    this.settings().page.selected = 1;
+    this.applyFilter();
+  }
+
+  applyFilter(): void {
+    let filteredItems = this.options();
+
+    if (this.searchTerm.trim()) {
+      const term = this.searchTerm.toLowerCase().trim();
+      filteredItems = this.options().filter(item => {
+        if (item.name?.toLowerCase().includes(term)) return true;
+        if (item.breadcrumb?.toLowerCase().includes(term)) return true;
+        return item.attributes.some(attr => {
+          const value = attr.breadcrumb || attr.value;
+          if (value == null) return false;
+          return String(value).toLowerCase().includes(term);
+        });
+      });
+    }
+
+    const totalPages = Math.ceil(filteredItems.length / this.settings().perPage.selected) || 1;
+    this.pagination.set({
+      data: filteredItems,
+      totalRecords: filteredItems.length,
+      totalPages: totalPages,
+      perPage: this.settings().perPage.selected,
+      page: this.settings().page.selected
+    });
+
+    this.settings().page.values = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+    if (this.settings().page.selected > totalPages) {
+      this.settings().page.selected = 1;
+    }
+  }
+
+  clearSearch(): void {
+    this.searchTerm = '';
+    this.onSearchChange();
+  }
+
+  select(item: PersistentObject): void {
+    this.valueChange.emit(item.id ?? null);
+    this.close();
+  }
+
+  close(): void {
+    this.showModal.set(false);
+    this.searchTerm = '';
+  }
+}

--- a/libs/replication/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
+++ b/libs/replication/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication.Abstractions</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Replication: ReplicatedAttribute, ModuleInformation, and ETL script models.</Description>

--- a/libs/replication/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
+++ b/libs/replication/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cross-module ETL replication for MintPlayer.Spark using RavenDB ETL tasks and the durable message bus.</Description>

--- a/libs/socket_extensions/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
+++ b/libs/socket_extensions/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
@@ -8,7 +8,7 @@
 
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Extension methods for WebSocket (ReadMessage, WriteMessage, ReadObject, WriteObject)</Description>

--- a/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
+++ b/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark low-code framework. Auto-generates DI registration for Actions classes.</Description>

--- a/libs/spark/MintPlayer.Spark.Abstractions/EReferenceDisplayType.cs
+++ b/libs/spark/MintPlayer.Spark.Abstractions/EReferenceDisplayType.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace MintPlayer.Spark.Abstractions;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EReferenceDisplayType
+{
+    /// <summary>
+    /// Renders as a dropdown/select element listing every referenced item.
+    /// </summary>
+    Dropdown,
+
+    /// <summary>
+    /// Renders as a readonly textbox with a "…" button that opens a searchable modal grid picker.
+    /// </summary>
+    Modal
+}

--- a/libs/spark/MintPlayer.Spark.Abstractions/EntityTypeDefinition.cs
+++ b/libs/spark/MintPlayer.Spark.Abstractions/EntityTypeDefinition.cs
@@ -80,6 +80,14 @@ public sealed class EntityAttributeDefinition
     /// </summary>
     public string? EditMode { get; set; }
     /// <summary>
+    /// For Reference attributes, controls how the value is picked in the PO-edit UI.
+    /// <see cref="EReferenceDisplayType.Modal"/> renders a readonly textbox with a "…" button that
+    /// opens a searchable modal grid; <see cref="EReferenceDisplayType.Dropdown"/> (or null/default)
+    /// renders a <c>&lt;bs-select&gt;</c>. Hand-set in the model JSON and preserved across synchronize
+    /// (like <see cref="EditMode"/>). Only meaningful when <see cref="DataType"/> is "Reference".
+    /// </summary>
+    public EReferenceDisplayType? ReferenceDisplayType { get; set; }
+    /// <summary>
     /// For array AsDetail attributes, when true the rows can be drag-reordered in the
     /// PO-edit UI (order = array position). Set by <c>[Sortable]</c> via the synchronizer.
     /// Null/absent for non-sortable attributes. Only meaningful when

--- a/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
+++ b/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Abstractions</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions and shared models for MintPlayer.Spark low-code framework.</Description>

--- a/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Low-code .NET framework for building data-driven web applications with minimal boilerplate. Uses PersistentObject pattern to eliminate DTOs and repository layers.</Description>

--- a/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker.Abstractions/MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj
+++ b/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker.Abstractions/MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.SubscriptionWorker.Abstractions</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Public abstractions for MintPlayer.Spark.SubscriptionWorker: the SparkSubscriptionWorker&lt;T&gt; base class, RetryNumerator, options. Reference this from libraries that only need to DEFINE workers; reference the implementation package from hosts that register them.</Description>

--- a/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
+++ b/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.SubscriptionWorker</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>RavenDB subscription worker framework for MintPlayer.Spark with built-in retry logic, incremental backoff, and ASP.NET Core lifecycle management.</Description>

--- a/libs/testing/MintPlayer.Spark.Testing/MintPlayer.Spark.Testing.csproj
+++ b/libs/testing/MintPlayer.Spark.Testing/MintPlayer.Spark.Testing.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Testing</PackageId>
-    <Version>10.0.0-preview.39</Version>
+    <Version>10.0.0-preview.40</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Test harness for writing integration tests against MintPlayer.Spark apps: an embedded RavenDB driver (SparkTestDriver), an in-memory Spark host factory (SparkEndpointFactory), an antiforgery-aware HTTP client, JSON fixture seeding, index helpers, and Verify snapshot defaults.</Description>

--- a/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
+++ b/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub.DevTunnel</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Development tunneling for MintPlayer.Spark GitHub webhooks — smee.io tunnel and WebSocket dev client for receiving production-forwarded webhooks locally.</Description>

--- a/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
+++ b/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub</PackageId>
-		<Version>10.0.0-preview.39</Version>
+		<Version>10.0.0-preview.40</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>GitHub webhook integration for MintPlayer.Spark — broadcasts typed webhook events to the Spark message bus with support for production-to-dev WebSocket forwarding.</Description>


### PR DESCRIPTION
## Summary
A Reference column inside an **inline** (`editMode: "inline"`) AsDetail table was hardcoded to a `<bs-select>` listing the entire query result. This adds the searchable **"…" + modal grid** picker (the one top-level references already use) as an opt-in for inline cells, by first **extracting the picker into reusable components**.

## Linked issues
- Closes #189

## Screenshots
Before
<img width="496" height="460" alt="afbeelding" src="https://github.com/user-attachments/assets/27796bc7-7d85-4e9d-ac27-36b460b6c56a" />

After
<img width="496" height="460" alt="afbeelding" src="https://github.com/user-attachments/assets/e46c1f0c-a740-44ac-bab3-961ec32fa2d5" />

<img width="847" height="628" alt="afbeelding" src="https://github.com/user-attachments/assets/3dd95cb0-7eef-4a82-83bf-b6f74b6fcfa8" />


## Changes
- **Extract `SparkReferencePickerComponent` + `SparkLookupPickerComponent`** (standalone, per-instance modal state) from `SparkPoFormComponent`. Reused in **both** the top-level branch and the inline AsDetail cell, removing the old single-slot `referenceModal*` / `lookupModal*` state and methods.
- **New `referenceDisplayType` (Dropdown | Modal) flag** on `EntityAttributeDefinition` — a **JSON-only, hand-set** field preserved across `synchronize` (like `editMode`). Backend enum `EReferenceDisplayType` uses `JsonStringEnumConverter` (serializes `"Dropdown"`/`"Modal"`). **Default/absent → `<bs-select>` (no regression).**
- **Inline lookup parity:** inline lookup cells now honor `ELookupDisplayType` too, closing the identical hardcoded-`<select>` gap.
- Picker modals carry their own `<bs-form>` + `BsFormControlDirective` so inputs keep `.form-control` styling after `bs-modal` portals them out of the host form.
- **HR demo:** `CarreerJob.ProfessionId` flagged `Modal` to showcase the inline Jobs picker.

## Acceptance
- ✅ Inline reference column flagged Modal → "…" field + searchable modal grid; picking a row writes the id into that row; coexists with drag-reorder (#188).
- ✅ Default (no flag) still renders `<bs-select>`.
- ✅ Extracted picker reused by the top-level reference branch (no behavior change).
- ✅ Inline lookup cells honor `ELookupDisplayType`.

## Verification
- `dotnet build` (Abstractions + Spark) clean.
- 37 vitest specs pass (po-form + new reference/lookup picker specs, incl. gating in both directions).
- Live HR demo: Person → Employment → inline Jobs table renders the Profession picker; selection writes per-row; top-level Company reuses the same picker.

> ⚠️ Before merge: bump package versions if this should publish (CI auto-publishes ng-spark/NuGet on push to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)