### PR TITLE
feat(spark): add MultiLineString attribute datatype

### DIFF
--- a/libs/all_features/MintPlayer.Spark.AllFeatures.SourceGenerators/MintPlayer.Spark.AllFeatures.SourceGenerators.csproj
+++ b/libs/all_features/MintPlayer.Spark.AllFeatures.SourceGenerators/MintPlayer.Spark.AllFeatures.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.AllFeatures.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark.AllFeatures. Auto-generates AddSparkFull/UseSparkFull/MapSparkFull convenience methods.</Description>

--- a/libs/all_features/MintPlayer.Spark.AllFeatures/MintPlayer.Spark.AllFeatures.csproj
+++ b/libs/all_features/MintPlayer.Spark.AllFeatures/MintPlayer.Spark.AllFeatures.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.AllFeatures</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>All-in-one package for MintPlayer.Spark. References all Spark libraries and source-generates AddSparkFull/UseSparkFull/MapSparkFull convenience methods.</Description>

--- a/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
+++ b/libs/authorization/MintPlayer.Spark.Authorization/MintPlayer.Spark.Authorization.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Authorization</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Optional authorization package for MintPlayer.Spark low-code framework. Provides group-based access control for PersistentObjects and Queries.</Description>

--- a/libs/client/MintPlayer.Spark.Client.Authorization/MintPlayer.Spark.Client.Authorization.csproj
+++ b/libs/client/MintPlayer.Spark.Client.Authorization/MintPlayer.Spark.Client.Authorization.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Client.Authorization</PackageId>
-    <Version>10.0.0-preview.40</Version>
+    <Version>10.0.0-preview.41</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Authorization extensions for the MintPlayer.Spark typed C# client.</Description>

--- a/libs/client/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
+++ b/libs/client/MintPlayer.Spark.Client/MintPlayer.Spark.Client.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Client</PackageId>
-    <Version>10.0.0-preview.40</Version>
+    <Version>10.0.0-preview.41</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Typed C# client for consuming MintPlayer.Spark backend APIs.</Description>

--- a/libs/cron/MintPlayer.Spark.Cron/MintPlayer.Spark.Cron.csproj
+++ b/libs/cron/MintPlayer.Spark.Cron/MintPlayer.Spark.Cron.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Cron</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cron-scheduled background jobs for MintPlayer.Spark. Define jobs by implementing ISparkCronJob, declare the schedule with a static abstract CronSchedule, and let the scheduler run them. Multi-node safe via RavenDB compare-exchange locking.</Description>

--- a/libs/messaging/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
+++ b/libs/messaging/MintPlayer.Spark.Messaging.Abstractions/MintPlayer.Spark.Messaging.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging.Abstractions</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Messaging: IMessageBus, IRecipient, and MessageQueueAttribute.</Description>

--- a/libs/messaging/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
+++ b/libs/messaging/MintPlayer.Spark.Messaging/MintPlayer.Spark.Messaging.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Messaging</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Durable message bus for MintPlayer.Spark with RavenDB persistence, scoped recipients, queue isolation, and retry logic.</Description>

--- a/libs/migrations/MintPlayer.Spark.Migrations/MintPlayer.Spark.Migrations.csproj
+++ b/libs/migrations/MintPlayer.Spark.Migrations/MintPlayer.Spark.Migrations.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Migrations</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Database migrations for MintPlayer.Spark. Define migrations by implementing ISparkMigration with a static abstract Version; they run once, in version order, at startup. Multi-node safe via RavenDB compare-exchange locking, idempotent via per-version marker documents.</Description>

--- a/libs/node_packages/ng-spark/package.json
+++ b/libs/node_packages/ng-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-spark",
   "private": false,
-  "version": "22.0.7",
+  "version": "22.0.8",
   "description": "Angular component library for MintPlayer.Spark CRUD applications",
   "repository": {
     "type": "git",

--- a/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
+++ b/libs/node_packages/ng-spark/po-detail/src/spark-po-detail.component.html
@@ -163,6 +163,8 @@
                 } @else {
                   {{ (attr.name | attributeValue:item():entityType():lookupReferenceOptions():allEntityTypes()) || '-' }}
                 }
+              } @else if (attr.dataType === 'MultiLineString') {
+                <div style="white-space: pre-wrap;">{{ (attr.name | attributeValue:item():entityType():lookupReferenceOptions():allEntityTypes()) || '-' }}</div>
               } @else {
                 {{ (attr.name | attributeValue:item():entityType():lookupReferenceOptions():allEntityTypes()) || '-' }}
               }

--- a/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
+++ b/libs/node_packages/ng-spark/po-form/src/spark-po-form.component.html
@@ -168,6 +168,13 @@
                       }
                     </bs-select>
                   }
+                } @else if (col.dataType === 'MultiLineString') {
+                  <textarea
+                    [(ngModel)]="row[col.name]"
+                    [required]="col.isRequired"
+                    rows="3"
+                    [class.is-invalid]="hasInlineError(attr, rowIndex, col)"
+                    (ngModelChange)="onFieldChange()"></textarea>
                 } @else {
                   <input
                     [type]="col.dataType | inputType"
@@ -320,6 +327,15 @@
             </bs-input-group>
           } @else if (getEditRendererComponent(attr); as editComp) {
             <ng-container *ngComponentOutlet="editComp; inputs: getEditRendererInputs(attr)"></ng-container>
+          } @else if (attr.dataType === 'MultiLineString') {
+            <textarea
+              [id]="attr.name"
+              [ngModel]="formData()[attr.name]"
+              (ngModelChange)="formData()[attr.name] = $event; onFieldChange()"
+              [name]="attr.name"
+              [required]="attr.isRequired"
+              rows="6"
+              [class.is-invalid]="hasError(attr.name)"></textarea>
           } @else {
             <input
               [type]="attr.dataType | inputType"

--- a/libs/replication/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
+++ b/libs/replication/MintPlayer.Spark.Replication.Abstractions/MintPlayer.Spark.Replication.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication.Abstractions</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions for MintPlayer.Spark.Replication: ReplicatedAttribute, ModuleInformation, and ETL script models.</Description>

--- a/libs/replication/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
+++ b/libs/replication/MintPlayer.Spark.Replication/MintPlayer.Spark.Replication.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Replication</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Cross-module ETL replication for MintPlayer.Spark using RavenDB ETL tasks and the durable message bus.</Description>

--- a/libs/socket_extensions/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
+++ b/libs/socket_extensions/MintPlayer.Dotnet.SocketExtensions/MintPlayer.Dotnet.SocketExtensions.csproj
@@ -8,7 +8,7 @@
 
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Extension methods for WebSocket (ReadMessage, WriteMessage, ReadObject, WriteObject)</Description>

--- a/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
+++ b/libs/source_generators/MintPlayer.Spark.SourceGenerators/MintPlayer.Spark.SourceGenerators.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet Package Metadata -->
         <PackageId>MintPlayer.Spark.SourceGenerators</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
         <Company>MintPlayer</Company>
         <Description>Source generators for MintPlayer.Spark low-code framework. Auto-generates DI registration for Actions classes.</Description>

--- a/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
+++ b/libs/spark/MintPlayer.Spark.Abstractions/MintPlayer.Spark.Abstractions.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Abstractions</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Abstractions and shared models for MintPlayer.Spark low-code framework.</Description>

--- a/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
+++ b/libs/spark/MintPlayer.Spark/MintPlayer.Spark.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Low-code .NET framework for building data-driven web applications with minimal boilerplate. Uses PersistentObject pattern to eliminate DTOs and repository layers.</Description>

--- a/libs/spark/MintPlayer.Spark/Services/ModelSynchronizer.cs
+++ b/libs/spark/MintPlayer.Spark/Services/ModelSynchronizer.cs
@@ -390,8 +390,15 @@ internal partial class ModelSynchronizer : IModelSynchronizer
 
             if (existingAttrs.TryGetValue(propertyName, out var existingAttr))
             {
-                // Update existing attribute, preserving custom settings
-                existingAttr.DataType = dataType;
+                // Update existing attribute, preserving custom settings.
+                // "MultiLineString" is a presentation-only override of a string property (render a
+                // textarea instead of a single-line input): the CLR shape is still string, so keep a
+                // hand-set MultiLineString rather than resetting it to "string" on every sync. Any other
+                // change still wins - switching the property away from string clears it.
+                if (!(existingAttr.DataType == "MultiLineString" && dataType == "string"))
+                {
+                    existingAttr.DataType = dataType;
+                }
                 existingAttr.Order = existingAttr.Order > 0 ? existingAttr.Order : order;
 
                 if (referenceAttr != null)

--- a/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker.Abstractions/MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj
+++ b/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker.Abstractions/MintPlayer.Spark.SubscriptionWorker.Abstractions.csproj
@@ -7,7 +7,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.SubscriptionWorker.Abstractions</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Public abstractions for MintPlayer.Spark.SubscriptionWorker: the SparkSubscriptionWorker&lt;T&gt; base class, RetryNumerator, options. Reference this from libraries that only need to DEFINE workers; reference the implementation package from hosts that register them.</Description>

--- a/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
+++ b/libs/subscription_worker/MintPlayer.Spark.SubscriptionWorker/MintPlayer.Spark.SubscriptionWorker.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.SubscriptionWorker</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>RavenDB subscription worker framework for MintPlayer.Spark with built-in retry logic, incremental backoff, and ASP.NET Core lifecycle management.</Description>

--- a/libs/testing/MintPlayer.Spark.Testing/MintPlayer.Spark.Testing.csproj
+++ b/libs/testing/MintPlayer.Spark.Testing/MintPlayer.Spark.Testing.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>MintPlayer.Spark.Testing</PackageId>
-    <Version>10.0.0-preview.40</Version>
+    <Version>10.0.0-preview.41</Version>
     <Authors>MintPlayer</Authors>
     <Company>MintPlayer</Company>
     <Description>Test harness for writing integration tests against MintPlayer.Spark apps: an embedded RavenDB driver (SparkTestDriver), an in-memory Spark host factory (SparkEndpointFactory), an antiforgery-aware HTTP client, JSON fixture seeding, index helpers, and Verify snapshot defaults.</Description>

--- a/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
+++ b/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub.DevTunnel/MintPlayer.Spark.Webhooks.GitHub.DevTunnel.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub.DevTunnel</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Development tunneling for MintPlayer.Spark GitHub webhooks — smee.io tunnel and WebSocket dev client for receiving production-forwarded webhooks locally.</Description>

--- a/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
+++ b/libs/webhooks/MintPlayer.Spark.Webhooks.GitHub/MintPlayer.Spark.Webhooks.GitHub.csproj
@@ -9,7 +9,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>MintPlayer.Spark.Webhooks.GitHub</PackageId>
-		<Version>10.0.0-preview.40</Version>
+		<Version>10.0.0-preview.41</Version>
 		<Authors>MintPlayer</Authors>
 		<Company>MintPlayer</Company>
 		<Description>GitHub webhook integration for MintPlayer.Spark — broadcasts typed webhook events to the Spark message bus with support for production-to-dev WebSocket forwarding.</Description>

--- a/tests/MintPlayer.Spark.Tests/Services/ModelSynchronizerTests.cs
+++ b/tests/MintPlayer.Spark.Tests/Services/ModelSynchronizerTests.cs
@@ -213,6 +213,30 @@ public sealed class ModelSynchronizerTests : IDisposable
     }
 
     [Fact]
+    public void MultiLineString_dataType_is_preserved_on_re_synchronize()
+    {
+        var ctx = new OrderedContext();
+        var sync = CreateSynchronizer();
+
+        sync.SynchronizeModels(ctx);
+
+        // Hand-edit: promote the plain string "Name" attribute to a MultiLineString (textarea) presentation.
+        var path = ModelFile("MS_OrderedParent");
+        var tampered = System.Text.RegularExpressions.Regex.Replace(
+            File.ReadAllText(path),
+            "(\"name\": \"Name\".*?\"dataType\": )\"string\"",
+            "$1\"MultiLineString\"",
+            System.Text.RegularExpressions.RegexOptions.Singleline);
+        File.WriteAllText(path, tampered);
+
+        sync.SynchronizeModels(ctx);
+
+        var file = Read<EntityTypeFile>(path);
+        file.PersistentObject.Attributes.Single(a => a.Name == "Name").DataType
+            .Should().Be("MultiLineString", "a hand-set MultiLineString is a presentation override the synchronizer preserves across re-sync");
+    }
+
+    [Fact]
     public void Synthesizes_a_default_breadcrumb_from_the_first_attribute_when_none_authored()
     {
         var ctx = new SinglePersonContext();


### PR DESCRIPTION
## What

Adds a **`MultiLineString`** attribute datatype so a `string` property can render as a multi-line `<textarea>` instead of a single-line `<input>`.

- **PO edit form** (`spark-po-form`): textarea for top-level fields and inline AsDetail cells (`@else if (dataType === 'MultiLineString')`), inheriting the existing `<bs-form>` form-control styling.
- **PO detail view** (`spark-po-detail`): renders the value in a `white-space: pre-wrap` block so line breaks are preserved.
- **ModelSynchronizer**: opt in by hand-editing an attribute's `dataType` to `"MultiLineString"` in the model JSON. The synchronizer now **preserves** that value on re-sync when the CLR property is still a `string` (any other shape change still wins — switching the property off `string` resets it). No new C# attribute needed; this mirrors how `editMode`/`isVisible` hand-edits survive sync.

## Why

Downstream apps (MintPlayer) need a textarea for fields like song lyrics, edited through the standard PO edit form rather than a bespoke editor.

## Tests

- New `ModelSynchronizerTests.MultiLineString_dataType_is_preserved_on_re_synchronize` (23/23 green locally).
- `nx build @mintplayer/ng-spark` succeeds.

## Versions

- NuGet packages → `10.0.0-preview.41`
- `@mintplayer/ng-spark` → `22.0.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)