### PR TITLE
docs(security): Round-4 audit findings + implementation plan

### DIFF
--- a/docs/prd/PRD-SecurityAudit-Round4-Plan.md
+++ b/docs/prd/PRD-SecurityAudit-Round4-Plan.md
@@ -1,0 +1,104 @@
+# Implementation plan — Security Audit Round 4
+
+Companion to [`PRD-SecurityAudit.md` §11](./PRD-SecurityAudit.md). Same shape as prior rounds: **TDD — a failing test that pins the secure behavior first, then the fix.** One `fix(security)` PR on branch `security-audit`, ordered by severity so the High lands first and can ship alone if triage wants to split.
+
+Every finding below was verified against code on HEAD by an adversarial verifier (see PRD §11 method). Existing e2e security tests live in `tests/MintPlayer.Spark.E2E.Tests/Security/`; unit tests in `tests/MintPlayer.Spark.Tests/`. New tests extend those files where one already covers the surface.
+
+## Ordering & bundling
+
+1. **R4-H1** — query/stream row-level authz bypass *(the one High; fix first)*
+2. **R4-M1 + R4-M2** — replication dev-mode mTLS bypass + ETL SSRF *(same file, one workstream)*
+3. **R4-M3** — combined-action deny
+4. **R4-L1 / L2 / L3 / L4** — lookupref reads, register enumeration, mandatory ETag, WS origin port
+5. **Sweep-in from §11.3** — H-1b (read-path visibility) and R2-M6 (webhook replay) are the two highest-value still-open priors; include unless triage defers.
+
+Each step: write the red test, make it green, keep the diff minimal (per the "minimal PR diff" preference — no formatter/schematic churn).
+
+---
+
+## Step 1 — R4-H1: enforce the row-level hook on query + stream paths (HIGH)
+
+**Design decision (PRD triage Q2):** push the per-row filter into a single shared seam so the three read surfaces can't drift again. `DatabaseAccess.FilterByRowLevelAuthAsync` already implements it for `/spark/po`; extract the row-filtering into an `IRowSecurity`-backed helper (it already exists — `QueryExecutor` simply doesn't inject it) and call it from both query executors after the entity-type `EnsureAuthorizedAsync` check.
+
+**Red test** — `tests/MintPlayer.Spark.E2E.Tests/Security/RowLevelAuthzTests.cs` (extend):
+- `Query_execute_applies_row_level_authz`: as a non-admin owning only their own `Car`, `GET /spark/queries/{GetCars}/execute` returns only their rows, not the admin's. Fails today (returns all).
+- `Query_stream_applies_row_level_authz`: same assertion over the WebSocket stream (`/spark/queries/{id}/stream`).
+- `Custom_query_applies_row_level_authz`: same for a `Custom.*` source (e.g. Fleet's `Stolen_Cars`).
+
+**Fix:**
+- `libs/spark/MintPlayer.Spark/Services/QueryExecutor.cs` — inject the row-security filter; apply it in `ExecuteDatabaseQueryAsync` (`:126`) and `ExecuteCustomQueryAsync` (`:194`) over the materialized results before mapping/returning.
+- `libs/spark/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs:50` — apply the same filter per batch before yielding (`:84-93`).
+- Reuse the exact predicate `DatabaseAccess` uses (`IsAllowedAsync("Query", entity)` via the Actions class) so behavior is identical across `/po`, `/queries/execute`, `/queries/stream`.
+
+**Watch:** custom queries return projections, not always the entity type — the filter must resolve the row's owning entity-type/Actions the same way `DatabaseAccess` does; where a projection can't be mapped back to an entity (the `V*` context-property case noted in project memory), fail closed (exclude) rather than leak.
+
+---
+
+## Step 2 — R4-M1 + R4-M2: replication dev-mode bypass + ETL SSRF (MEDIUM ×2)
+
+**Red tests** — `tests/MintPlayer.Spark.E2E.Tests/Security/ReplicationEndpointAuthTests.cs` (extend):
+- `Dev_mode_sync_apply_still_requires_module_and_cert`: host in Development, default options, unauth `POST /spark/sync/apply` with a made-up `RequestingModule` → 401/403; `ISyncActionHandler` never invoked. (Today: 200.)
+- `Etl_deploy_rejects_target_url_outside_allowlist`: `DeployAsync` with a `TargetUrls` entry not in the allow-list → error, `PutConnectionStringOperation` never sent. (In-process test against `EtlTaskManager`, mirroring existing `EtlDeployEndpointTests`.)
+
+**Fix (R4-M1)** — `libs/replication/MintPlayer.Spark.Replication/Services/ModuleCertificateValidator.cs`:
+- Development branch (`:65-78`) must still load `moduleInformations/{requestingModule}` from `SparkModules` and 403 on unknown (the code comment already claims this — make it true).
+- `ResolveMode` (`:45-53`): stop treating `Auto`→`Development` as "no cert". Require explicit `Mode=Disabled` to skip certs; when disabled, the endpoints bind loopback-only (or aren't mapped). Update `SparkReplicationOptions.cs` doc-comment for the `Mode` enum.
+
+**Fix (R4-M2)** — `libs/replication/MintPlayer.Spark.Replication/Services/EtlTaskManager.cs:53-60`:
+- Add an operator-configured allow-list on `SparkReplicationOptions` (peer hosts / required `https`). Validate every `TargetUrls` entry before assigning `TopologyDiscoveryUrls`; reject with a clear error otherwise.
+
+**Triage note (PRD Q4):** if dev boxes are always loopback-only, R4-M1 drops toward Low — confirm the deployment posture before deciding how hard to gate.
+
+---
+
+## Step 3 — R4-M3: combined-action DENY expansion (MEDIUM)
+
+**Red test** — `tests/MintPlayer.Spark.Tests/Authorization/` (new `AccessControlServiceDenyTests.cs`, or extend the existing access-control unit tests):
+- `Combined_form_deny_blocks_expanded_action`: rights = broad grant `QueryReadEditNewDelete/Car` (Everyone) + combined deny `EditNewDelete/Car` (group G); a member of G requesting `Edit/Car` → **denied**. Fails today (allowed).
+- Guard test: an exact-form deny still works (regression).
+
+**Fix** — `libs/authorization/MintPlayer.Spark.Authorization/Services/AccessControlService.cs`:
+- In the denial-evaluation step (`:70`), match deny rights via **both** exact `MatchesResource` **and** `IsCombinedActionMatch` (`:136-151`) — i.e. apply the same combined-action expansion to denies that `:85` currently applies only to allows. Deny short-circuits before any grant. Preserve the "denials take precedence" invariant (comment at `:69`).
+
+---
+
+## Step 4 — Lows
+
+### R4-L1 — gate LookupReference reads
+**Red test** — `tests/MintPlayer.Spark.E2E.Tests/Security/LookupReferenceAuthTests.cs` (extend): `Anonymous_lookupref_list_is_refused` and `Anonymous_lookupref_get_is_refused` → 401.
+**Fix** — `libs/spark/MintPlayer.Spark/Endpoints/LookupReferences/List.cs`, `Get.cs`: inject `IPermissionService`, add `EnsureAuthorizedAsync("Read","LookupReferences")` (mirror the resource used by the R2-H4 `AddValue`/`UpdateValue`/`DeleteValue` gate and the EntityTypes read gate).
+
+### R4-L2 — register account-enumeration
+**Red test** — new `tests/MintPlayer.Spark.E2E.Tests/Security/RegisterEnumerationTests.cs`: `Register_response_is_indistinguishable_for_taken_vs_free_email` (status + body shape identical; no address echoed).
+**Fix** — `libs/authorization/MintPlayer.Spark.Authorization/Identity/UserStore.cs:60-66`: return a generic failure (don't echo the email; use a non-`DuplicateEmail`-distinguishable result), **or** wrap the mapped `/register` endpoint to normalize its response. Simplest robust option: post-process the register result to a generic 400. Document the choice — this overrides stock `MapIdentityApi` behavior.
+
+### R4-L3 — mandatory optimistic concurrency
+**Red test** — `tests/MintPlayer.Spark.E2E.Tests/Security/ConcurrencyTests.cs` (extend): `Update_without_etag_is_rejected` (PUT existing record, no `Etag` → 400/428) **or** `Two_concurrent_etagless_updates_conflict` (second → 409).
+**Fix** — `libs/spark/MintPlayer.Spark/Services/DatabaseAccess.cs:216`: require `Etag` for updates of existing records (reject when empty), **or** set `session.Advanced.UseOptimisticConcurrency = true` on the write session (`SparkMiddleware.cs:113-114`) so the save is conditional on the loaded change vector — closing the TOCTOU gap between `checkSession` and the save session. Prefer the session flag: it's atomic and removes the separate-session check entirely.
+
+### R4-L4 — WebSocket origin port
+**Red test** — `tests/MintPlayer.Spark.E2E.Tests/Security/WebSocketOriginTests.cs` (extend): `WS_rejects_same_host_different_port` (`Origin: https://<host>:<other-port>` → 403).
+**Fix** — `libs/spark/MintPlayer.Spark/SparkMiddleware.cs:226-233`: compare the full authority (`Request.Host.ToString()` / host+port, ideally scheme) instead of `originUri.Host` vs `Request.Host.Host`, or match against an explicit allowed-origins list.
+
+---
+
+## Step 5 — Sweep-in from §11.3 (recommended, confirm at triage)
+
+### H-1b — read-path attribute visibility (MEDIUM)
+Decide semantics first (PRD Q3). If `IsVisible=false` is a confidentiality control: add a read-side gate symmetric with `IsWritableBySchema` — in `EntityMapper.PopulateAttributeValues` (`:208-230`), omit/null `Value` for `IsVisible=false` attributes (and honor a per-caller `IsAttributeVisibleAsync` hook, the H-1b design). If it's a pure UI hint: stop gating writes on it and document that. Either way, make read and write symmetric.
+**Test** — `tests/MintPlayer.Spark.E2E.Tests/Security/AttributeWriteProtectionTests.cs` companion (new `AttributeReadVisibilityTests.cs`): an `IsVisible=false` attribute's value is not present in `GET /spark/po/{type}/{id}` nor in `/spark/queries/{id}/execute`.
+
+### R2-M6 — webhook delivery replay (MEDIUM)
+**Test** — `tests/MintPlayer.Spark.E2E.Tests/Security/` (webhook area): `Replayed_delivery_is_dropped` — same signed body + `X-GitHub-Delivery` twice → second is a no-op (no second broadcast).
+**Fix** — `libs/webhooks/MintPlayer.Spark.Webhooks.GitHub/Services/SparkWebhookEventProcessor.cs:35-83`: record processed `X-GitHub-Delivery` IDs in a bounded-TTL store (RavenDB doc with expiry / compare-exchange) and drop duplicates; optionally reject deliveries outside a timestamp window.
+
+**Defer (document, don't fix this PR unless asked):** M-2 (claim-issuer trust) — natural home is the IdentityProvider/OIDC multi-issuer work (PRD Q5); M-4 (`[SparkQuery]` opt-in) — footgun, not reachable; R2-H19 (`navigate` client-op) — inert until a navigate handler ships. Leave a one-line tracking note in each so they aren't lost (per the "out-of-scope follow-through" preference).
+
+---
+
+## Verification
+
+- Per fix: `dotnet test tests/MintPlayer.Spark.E2E.Tests --filter <TestClass>` red → green.
+- Full security suite green before PR: `dotnet test tests/MintPlayer.Spark.E2E.Tests --filter FullyQualifiedName~Security` + `dotnet test tests/MintPlayer.Spark.Tests`.
+- Do **not** run `ng build`/`ng serve` for any frontend-touching change — the ASP.NET host proxies the dev server; save + live-reload (per repo guidance).
+- CI auto-publishes on push to master — land this via PR to `master`, never hand-publish from the branch.

--- a/docs/prd/PRD-SecurityAudit.md
+++ b/docs/prd/PRD-SecurityAudit.md
@@ -1353,3 +1353,174 @@ Test coverage added: `AddJob_throws_when_the_schedule_is_unparseable` (Theory), 
 2. **R3-M1 framing** — is cron lock-poisoning in-threat-model given there's no reachable compare-exchange write path today? If treated as pure robustness/observability, the heartbeat + Warning-escalation parts are the high-value pieces and the value-validation is defense-in-depth.
 3. **R3-M2** — fail-fast at registration (recommended) vs. keep runtime-only but escalate to Warning + disable. Fail-fast is consistent with the existing whitespace check.
 4. **R3-L1** — documentation-only, or also ship an opt-in principal/tenant-scoping hook for cron jobs?
+
+## 11. Round 4 — Full-repo re-audit + regression sweep (2026-07-02)
+
+**Status:** Draft — awaiting triage.
+**Scope:** whole repository at branch `security-audit` (from `master` @ `febea26`). Re-verifies that Round-1/2/3 fixes still hold on HEAD, and audits code added since Round 3 (MultiLineString datatype #204, inline Reference/Lookup modal picker #189/#198, AsDetail drag-reorder `[Sortable]` #187/#188, breadcrumb nested-reference resolution #185/#186).
+**Method:** 6 parallel auditor agents by dimension (authz-core, authn/OIDC, CRUD/input-validation, injection/data-access, files/webhooks/transport, frontend/config/supply-chain). Every candidate finding was then handed to an independent adversarial verifier that read the actual code on HEAD and returned one of `CONFIRMED` / `ALREADY_FIXED` / `NOT_EXPLOITABLE` / `DUPLICATE_OF_PRIOR_OPEN` / `FALSE_POSITIVE`. **All findings below were verified against code on HEAD, not against this PRD's prose** (the prose is known to be stale — several R2 items marked without a Resolution block are in fact fixed in the tree; see §9.3/§10.5).
+**Threat model:** unchanged from R2 (internet-facing, multi-tenant, multi-node RavenDB cluster; a low-privilege authenticated user is a first-class attacker).
+
+ID prefix `R4-`. 18 candidates → **8 confirmed** (1 High, 3 Medium, 4 Low), **5 still-open prior findings re-confirmed**, 1 already-fixed, 2 not-exploitable.
+
+### 11.1 Headline
+
+**One High: row-level authorization is silently bypassed on the primary listing surface.** The row-level `IsAllowedAsync` hook (the R2-H2 fix) is enforced by `DatabaseAccess` on `/spark/po/...`, but the **query-execute and query-stream paths do not call it** — and the Angular grid renders every list through `/spark/queries/{id}/execute`, not `/spark/po/`. So the exact access-control a developer writes in their Actions class is enforced on the endpoint the UI doesn't use and skipped on the one it does. This is the finding to fix first.
+
+Everything else is Medium or below. The two replication Mediums are the same class as R2-C1/C2 (only the auth half of that fix landed): the mTLS gate self-disables in `Development` mode (the default posture under `ASPNETCORE_ENVIRONMENT=Development`), and `TargetUrls` is still unvalidated (SSRF from the DB server). **Positive result:** the R2 rate-limiter (L-3) is intact and active in Fleet, and the two config items initially flagged (RavenDB `PublicNetwork`, `AllowedHosts:"*"`) proved **not exploitable** on HEAD (topology isolation holds; no Host-header-reflecting sink exists).
+
+### 11.2 Confirmed findings
+
+#### HIGH
+
+---
+
+##### R4-H1 — Query-execute and query-stream paths bypass the row-level authorization hook (H-2 gate not applied on the surface the UI actually uses)
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** extends H-2 / R2-H2 (row-level hook), not covered by R2-M2 (paging) or R2-M4 (stream re-auth)
+
+**Where:**
+- `libs/spark/MintPlayer.Spark/Services/QueryExecutor.cs:126` (`ExecuteDatabaseQueryAsync`)
+- `libs/spark/MintPlayer.Spark/Services/QueryExecutor.cs:194` (`ExecuteCustomQueryAsync`)
+- `libs/spark/MintPlayer.Spark/Streaming/StreamingQueryExecutor.cs:50`
+- contrast with `libs/spark/MintPlayer.Spark/Services/DatabaseAccess.cs:143` (`FilterByRowLevelAuthAsync`, correctly applied on `/spark/po`)
+
+**Attack:** A non-admin who holds an entity-type grant (`QueryRead/Car` or `QueryReadEditNew/Car` in `security.json`) calls `GET /spark/queries/{GetCars-id}/execute`. `ExecuteDatabaseQueryAsync` calls **only** `permissionService.EnsureAuthorizedAsync("Query", "Car")` (the entity-type check) and then materializes and returns **every** `Car` row — it never invokes `CarActions.IsAllowedAsync("Query", car)` (the per-row `CreatedBy == CurrentUserId` restriction). The same data requested via `GET /spark/po/{carTypeId}` is correctly filtered by `DatabaseAccess.FilterByRowLevelAuthAsync`. Because the query-list grid renders through `/spark/queries/{id}/execute`, the developer's row-level rule is bypassed on the real listing surface. `ExecuteCustomQueryAsync` (`Custom.*` sources) and the WebSocket streaming path have the identical gap. `QueryExecutor` does not even inject `IRowSecurity`.
+
+**Expected:** After the entity-type check, both `QueryExecutor` paths (Database + Custom) and `StreamingQueryExecutor` must run the same per-row `IsAllowedAsync("Query", entity)` filter that `DatabaseAccess` uses, so the H-2 gate is enforced consistently across every read surface (`/po`, `/queries/execute`, `/queries/stream`).
+
+**Test asserts:** As a non-admin owning only their own `Car`, `GET /spark/queries/{GetCars}/execute` returns only rows they may see (not the admin's); the WebSocket stream yields the same filtered set.
+
+#### MEDIUM
+
+---
+
+##### R4-M1 — Replication mTLS gate self-disables in `Development` mode (the default posture), reinstating the R2-C1/C2 unauthenticated-CRUD + ETL surface
+
+**Layer:** Deployment / Framework · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** new residual of R2-C1 / R2-C2 (recorded fixed)
+
+**Where:**
+- `libs/replication/MintPlayer.Spark.Replication/Services/ModuleCertificateValidator.cs:45-53` (`ResolveMode`: `Auto` → `Development` when `IHostEnvironment.IsDevelopment()`)
+- `libs/replication/MintPlayer.Spark.Replication/Services/ModuleCertificateValidator.cs:65-78` (Development branch: returns `Ok` for any non-empty `RequestingModule`, never inspects the client cert)
+- `libs/replication/MintPlayer.Spark.Replication/Services/SparkReplicationOptions.cs:91` (`ClientCertificate.Mode` defaults to `Auto`)
+- gates `SyncApply.cs:42-53`, `EtlDeploy.cs:46-65`
+
+**Attack:** `Mode` defaults to `Auto`, which resolves to `Development` whenever `ASPNETCORE_ENVIRONMENT=Development` — the default env var baked into countless container images and staging boxes. In that mode `ValidateAsync` returns `Ok` for **any** request whose body carries a non-empty `RequestingModule` string, with **no client certificate inspected and (verifier-confirmed) not even the SparkModules existence check the code comment claims** — the module lookup only runs in the Production branch. An unauthenticated attacker who can reach the port POSTs `/spark/sync/apply` with `{requestingModule:"x", actions:[{actionType:Delete, collection:"SparkUsers", documentId:"..."}]}` for arbitrary CRUD on any collection, or `/spark/etl/deploy` to register ETL tasks with attacker JS + target URLs. This is exactly the R2-C1/C2 impact, reachable on any dev-mode host on a routable interface.
+
+**Expected:** Don't silently disable the cert check based on host environment. Require explicit opt-in (`Mode=Disabled`) to run without certs, and when disabled, bind the replication endpoints to loopback (or refuse to map them) rather than accepting arbitrary callers. Even in Development, still require the `RequestingModule` to exist in `SparkModules`.
+
+**Test asserts:** With `IHostEnvironment=Development` and default options, unauth `POST /spark/sync/apply` with a made-up `RequestingModule` returns 401/403 (not 200); the SyncActionHandler is never invoked.
+
+---
+
+##### R4-M2 — ETL deploy passes caller-supplied `TargetUrls` unvalidated into the RavenDB connection string (SSRF from the DB server)
+
+**Layer:** Application · **Testable?** Indirect · **Confidence:** Confirmed · **Prior:** unfinished half of R2-C1 (the allow-list was specified but never implemented)
+
+**Where:** `libs/replication/MintPlayer.Spark.Replication/Services/EtlTaskManager.cs:53-60` (`TargetUrls` → `RavenConnectionString.TopologyDiscoveryUrls` → `PutConnectionStringOperation`/`AddEtlOperation`), `EtlDeploy.cs:67`
+
+**Attack:** `request.TargetUrls` flows straight into the ETL topology-discovery URLs with no scheme/host validation. RavenDB then makes outbound HTTP connections to those URLs — an SSRF executed **from the database server**. A caller who reaches this endpoint (unauthenticated in dev per R4-M1, or a compromised peer module in prod) points Raven at `http://169.254.169.254/…` or internal admin endpoints. R2-C1's stated expected behavior explicitly included "validate `TargetUrls` against an operator-configured allow-list"; only the mTLS auth half shipped.
+
+**Expected:** Validate every `TargetUrls` entry against an operator-configured allow-list (require `https`, host ∈ a known-peer set) before building the connection string; reject otherwise.
+
+**Test asserts:** `DeployAsync` with a `TargetUrls` entry outside the allow-list throws/returns an error and never calls `PutConnectionStringOperation`.
+
+---
+
+##### R4-M3 — Combined-action DENY rights in `security.json` are silently ignored, breaking "deny takes precedence"
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** new (M-2 is at the same file but concerns claim-injection, unrelated)
+
+**Where:** `libs/authorization/MintPlayer.Spark.Authorization/Services/AccessControlService.cs:70` (deny check uses exact-string `MatchesResource`), `:85` (combined-action expansion filters to `!IsDenied` only), `:120` (`MatchesResource` = exact case-insensitive equality)
+
+**Attack:** The grant path supports combined-action resources (`EditNewDelete/Car` expands to `Edit`, `New`, `Delete`), so an admin naturally writes a **deny** the same way: `{resource:"EditNewDelete/Car", groupId:<g>, isDenied:true}`. But step-1 denial evaluation only matches via exact-string `MatchesResource`, so a request for `Edit/Car` does not match the `EditNewDelete/Car` deny; and the combined-action expansion (step 3) iterates `relevantRights.Where(r => !r.IsDenied)`, so the combined-form deny is never expanded. If any broad grant (or `DefaultBehavior=AllowAll`) covers `Edit/Car`, the user is **allowed despite the explicit deny** — violating the in-code "denials take precedence" invariant (comment at line 69) for any deny authored in combined form.
+
+**Expected:** Apply `IsCombinedActionMatch` to deny rights as well: before granting, check whether any relevant deny (exact **or** combined form) covers the requested action/target, and if so return false.
+
+**Test asserts:** With a broad `QueryReadEditNewDelete/Car` grant and a combined `EditNewDelete/Car` deny for group G, a member of G is refused `Edit/Car`.
+
+#### LOW
+
+---
+
+##### R4-L1 — LookupReference **read** endpoints are completely unauthenticated (inconsistent with EntityTypes metadata gating and the R2-H4 write gate)
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** new
+
+**Where:** `libs/spark/MintPlayer.Spark/Endpoints/LookupReferences/List.cs:15`, `Get.cs:17` (inject only `ILookupReferenceService`, no `IPermissionService`); contrast `AddValue.cs:19,30` (R2-H4 added `EnsureAuthorizedAsync("Edit","LookupReferences")`) and `EntityTypes/{Get,List}.cs` (gate reads behind `IsAllowedAsync("Query",…)`).
+
+**Attack:** `GET /spark/lookupref/` and `GET /spark/lookupref/{name}` perform zero authorization; the `/spark` group has no blanket `RequireAuthorization` (endpoints self-gate), so an anonymous caller enumerates every lookup-reference dictionary and all values. The mutation side was gated by R2-H4; the read side was left open.
+
+**Expected:** Gate the read endpoints behind a permission check (e.g. `IsAllowedAsync("Read","LookupReferences")`), consistent with the EntityTypes metadata reads.
+
+**Test asserts:** Unauthenticated `GET /spark/lookupref/` and `/spark/lookupref/{name}` return 401.
+
+---
+
+##### R4-L2 — Account enumeration via `/spark/auth/register` (`DuplicateEmail` echoes the submitted address)
+
+**Layer:** Framework (stock `MapIdentityApi` behavior) · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** new
+
+**Where:** `libs/authorization/MintPlayer.Spark.Authorization/Identity/UserStore.cs:60-66` (`CreateAsync` returns `Failed` with code `DuplicateEmail`, description `"Email '{x}' is already taken."`), route mapped by `SparkAuthenticationExtensions.cs:83` (`MapIdentityApi<TUser>()`)
+
+**Attack:** Unauthenticated `POST /spark/auth/register` with a candidate email returns a distinguishable 400 (`DuplicateEmail`, echoing the address) if the email exists, versus a different result if free — enabling account enumeration at scale (rate-limited only by the generous per-IP `/spark` limiter). `/forgotPassword` correctly does **not** leak (returns 200 regardless); `/register` does.
+
+**Expected:** Return a generic, indistinguishable failure for registration on an existing email (or accept and send an out-of-band "you already have an account" email); do not echo the address in the error.
+
+**Test asserts:** `POST /spark/auth/register` for a taken vs. free email yields responses indistinguishable in status and body.
+
+---
+
+##### R4-L3 — Optimistic concurrency is client-opt-in on Update: omitting `Etag` yields unconditional last-write-wins (M-7 incompletely fixed)
+
+**Layer:** Framework · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** M-7 was recorded fixed/INTACT (§9.3) but the fix only fires when the client volunteers an `Etag`
+
+**Where:** `libs/spark/MintPlayer.Spark/Services/DatabaseAccess.cs:216` (change-vector compare gated on `!string.IsNullOrEmpty(persistentObject.Etag)`), `Update.cs:70`; the injected session is opened without `Advanced.UseOptimisticConcurrency` (`SparkMiddleware.cs:113-114`), and the etag is read in a separate `checkSession` than the one that saves (TOCTOU, not an atomic conditional write).
+
+**Attack:** A client that omits/empties `Etag` skips the conflict check entirely and the save runs last-write-wins, silently clobbering a concurrent authorized editor. No 409. Integrity-only (caller already holds Edit rights), hence Low — but it makes the M-7 protection trivially bypassable.
+
+**Expected:** Make the concurrency check mandatory for updates of existing records (reject writes lacking an `Etag`, or enable `session.Advanced.UseOptimisticConcurrency` so the save is conditional on the loaded change vector).
+
+**Test asserts:** A PUT to an existing record with no `Etag` is rejected (400/428), or two concurrent etag-less PUTs produce a 409 on the second.
+
+---
+
+##### R4-L4 — WebSocket origin guard compares hostname only, ignoring port — same-host different-port CSWSH (residual of R2-H5)
+
+**Layer:** Application · **Testable?** Yes · **Confidence:** Confirmed · **Prior:** new residual of R2-H5 (recorded fixed)
+
+**Where:** `libs/spark/MintPlayer.Spark/SparkMiddleware.cs:226-233` — compares `originUri.Host` to `Request.Host.Host` (hostname only; `HostString.Host` excludes the port, exposed separately as `.Port`).
+
+**Attack:** The browser same-origin policy treats a different port as a different origin, but this guard passes any Origin whose hostname matches. On a host that also serves attacker-influenced content on another port (multi-service box, some reverse-proxy layouts), a page at `http://victim-host:8080/` can open `wss://victim-host/spark/queries/{id}/stream`; the guard passes, the victim's ambient auth cookie is sent, and the attacker page reads the streamed result set — the CSWSH scenario R2-H5 exists to block. Narrow precondition → Low.
+
+**Expected:** Compare the full origin authority (host **and** port, ideally scheme) against `Request.Host`, or match an explicit allowed-origins list.
+
+**Test asserts:** A WS upgrade with `Origin: https://<same-host>:<other-port>` is rejected (403).
+
+### 11.3 Still-open prior findings, re-confirmed on HEAD
+
+These were reported before, never fixed, and re-verified live this round. They should be swept into the same PR (or explicitly deferred with a rationale).
+
+| ID | Sev | Summary | Where (HEAD) |
+|----|-----|---------|--------------|
+| **H-1b** | Medium | Read path serializes `IsVisible=false` / read-only attribute **values** to any authorized reader — asymmetric with the R2-H8 **write** gate `IsWritableBySchema`, which treats `IsVisible=false` as a security boundary. A field the framework won't let a client write is still fully readable. | `EntityMapper.cs:208,230,361,545` (write gate); `PersistentObject/Get.cs:37`, `List.cs:29` (serialize) |
+| **M-2** | Medium (latent) | Group membership derived verbatim from `group`/`groups`/`role`/`groupsid`/xmlsoap-Group claims with no issuer check; `ResolveGroupIds` maps any value onto a `security.json` group by name. Not reachable in the shipped cookie-Identity config (roles are server-issued); becomes exploitable the moment a second/federated issuer is added. | `ClaimsGroupMembershipProvider.cs:19,37`; `AccessControlService.cs:104` |
+| **R2-M6** | Medium | GitHub webhook processor verifies the HMAC but never checks `X-GitHub-Delivery`/nonce/timestamp — a captured signed delivery can be replayed indefinitely, re-broadcasting onto the durable MessageBus. | `SparkWebhookEventProcessor.cs:35-83` |
+| **M-4** | Low | `Custom.*` query resolution binds to any matching-shape public method via reflection with no `[SparkQuery]` opt-in. Not attacker-controllable end-to-end today (`query.Source` is server-owned model JSON); footgun/defense-in-depth. | `QueryExecutor.cs:315`; `StreamingQueryExecutor.cs:103` |
+| **R2-H19** | Low | `navigate` client-operation wire type exists but no handler is registered, so it's inert today; the dispatcher's documented "validate via `sanitizeReturnUrl`" contract is unenforced for when a navigate/redirect handler ships. | `operations.ts:15`; `dispatcher.service.ts:38` |
+
+### 11.4 Verified this round — not exploitable / already fixed
+
+- **Rate limiting (L-3) — ALREADY FIXED / intact.** The initial "no rate limiter" flag was a misread: Fleet's `options.RateLimiter = _ => {}` (Program.cs:27) is a **non-null** delegate, and `SparkFullGenerator` emits `AddRateLimiter` iff the delegate is non-null; the empty body keeps the default (150 req/10 s per client IP, scoped to `/spark`), so `/spark/auth/*` **is** throttled. Residual (per-IP not per-account) is minor hardening, and 2FA additionally flows through Identity `SignInManager` lockout.
+- **RavenDB `UnsecuredAccessAllowed=PublicNetwork` in webhooks-demo (R2-L1 walk-back) — NOT EXPLOITABLE.** The real R2-L1 control was topology isolation (no published host ports; `spark-raven` on `spark-internal`, not the public `web` network) — intact at HEAD. `PublicNetwork` vs `PrivateNetwork` is near-equivalent on an RFC1918 bridge; the flag was flipped only because the pinned Raven build refuses to start unsecured on a `0.0.0.0` bind under `PrivateNetwork`. Demo infra, not product code.
+- **`AllowedHosts:"*"` across the four demo apps — NOT EXPLOITABLE.** A grep across `Demo/` for `Request.Host`/`GetDisplayUrl`/Host-based URL construction found **zero** reflecting sinks. Template default in demo/dev projects; generic hardening, no reachable vuln.
+- **New code since Round 3 (MultiLineString #204, inline Reference/Lookup picker #189, AsDetail `[Sortable]` #187, breadcrumb nested-ref #185) — no new confirmed vuln.** Reviewed for injection/XSS/authz regressions; the frontend renderers use Angular interpolation (auto-escaped) and the breadcrumb resolver runs through the existing row-auth gate.
+- **R1/R2/R3 fix drift** — all sampled prior fixes (R2-C1/C2 mTLS, C3 webhook `FixedTimeEquals`, C4 returnUrl sanitize, H1 fail-closed PermissionService, H3 antiforgery, H8 write gate, cron round-3 fixes) confirmed present on HEAD. The only regressions are the two R4 **residuals** above (mTLS dev-mode escape hatch, ETL allow-list gap) — partial fixes, not reverts.
+
+### 11.5 Triage questions (for the user)
+
+1. **PR shape.** Recommend one `fix(security)` PR on `security-audit`, tests-first, ordered R4-H1 → R4-M1/M2 → R4-M3 → the Lows, sweeping in the §11.3 re-confirmed items (H-1b, R2-M6 especially). Or split High+replication-Mediums first, rest as follow-up. Your call.
+2. **R4-H1 fix locus.** Push the per-row filter down into a shared `IRowSecurity.Filter` that both `DatabaseAccess` and the query/stream executors call (removes the duplication that caused the gap), vs. bolt `IsAllowedAsync` onto each executor. Recommend the shared filter.
+3. **H-1b / IsVisible semantics.** Is `IsVisible=false` meant to be a **confidentiality** control (then gate it on read too) or a pure UI hint (then stop gating **writes** on it and document that)? The two must be made symmetric either way.
+4. **R4-M1 dev-mode posture.** Is running the replication endpoints under `ASPNETCORE_ENVIRONMENT=Development` on a routable interface in-threat-model? If dev boxes are always loopback-only, this drops to Low; if staging images ship with the default env var, it's the real Medium.
+5. **M-2 timing.** Fix the claim-issuer trust now (defense-in-depth) or defer until the IdentityProvider/OIDC multi-issuer work lands (its natural home)? It is not reachable in the shipped cookie-Identity config today.


### PR DESCRIPTION
## Summary

Round-4 full-repo security re-audit of `MintPlayer.Spark`, plus the TDD implementation plan for the fixes. **Docs-only so far** — this branch is the vehicle for the `fix(security)` commits that follow (see *Next* below).

- Appends **§11** to `docs/prd/PRD-SecurityAudit.md` — findings, still-open priors, verified-clean surfaces, triage questions.
- Adds `docs/prd/PRD-SecurityAudit-Round4-Plan.md` — a step-by-step, test-first plan mapping every finding to a concrete test in the existing suites.

## Method

6 parallel auditor agents by dimension (authz-core, authn/OIDC, CRUD/input-validation, injection/data-access, files/webhooks/transport, frontend/config/supply-chain). Every candidate was then handed to an independent adversarial verifier that read the actual code on HEAD and returned `CONFIRMED` / `ALREADY_FIXED` / `NOT_EXPLOITABLE` / `DUPLICATE_OF_PRIOR_OPEN` / `FALSE_POSITIVE`.

**18 candidates → 8 confirmed** (1 High, 3 Medium, 4 Low), **5 still-open priors re-confirmed**, 1 already-fixed, 2 not-exploitable.

Scope: whole repo at `master` @ `febea26`, including code added since Round 3 — MultiLineString (#204), inline Reference/Lookup modal picker (#189/#198), AsDetail `[Sortable]` (#187/#188), breadcrumb nested-reference resolution (#185/#186).

## Headline — R4-H1 (High)

Row-level authorization is silently bypassed on the primary listing surface. The row-level `IsAllowedAsync` hook (the R2-H2 fix) is enforced by `DatabaseAccess` on `/spark/po/...`, but **`/spark/queries/{id}/execute` and the WebSocket stream never call it** — and the Angular grid renders every list through the query path, not `/spark/po`. So the access-control a developer writes in their Actions class is enforced on the endpoint the UI doesn't use, and skipped on the one it does. `QueryExecutor` doesn't even inject `IRowSecurity`.

## Confirmed findings

| ID | Sev | Summary |
|----|-----|---------|
| R4-H1 | High | Query-execute + query-stream bypass the row-level authz hook |
| R4-M1 | Medium | Replication mTLS gate self-disables under `Development` (the default posture), reinstating the R2-C1/C2 unauthenticated-CRUD + ETL surface |
| R4-M2 | Medium | ETL deploy passes caller-supplied `TargetUrls` unvalidated into the Raven connection string (SSRF from the DB server) — the unfinished half of R2-C1 |
| R4-M3 | Medium | Combined-action **DENY** rights in `security.json` are silently ignored, breaking "deny takes precedence" |
| R4-L1 | Low | LookupReference *read* endpoints are entirely unauthenticated (writes were gated by R2-H4) |
| R4-L2 | Low | Account enumeration via `/spark/auth/register` (`DuplicateEmail` echoes the address) |
| R4-L3 | Low | Optimistic concurrency is client-opt-in — omitting `Etag` gives unconditional last-write-wins (M-7 incompletely fixed) |
| R4-L4 | Low | WebSocket origin guard compares hostname only, ignoring port — same-host different-port CSWSH |

Also re-confirmed still open on HEAD: **H-1b** (read path serializes `IsVisible=false` values — asymmetric with the R2-H8 write gate), **M-2** (claim-issuer trust, latent), **R2-M6** (webhook delivery replay), **M-4** and **R2-H19** (footguns, not reachable today).

## Verified clean

- **Rate limiting (L-3) intact** — the earlier "no rate limiter" read was wrong: Fleet's non-null `options.RateLimiter` delegate makes `SparkFullGenerator` emit `AddRateLimiter`, so `/spark/auth/*` is throttled.
- **RavenDB `PublicNetwork`** in webhooks-demo — not exploitable; the real control is topology isolation, intact at HEAD.
- **`AllowedHosts:"*"`** across the demos — no Host-header-reflecting sink exists anywhere in `Demo/`.
- **New code since Round 3** — no new confirmed vuln.
- **R1/R2/R3 fix drift** — all sampled prior fixes confirmed present; the only regressions are the two R4 *residuals* above (partial fixes, not reverts).

## Next

Per the plan doc, fixes land on this branch, test-first, in this order: R4-H1 → R4-M1/M2 → R4-M3 → the Lows, sweeping in H-1b and R2-M6.

## Triage questions (§11.5)

1. **PR shape** — one `fix(security)` PR here, or split High + replication-Mediums first?
2. **R4-H1 fix locus** — shared `IRowSecurity.Filter` called by both `DatabaseAccess` and the query/stream executors (recommended, removes the duplication that caused the gap), vs. bolting `IsAllowedAsync` onto each executor.
3. **H-1b semantics** — is `IsVisible=false` a confidentiality control (gate it on read too) or a UI hint (stop gating writes on it)? Read and write must be made symmetric either way.
4. **R4-M1 dev-mode posture** — are replication endpoints ever reachable on a routable interface under `ASPNETCORE_ENVIRONMENT=Development`? Loopback-only dev boxes would drop this to Low.
5. **M-2 timing** — fix claim-issuer trust now, or defer to the IdentityProvider/OIDC multi-issuer work (its natural home)?

## Test plan

None yet — docs-only change. The plan doc specifies the red tests for each finding in `tests/MintPlayer.Spark.E2E.Tests/Security/` and `tests/MintPlayer.Spark.Tests/`; they land with their fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
